### PR TITLE
chore(devops): add docker compose workflows for local and production

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,9 @@
+# PostgreSQL
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=postgres
+POSTGRES_DB=collab_dev
+
+# Production only
+COSMOS_ENDPOINT=
+COSMOS_KEY=
+API_URL=http://localhost:8080

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.vscode/
+.env
+.idea/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
 # collaboration-in-local-communities
+
+`docker-compose.yml` is the local dev stack for the monorepo. It runs Postgres, the Cosmos emulator, the backend, and the frontend together so `docker compose up` gives you the full app environment described in issue `#4`.
+
+`docker-compose.db.yml` is the backing-services-only variant. It starts just Postgres and the Cosmos emulator, which is useful if you want to run the backend and frontend directly from your IDE while still depending on containerized local databases.
+
+`docker-compose.prod.yml` is the production-oriented compose file. It builds the app containers in their production targets and expects external runtime configuration such as the Cosmos endpoint/key instead of bundling the local emulator into that stack.

--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,8 @@
+bin/
+obj/
+.vs/
+.vscode/
+*.user
+*.suo
+Properties/launchSettings.json
+DS_Store

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,2 +1,3 @@
 bin
 obj
+appsettings.Development.json

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,22 @@
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
+WORKDIR /src
+COPY backend.csproj .
+RUN dotnet restore
+COPY . .
+RUN dotnet publish -c Release -o /app/publish --no-restore
+
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS dev
+WORKDIR /src
+COPY backend.csproj .
+RUN dotnet restore
+EXPOSE 8080
+ENV ASPNETCORE_URLS=http://+:8080
+ENV DOTNET_USE_POLLING_FILE_WATCHER=1
+CMD ["dotnet", "watch", "run", "--urls", "http://+:8080"]
+
+FROM mcr.microsoft.com/dotnet/aspnet:10.0-noble-chiseled-extra AS final
+WORKDIR /app
+COPY --from=build /app/publish .
+EXPOSE 8080
+ENV ASPNETCORE_URLS=http://+:8080
+ENTRYPOINT ["dotnet", "backend.dll"]

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -12,12 +12,15 @@ if (app.Environment.IsDevelopment())
     app.MapOpenApi();
 }
 
