### PR TITLE
Added docker buildx setup for caching support

### DIFF
--- a/.github/workflows/cd-backend.yml
+++ b/.github/workflows/cd-backend.yml
@@ -22,6 +22,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
       - name: Log in to GHCR
         uses: docker/login-action@v4
         with:

--- a/.github/workflows/cd-frontend.yml
+++ b/.github/workflows/cd-frontend.yml
@@ -22,6 +22,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
       - name: Log in to GHCR
         uses: docker/login-action@v4
         with:


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows for both the backend and frontend to include a step that sets up Docker Buildx. This ensures that Docker builds in the CI/CD process are more reliable and support advanced features.

**CI/CD workflow improvements:**

* [`.github/workflows/cd-backend.yml`](diffhunk://#diff-db54fba46501e9e157f25837bd19aca769aa12c326d67449ccb9d15c314f2913R25-R27): Added a `Set up Docker Buildx` step before logging into GHCR.
* [`.github/workflows/cd-frontend.yml`](diffhunk://#diff-5b880ad0c8a1d6632ed6ed83caab7309f856010a5e5eef08dc7e352aa3b30604R25-R27): Added a `Set up Docker Buildx` step before logging into GHCR.