-app.UseHttpsRedirection();
-
-var summaries = new[]
+// Skip HTTPS redirect inside Docker containers (HTTP-only on port 8080)
+if (!bool.TryParse(Environment.GetEnvironmentVariable("DOTNET_RUNNING_IN_CONTAINER"), out var inContainer) || !inContainer)
 {
+    app.UseHttpsRedirection();
+}
+
+string[] summaries = [
     "Freezing", "Bracing", "Chilly", "Cool", "Mild", "Warm", "Balmy", "Hot", "Sweltering", "Scorching"
-};
+];
 
 app.MapGet("/weatherforecast", () =>
 {

--- a/backend/appsettings.Development.json
+++ b/backend/appsettings.Development.json
@@ -1,4 +1,11 @@
 {
+  "ConnectionStrings": {
+    "DefaultConnection": "Host=localhost;Port=5432;Database=collab_dev;Username=postgres;Password=postgres"
+  },
+  "CosmosDb": {
+    "AccountEndpoint": "https://localhost:8081/",
+    "AccountKey": "C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMssZyOIBJRxs06pw=="
+  },
   "Logging": {
     "LogLevel": {
       "Default": "Information",

--- a/backend/appsettings.json
+++ b/backend/appsettings.json
@@ -1,4 +1,11 @@
 {
+  "ConnectionStrings": {
+    "DefaultConnection": "Host=localhost;Port=5432;Database=collab_dev;Username=postgres;Password=postgres"
+  },
+  "CosmosDb": {
+    "AccountEndpoint": "https://localhost:8081/",
+    "AccountKey": "C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMssZyOIBJRxs06pw=="
+  },
   "Logging": {
     "LogLevel": {
       "Default": "Information",

--- a/docker-compose.db.yml
+++ b/docker-compose.db.yml
@@ -1,0 +1,31 @@
+services:
+  db:
+    image: postgres:18-alpine
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER:-postgres}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
+      POSTGRES_DB: ${POSTGRES_DB:-collab_dev}
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: [ "CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-postgres}" ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  cosmos:
+    image: mcr.microsoft.com/cosmosdb/linux/azure-cosmos-emulator:latest
+    ports:
+      - "8081:8081"
+      - "10250-10255:10250-10255"
+    environment:
+      AZURE_COSMOS_EMULATOR_PARTITION_COUNT: 10
+      AZURE_COSMOS_EMULATOR_ENABLE_DATA_PERSISTENCE: "true"
+    volumes:
+      - cosmos_data:/tmp/cosmos/appdata
+
+volumes:
+  postgres_data:
+  cosmos_data:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,47 @@
+services:
+  db:
+    image: postgres:18-alpine
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER:?POSTGRES_USER is required}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}
+      POSTGRES_DB: ${POSTGRES_DB:?POSTGRES_DB is required}
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: [ "CMD-SHELL", "pg_isready -U ${POSTGRES_USER}" ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  backend:
+    build:
+      context: ./backend
+      dockerfile: Dockerfile
+      target: final
+    ports:
+      - "8080:8080"
+    environment:
+      ASPNETCORE_ENVIRONMENT: Production
+      ASPNETCORE_URLS: http://+:8080
+      ConnectionStrings__DefaultConnection: "Host=db;Port=5432;Database=${POSTGRES_DB\
+        };Username=${POSTGRES_USER};Password=${POSTGRES_PASSWORD}"
+      CosmosDb__AccountEndpoint: ${COSMOS_ENDPOINT:?COSMOS_ENDPOINT is required}
+      CosmosDb__AccountKey: ${COSMOS_KEY:?COSMOS_KEY is required}
+    depends_on:
+      db:
+        condition: service_healthy
+
+  frontend:
+    build:
+      context: ./frontend
+      dockerfile: Dockerfile
+      target: runner
+    ports:
+      - "3000:3000"
+    environment:
+      NEXT_PUBLIC_API_URL: ${API_URL:?API_URL is required}
+    depends_on:
+      - backend
+
+volumes:
+  postgres_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,72 @@
+services:
+  db:
+    image: postgres:18-alpine
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER:-postgres}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
+      POSTGRES_DB: ${POSTGRES_DB:-collab_dev}
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: [ "CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-postgres}" ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  cosmos:
+    image: mcr.microsoft.com/cosmosdb/linux/azure-cosmos-emulator:latest
+    ports:
+      - "8081:8081"
+      - "10250-10255:10250-10255"
+    environment:
+      AZURE_COSMOS_EMULATOR_PARTITION_COUNT: 10
+      AZURE_COSMOS_EMULATOR_ENABLE_DATA_PERSISTENCE: "true"
+    volumes:
+      - cosmos_data:/tmp/cosmos/appdata
+
+  backend:
+    build:
+      context: ./backend
+      dockerfile: Dockerfile
+      target: dev
+    ports:
+      - "8080:8080"
+    volumes:
+      - ./backend:/src
+      - backend_obj:/src/obj
+    environment:
+      ASPNETCORE_ENVIRONMENT: Development
+      ASPNETCORE_URLS: http://+:8080
+      DOTNET_USE_POLLING_FILE_WATCHER: "1"
+      ConnectionStrings__DefaultConnection: "Host=db;Port=5432;Database=${POSTGRES_DB\
+        :-collab_dev};Username=${POSTGRES_USER:-postgres};Password=${POSTGRES_P\
+        ASSWORD:-postgres}"
+      CosmosDb__AccountEndpoint: "https://cosmos:8081/"
+      CosmosDb__AccountKey: "C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4\
+        b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw=="
+    depends_on:
+      db:
+        condition: service_healthy
+
+  frontend:
+    build:
+      context: ./frontend
+      dockerfile: Dockerfile
+      target: dev
+    ports:
+      - "3000:3000"
+    volumes:
+      - ./frontend:/app
+      - frontend_node_modules:/app/node_modules
+    environment:
+      NEXT_PUBLIC_API_URL: http://localhost:8080
+    depends_on:
+      - backend
+
+volumes:
+  postgres_data:
+  cosmos_data:
+  backend_obj:
+  frontend_node_modules:

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,7 @@
+node_modules/
+.next/
+.env*
+npm-debug.log*
+.vscode/
+.idea/
+.DS_Store

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,29 @@
+FROM node:24-alpine AS deps
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci
+
+FROM node:24-alpine AS builder
+WORKDIR /app
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+RUN npm run build
+
+FROM node:24-alpine AS dev
+WORKDIR /app
+COPY --from=deps /app/node_modules ./node_modules
+EXPOSE 3000
+ENV PORT=3000
+ENV HOSTNAME=0.0.0.0
+CMD ["npm", "run", "dev"]
+
+FROM gcr.io/distroless/nodejs24-debian12:nonroot AS runner
+WORKDIR /app
+ENV NODE_ENV=production
+COPY --from=builder /app/public ./public
+COPY --from=builder --chown=nonroot:nonroot /app/.next/standalone ./
+COPY --from=builder --chown=nonroot:nonroot /app/.next/static ./.next/static
+EXPOSE 3000
+ENV PORT=3000
+ENV HOSTNAME=0.0.0.0
+CMD ["server.js"]

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -1,7 +1,7 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  output: "standalone",
 };
 
 export default nextConfig;


### PR DESCRIPTION
Add multi-stage Dockerfiles for the backend and frontend, plus compose files for the full local dev stack, a db-only IDE workflow, and a production-oriented setup. Fix local git ignore handling, keep IDE files out of the repo, add development appsettings defaults for local services, and document the compose entry points in the README.