### PR TITLE
118-admin-category-crud-postputdelete-apiadmincategories

### DIFF
--- a/backend/Application/Categories/AllowedCategoryIcons.cs
+++ b/backend/Application/Categories/AllowedCategoryIcons.cs
@@ -1,0 +1,27 @@
+namespace Backend.Application.Categories;
+
+/// <summary>
+/// Valid category icon identifiers. The frontend lib/icon-registry.ts must mirror this list; drift between the two is a bug.
+/// </summary>
+public static class AllowedCategoryIcons
+{
+    public static IReadOnlySet<string> Values { get; } = new HashSet<string>(StringComparer.Ordinal)
+    {
+        "DeliveryTruck01Icon",
+        "Mortarboard02Icon",
+        "Wrench01Icon",
+        "ShoppingBag03Icon",
+        "Bone01Icon",
+        "SparklesIcon",
+        "RunningShoesIcon",
+        "MoreHorizontalCircle01Icon",
+        "Briefcase01Icon",
+        "BubbleChatIcon",
+        "HandHelpingIcon",
+        "FavouriteIcon",
+        "StarIcon",
+        "ToolboxIcon",
+        "Calendar01Icon",
+        "BabyBottleIcon"
+    };
+}

--- a/backend/Application/Categories/CategoryListItem.cs
+++ b/backend/Application/Categories/CategoryListItem.cs
@@ -4,4 +4,5 @@ public sealed record CategoryListItem(
     Guid Id,
     string Code,
     string Name,
+    string Icon,
     string? Description);

--- a/backend/Common/StringUtilities.cs
+++ b/backend/Common/StringUtilities.cs
@@ -1,6 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 
-namespace Backend.Shared;
+namespace Backend.Common;
 
 /// <summary>
 /// Utilities for normalizing string values.

--- a/backend/Domain/Entities/Category.cs
+++ b/backend/Domain/Entities/Category.cs
@@ -2,10 +2,13 @@ namespace Backend.Domain.Entities;
 
 public sealed class Category
 {
+    public const string DefaultIcon = "MoreHorizontalCircle01Icon";
+
     public Guid Id { get; set; }
     public string Code { get; set; } = string.Empty;
     public string Name { get; set; } = string.Empty;
     public string? Description { get; set; }
+    public string Icon { get; set; } = DefaultIcon;
     public int SortOrder { get; set; }
     public bool IsActive { get; set; } = true;
     public DateTimeOffset CreatedAt { get; set; }

--- a/backend/Features/Admin/Categories/AdminCategoriesController.Functions.cs
+++ b/backend/Features/Admin/Categories/AdminCategoriesController.Functions.cs
@@ -1,0 +1,40 @@
+using Backend.Application.Categories;
+using Backend.Features.Categories;
+using Backend.Infrastructure.Validation;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Backend.Features.Admin.Categories;
+
+public sealed partial class AdminCategoriesController
+{
+    private static ConflictObjectResult DuplicateCodeConflict(string code)
+    {
+        return new ConflictObjectResult(new ProblemDetails
+        {
+            Title = "Duplicate category code",
+            Detail = $"Category code '{code}' already exists.",
+            Status = StatusCodes.Status409Conflict
+        });
+    }
+
+    private bool ValidateIcon(string fieldName, string icon)
+    {
+        if (!FieldValidator.ValidateRequired(ModelState, fieldName, icon))
+        {
+            return false;
+        }
+
+        if (AllowedCategoryIcons.Values.Contains(icon))
+        {
+            return true;
+        }
+
+        ModelState.AddModelError(fieldName, $"{fieldName} is not an allowed category icon.");
+        return false;
+    }
+
+    private ValueTask EvictCategoryListAsync(CancellationToken cancellationToken)
+    {
+        return outputCacheStore.EvictByTagAsync(CategoriesCache.Tag, cancellationToken);
+    }
+}

--- a/backend/Features/Admin/Categories/AdminCategoriesController.cs
+++ b/backend/Features/Admin/Categories/AdminCategoriesController.cs
@@ -1,0 +1,177 @@
+using Backend.Domain.Entities;
+using Backend.Infrastructure.Persistence;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.OutputCaching;
+using Microsoft.EntityFrameworkCore;
+using Npgsql;
+
+namespace Backend.Features.Admin.Categories;
+
+// [Authorize(Roles = "Admin")]
+[ApiController]
+[Route("api/admin/categories")]
+public sealed class AdminCategoriesController(
+    AppDbContext db,
+    IOutputCacheStore outputCacheStore)
+    : ControllerBase
+{
+    [HttpPost]
+    public async Task<IActionResult> CreateAsync(
+        CreateCategoryRequest request,
+        CancellationToken cancellationToken)
+    {
+        var code = Normalize(request.Code);
+        var name = Normalize(request.Name);
+        var description = NormalizeOptional(request.Description);
+
+        if (!ValidateRequired(nameof(request.Code), code) ||
+            !ValidateRequired(nameof(request.Name), name))
+        {
+            return ValidationProblem(ModelState);
+        }
+
+        var codeExists = await db.Categories
+            .AnyAsync(category => category.Code == code, cancellationToken);
+        if (codeExists)
+        {
+            return DuplicateCodeConflict(code);
+        }
+
+        var category = new Category
+        {
+            Code = code,
+            Name = name,
+            Description = description,
+            SortOrder = request.SortOrder,
+            IsActive = true
+        };
+
+        db.Categories.Add(category);
+
+        try
+        {
+            await db.SaveChangesAsync(cancellationToken);
+        }
+        catch (DbUpdateException exception) when (IsDuplicateCategoryCode(exception))
+        {
+            return DuplicateCodeConflict(code);
+        }
+
+        await EvictCategoryListAsync(cancellationToken);
+
+        var response = ToResponse(category);
+        return Created($"/api/admin/categories/{category.Id}", response);
+    }
+
+    [HttpPut("{id:guid}")]
+    public async Task<IActionResult> UpdateAsync(
+        Guid id,
+        UpdateCategoryRequest request,
+        CancellationToken cancellationToken)
+    {
+        var category = await db.Categories
+            .FirstOrDefaultAsync(category => category.Id == id, cancellationToken);
+        if (category is null)
+        {
+            return NotFound();
+        }
+
+        var name = Normalize(request.Name);
+        var description = NormalizeOptional(request.Description);
+
+        if (!ValidateRequired(nameof(request.Name), name))
+        {
+            return ValidationProblem(ModelState);
+        }
+
+        category.Name = name;
+        category.Description = description;
+        category.SortOrder = request.SortOrder;
+        category.UpdatedAt = DateTimeOffset.UtcNow;
+
+        await db.SaveChangesAsync(cancellationToken);
+        await EvictCategoryListAsync(cancellationToken);
+
+        return Ok(ToResponse(category));
+    }
+
+    [HttpDelete("{id:guid}")]
+    public async Task<IActionResult> DeleteAsync(Guid id, CancellationToken cancellationToken)
+    {
+        var category = await db.Categories
+            .FirstOrDefaultAsync(category => category.Id == id, cancellationToken);
+        if (category is null)
+        {
+            return NotFound();
+        }
+
+        if (!category.IsActive)
+        {
+            return NoContent();
+        }
+
+        category.IsActive = false;
+        category.UpdatedAt = DateTimeOffset.UtcNow;
+
+        await db.SaveChangesAsync(cancellationToken);
+        await EvictCategoryListAsync(cancellationToken);
+
+        return NoContent();
+    }
+
+    private static AdminCategoryResponse ToResponse(Category category)
+    {
+        return new AdminCategoryResponse(
+            category.Id,
+            category.Code,
+            category.Name,
+            category.Description,
+            category.SortOrder,
+            category.IsActive);
+    }
+
+    private static string Normalize(string value)
+    {
+        return value.Trim();
+    }
+
+    private static string? NormalizeOptional(string? value)
+    {
+        var normalized = value?.Trim();
+        return string.IsNullOrWhiteSpace(normalized) ? null : normalized;
+    }
+
+    private static ConflictObjectResult DuplicateCodeConflict(string code)
+    {
+        return new ConflictObjectResult(new ProblemDetails
+        {
+            Title = "Duplicate category code",
+            Detail = $"Category code '{code}' already exists.",
+            Status = StatusCodes.Status409Conflict
+        });
+    }
+
+    private static bool IsDuplicateCategoryCode(DbUpdateException exception)
+    {
+        return exception.InnerException is PostgresException postgresException &&
+            postgresException.SqlState == PostgresErrorCodes.UniqueViolation &&
+            postgresException.ConstraintName == "ux_categories_code";
+    }
+
+    private bool ValidateRequired(string fieldName, string value)
+    {
+        if (!string.IsNullOrWhiteSpace(value))
+        {
+            return true;
+        }
+
+        ModelState.AddModelError(fieldName, $"{fieldName} is required.");
+        return false;
+    }
+
+    private ValueTask EvictCategoryListAsync(CancellationToken cancellationToken)
+    {
+        return outputCacheStore.EvictByTagAsync(Backend.Features.Categories.CategoriesCache.Tag, cancellationToken);
+    }
+}

--- a/backend/Features/Admin/Categories/AdminCategoriesController.cs
+++ b/backend/Features/Admin/Categories/AdminCategoriesController.cs
@@ -57,6 +57,9 @@ public sealed class AdminCategoriesController(
 
         var category = new Category
         {
+            // Ensure the entity has an ID immediately so callers receive it
+            // even before the DB generates values on insert.
+            Id = Guid.NewGuid(),
             Code = code,
             Name = name,
             Icon = icon,

--- a/backend/Features/Admin/Categories/AdminCategoriesController.cs
+++ b/backend/Features/Admin/Categories/AdminCategoriesController.cs
@@ -1,3 +1,4 @@
+using Backend.Application.Categories;
 using Backend.Domain.Entities;
 using Backend.Infrastructure.Persistence;
 using Microsoft.AspNetCore.Authorization;
@@ -23,10 +24,12 @@ public sealed class AdminCategoriesController(
     {
         var code = Normalize(request.Code);
         var name = Normalize(request.Name);
+        var icon = Normalize(request.Icon);
         var description = NormalizeOptional(request.Description);
 
         if (!ValidateRequired(nameof(request.Code), code) ||
-            !ValidateRequired(nameof(request.Name), name))
+            !ValidateRequired(nameof(request.Name), name) ||
+            !ValidateIcon(nameof(request.Icon), icon))
         {
             return ValidationProblem(ModelState);
         }
@@ -42,6 +45,7 @@ public sealed class AdminCategoriesController(
         {
             Code = code,
             Name = name,
+            Icon = icon,
             Description = description,
             SortOrder = request.SortOrder,
             IsActive = true
@@ -78,14 +82,17 @@ public sealed class AdminCategoriesController(
         }
 
         var name = Normalize(request.Name);
+        var icon = Normalize(request.Icon);
         var description = NormalizeOptional(request.Description);
 
-        if (!ValidateRequired(nameof(request.Name), name))
+        if (!ValidateRequired(nameof(request.Name), name) ||
+            !ValidateIcon(nameof(request.Icon), icon))
         {
             return ValidationProblem(ModelState);
         }
 
         category.Name = name;
+        category.Icon = icon;
         category.Description = description;
         category.SortOrder = request.SortOrder;
         category.UpdatedAt = DateTimeOffset.UtcNow;
@@ -126,6 +133,7 @@ public sealed class AdminCategoriesController(
             category.Id,
             category.Code,
             category.Name,
+            category.Icon,
             category.Description,
             category.SortOrder,
             category.IsActive);
@@ -167,6 +175,22 @@ public sealed class AdminCategoriesController(
         }
 
         ModelState.AddModelError(fieldName, $"{fieldName} is required.");
+        return false;
+    }
+
+    private bool ValidateIcon(string fieldName, string icon)
+    {
+        if (!ValidateRequired(fieldName, icon))
+        {
+            return false;
+        }
+
+        if (AllowedCategoryIcons.Values.Contains(icon))
+        {
+            return true;
+        }
+
+        ModelState.AddModelError(fieldName, $"{fieldName} is not an allowed category icon.");
         return false;
     }
 

--- a/backend/Features/Admin/Categories/AdminCategoriesController.cs
+++ b/backend/Features/Admin/Categories/AdminCategoriesController.cs
@@ -2,18 +2,19 @@ using Backend.Application.Categories;
 using Backend.Domain.Entities;
 using Backend.Features.Categories;
 using Backend.Infrastructure.Persistence;
+using Backend.Infrastructure.Validation;
+using Backend.Shared;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.OutputCaching;
 using Microsoft.EntityFrameworkCore;
-using Npgsql;
 
 namespace Backend.Features.Admin.Categories;
 
 // [Authorize(Roles = "Admin")]
 [ApiController]
 [Route("api/admin/categories")]
-public sealed class AdminCategoriesController(
+public sealed partial class AdminCategoriesController(
     AppDbContext db,
     IOutputCacheStore outputCacheStore)
     : ControllerBase
@@ -28,7 +29,7 @@ public sealed class AdminCategoriesController(
             return NotFound();
         }
 
-        return Ok(ToResponse(category));
+        return Ok(AdminCategoryResponse.FromCategory(category));
     }
 
     [HttpPost]
@@ -36,13 +37,13 @@ public sealed class AdminCategoriesController(
         CreateCategoryRequest request,
         CancellationToken cancellationToken)
     {
-        var code = Normalize(request.Code);
-        var name = Normalize(request.Name);
-        var icon = Normalize(request.Icon);
-        var description = NormalizeOptional(request.Description);
+        var code = StringUtilities.Normalize(request.Code);
+        var name = StringUtilities.Normalize(request.Name);
+        var icon = StringUtilities.Normalize(request.Icon);
+        var description = StringUtilities.Normalize(request.Description);
 
-        if (!ValidateRequired(nameof(request.Code), code) ||
-            !ValidateRequired(nameof(request.Name), name) ||
+        if (!FieldValidator.ValidateRequired(ModelState, nameof(request.Code), code) ||
+            !FieldValidator.ValidateRequired(ModelState, nameof(request.Name), name) ||
             !ValidateIcon(nameof(request.Icon), icon))
         {
             return ValidationProblem(ModelState);
@@ -74,14 +75,14 @@ public sealed class AdminCategoriesController(
         {
             await db.SaveChangesAsync(cancellationToken);
         }
-        catch (DbUpdateException exception) when (IsDuplicateCategoryCode(exception))
+        catch (DbUpdateException exception) when (PostgresExceptionHelpers.IsDuplicateCategoryCode(exception))
         {
             return DuplicateCodeConflict(code);
         }
 
         await EvictCategoryListAsync(cancellationToken);
 
-        var response = ToResponse(category);
+        var response = AdminCategoryResponse.FromCategory(category);
         return CreatedAtAction(nameof(GetByIdAsync), new { id = category.Id }, response);
     }
 
@@ -98,11 +99,11 @@ public sealed class AdminCategoriesController(
             return NotFound();
         }
 
-        var name = Normalize(request.Name);
-        var icon = Normalize(request.Icon);
-        var description = NormalizeOptional(request.Description);
+        var name = StringUtilities.Normalize(request.Name);
+        var icon = StringUtilities.Normalize(request.Icon);
+        var description = StringUtilities.Normalize(request.Description);
 
-        if (!ValidateRequired(nameof(request.Name), name) ||
+        if (!FieldValidator.ValidateRequired(ModelState, nameof(request.Name), name) ||
             !ValidateIcon(nameof(request.Icon), icon))
         {
             return ValidationProblem(ModelState);
@@ -117,7 +118,7 @@ public sealed class AdminCategoriesController(
         await db.SaveChangesAsync(cancellationToken);
         await EvictCategoryListAsync(cancellationToken);
 
-        return Ok(ToResponse(category));
+        return Ok(AdminCategoryResponse.FromCategory(category));
     }
 
     [HttpDelete("{id:guid}")]
@@ -142,77 +143,5 @@ public sealed class AdminCategoriesController(
         await EvictCategoryListAsync(cancellationToken);
 
         return NoContent();
-    }
-
-    private static AdminCategoryResponse ToResponse(Category category)
-    {
-        return new AdminCategoryResponse(
-            category.Id,
-            category.Code,
-            category.Name,
-            category.Icon,
-            category.Description,
-            category.SortOrder,
-            category.IsActive);
-    }
-
-    private static string Normalize(string value)
-    {
-        return value.Trim();
-    }
-
-    private static string? NormalizeOptional(string? value)
-    {
-        var normalized = value?.Trim();
-        return string.IsNullOrWhiteSpace(normalized) ? null : normalized;
-    }
-
-    private static ConflictObjectResult DuplicateCodeConflict(string code)
-    {
-        return new ConflictObjectResult(new ProblemDetails
-        {
-            Title = "Duplicate category code",
-            Detail = $"Category code '{code}' already exists.",
-            Status = StatusCodes.Status409Conflict
-        });
-    }
-
-    private static bool IsDuplicateCategoryCode(DbUpdateException exception)
-    {
-        return exception.InnerException is PostgresException postgresException &&
-            postgresException.SqlState == PostgresErrorCodes.UniqueViolation &&
-            postgresException.ConstraintName == "ux_categories_code";
-    }
-
-    private bool ValidateRequired(string fieldName, string value)
-    {
-        if (!string.IsNullOrWhiteSpace(value))
-        {
-            return true;
-        }
-
-        ModelState.AddModelError(fieldName, $"{fieldName} is required.");
-        return false;
-    }
-
-    private bool ValidateIcon(string fieldName, string icon)
-    {
-        if (!ValidateRequired(fieldName, icon))
-        {
-            return false;
-        }
-
-        if (AllowedCategoryIcons.Values.Contains(icon))
-        {
-            return true;
-        }
-
-        ModelState.AddModelError(fieldName, $"{fieldName} is not an allowed category icon.");
-        return false;
-    }
-
-    private ValueTask EvictCategoryListAsync(CancellationToken cancellationToken)
-    {
-        return outputCacheStore.EvictByTagAsync(CategoriesCache.Tag, cancellationToken);
     }
 }

--- a/backend/Features/Admin/Categories/AdminCategoriesController.cs
+++ b/backend/Features/Admin/Categories/AdminCategoriesController.cs
@@ -18,6 +18,19 @@ public sealed class AdminCategoriesController(
     IOutputCacheStore outputCacheStore)
     : ControllerBase
 {
+    [HttpGet("{id:guid}")]
+    public async Task<IActionResult> GetByIdAsync(Guid id, CancellationToken cancellationToken)
+    {
+        var category = await db.Categories
+            .FirstOrDefaultAsync(category => category.Id == id, cancellationToken);
+        if (category is null)
+        {
+            return NotFound();
+        }
+
+        return Ok(ToResponse(category));
+    }
+
     [HttpPost]
     public async Task<IActionResult> CreateAsync(
         CreateCategoryRequest request,

--- a/backend/Features/Admin/Categories/AdminCategoriesController.cs
+++ b/backend/Features/Admin/Categories/AdminCategoriesController.cs
@@ -1,9 +1,9 @@
 using Backend.Application.Categories;
+using Backend.Common;
 using Backend.Domain.Entities;
 using Backend.Features.Categories;
 using Backend.Infrastructure.Persistence;
 using Backend.Infrastructure.Validation;
-using Backend.Shared;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.OutputCaching;

--- a/backend/Features/Admin/Categories/AdminCategoriesController.cs
+++ b/backend/Features/Admin/Categories/AdminCategoriesController.cs
@@ -1,5 +1,6 @@
 using Backend.Application.Categories;
 using Backend.Domain.Entities;
+using Backend.Features.Categories;
 using Backend.Infrastructure.Persistence;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -196,6 +197,6 @@ public sealed class AdminCategoriesController(
 
     private ValueTask EvictCategoryListAsync(CancellationToken cancellationToken)
     {
-        return outputCacheStore.EvictByTagAsync(Backend.Features.Categories.CategoriesCache.Tag, cancellationToken);
+        return outputCacheStore.EvictByTagAsync(CategoriesCache.Tag, cancellationToken);
     }
 }

--- a/backend/Features/Admin/Categories/AdminCategoriesController.cs
+++ b/backend/Features/Admin/Categories/AdminCategoriesController.cs
@@ -66,7 +66,7 @@ public sealed class AdminCategoriesController(
         await EvictCategoryListAsync(cancellationToken);
 
         var response = ToResponse(category);
-        return Created($"/api/admin/categories/{category.Id}", response);
+        return CreatedAtAction(nameof(GetByIdAsync), new { id = category.Id }, response);
     }
 
     [HttpPut("{id:guid}")]

--- a/backend/Features/Admin/Categories/AdminCategoryResponse.cs
+++ b/backend/Features/Admin/Categories/AdminCategoryResponse.cs
@@ -4,6 +4,7 @@ public sealed record AdminCategoryResponse(
     Guid Id,
     string Code,
     string Name,
+    string Icon,
     string? Description,
     int SortOrder,
     bool IsActive);

--- a/backend/Features/Admin/Categories/AdminCategoryResponse.cs
+++ b/backend/Features/Admin/Categories/AdminCategoryResponse.cs
@@ -1,0 +1,9 @@
+namespace Backend.Features.Admin.Categories;
+
+public sealed record AdminCategoryResponse(
+    Guid Id,
+    string Code,
+    string Name,
+    string? Description,
+    int SortOrder,
+    bool IsActive);

--- a/backend/Features/Admin/Categories/AdminCategoryResponse.cs
+++ b/backend/Features/Admin/Categories/AdminCategoryResponse.cs
@@ -1,3 +1,5 @@
+using Backend.Domain.Entities;
+
 namespace Backend.Features.Admin.Categories;
 
 public sealed record AdminCategoryResponse(
@@ -7,4 +9,20 @@ public sealed record AdminCategoryResponse(
     string Icon,
     string? Description,
     int SortOrder,
-    bool IsActive);
+    bool IsActive)
+{
+    /// <summary>
+    /// Creates an <see cref="AdminCategoryResponse"/> from a <see cref="Category"/> entity.
+    /// </summary>
+    public static AdminCategoryResponse FromCategory(Category category)
+    {
+        return new AdminCategoryResponse(
+            category.Id,
+            category.Code,
+            category.Name,
+            category.Icon,
+            category.Description,
+            category.SortOrder,
+            category.IsActive);
+    }
+}

--- a/backend/Features/Admin/Categories/CreateCategoryRequest.cs
+++ b/backend/Features/Admin/Categories/CreateCategoryRequest.cs
@@ -1,0 +1,14 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Backend.Features.Admin.Categories;
+
+public sealed record CreateCategoryRequest(
+    [property: Required]
+    [property: StringLength(64)]
+    string Code,
+    [property: Required]
+    [property: StringLength(120)]
+    string Name,
+    [property: StringLength(500)]
+    string? Description,
+    int SortOrder);

--- a/backend/Features/Admin/Categories/CreateCategoryRequest.cs
+++ b/backend/Features/Admin/Categories/CreateCategoryRequest.cs
@@ -3,15 +3,15 @@ using System.ComponentModel.DataAnnotations;
 namespace Backend.Features.Admin.Categories;
 
 public sealed record CreateCategoryRequest(
-    [property: Required]
-    [property: StringLength(64)]
+    [Required]
+    [StringLength(64)]
     string Code,
-    [property: Required]
-    [property: StringLength(120)]
+    [Required]
+    [StringLength(120)]
     string Name,
-    [property: Required]
-    [property: StringLength(64)]
+    [Required]
+    [StringLength(64)]
     string Icon,
-    [property: StringLength(500)]
+    [StringLength(500)]
     string? Description,
     int SortOrder);

--- a/backend/Features/Admin/Categories/CreateCategoryRequest.cs
+++ b/backend/Features/Admin/Categories/CreateCategoryRequest.cs
@@ -9,6 +9,9 @@ public sealed record CreateCategoryRequest(
     [property: Required]
     [property: StringLength(120)]
     string Name,
+    [property: Required]
+    [property: StringLength(64)]
+    string Icon,
     [property: StringLength(500)]
     string? Description,
     int SortOrder);

--- a/backend/Features/Admin/Categories/UpdateCategoryRequest.cs
+++ b/backend/Features/Admin/Categories/UpdateCategoryRequest.cs
@@ -3,12 +3,12 @@ using System.ComponentModel.DataAnnotations;
 namespace Backend.Features.Admin.Categories;
 
 public sealed record UpdateCategoryRequest(
-    [property: Required]
-    [property: StringLength(120)]
+    [Required]
+    [StringLength(120)]
     string Name,
-    [property: Required]
-    [property: StringLength(64)]
+    [Required]
+    [StringLength(64)]
     string Icon,
-    [property: StringLength(500)]
+    [StringLength(500)]
     string? Description,
     int SortOrder);

--- a/backend/Features/Admin/Categories/UpdateCategoryRequest.cs
+++ b/backend/Features/Admin/Categories/UpdateCategoryRequest.cs
@@ -6,6 +6,9 @@ public sealed record UpdateCategoryRequest(
     [property: Required]
     [property: StringLength(120)]
     string Name,
+    [property: Required]
+    [property: StringLength(64)]
+    string Icon,
     [property: StringLength(500)]
     string? Description,
     int SortOrder);

--- a/backend/Features/Admin/Categories/UpdateCategoryRequest.cs
+++ b/backend/Features/Admin/Categories/UpdateCategoryRequest.cs
@@ -1,0 +1,11 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Backend.Features.Admin.Categories;
+
+public sealed record UpdateCategoryRequest(
+    [property: Required]
+    [property: StringLength(120)]
+    string Name,
+    [property: StringLength(500)]
+    string? Description,
+    int SortOrder);

--- a/backend/Features/Categories/CategoriesCache.cs
+++ b/backend/Features/Categories/CategoriesCache.cs
@@ -1,0 +1,6 @@
+namespace Backend.Features.Categories;
+
+internal static class CategoriesCache
+{
+    public const string Tag = "categories";
+}

--- a/backend/Features/Categories/CategoriesController.cs
+++ b/backend/Features/Categories/CategoriesController.cs
@@ -9,7 +9,7 @@ namespace Backend.Features.Categories;
 public sealed class CategoriesController(IListCategoriesQuery listCategoriesQuery) : ControllerBase
 {
     [HttpGet]
-    [OutputCache(Duration = 300)]
+    [OutputCache(Duration = 300, Tags = [CategoriesCache.Tag])]
     public async Task<IActionResult> ListAsync(CancellationToken cancellationToken)
     {
         var categories = await listCategoriesQuery.ExecuteAsync(cancellationToken);

--- a/backend/Features/Categories/CategoriesController.cs
+++ b/backend/Features/Categories/CategoriesController.cs
@@ -18,6 +18,7 @@ public sealed class CategoriesController(IListCategoriesQuery listCategoriesQuer
                 category.Id,
                 category.Code,
                 category.Name,
+                category.Icon,
                 category.Description));
 
         return Ok(response);

--- a/backend/Features/Categories/CategoryResponse.cs
+++ b/backend/Features/Categories/CategoryResponse.cs
@@ -4,4 +4,5 @@ public sealed record CategoryResponse(
     Guid Id,
     string Code,
     string Name,
+    string Icon,
     string? Description);

--- a/backend/Infrastructure/Persistence/Configurations/ReferenceDataConfigurations.cs
+++ b/backend/Infrastructure/Persistence/Configurations/ReferenceDataConfigurations.cs
@@ -14,6 +14,10 @@ internal sealed class CategoryConfiguration : IEntityTypeConfiguration<Category>
         builder.Property(category => category.Code).HasMaxLength(64).IsRequired();
         builder.Property(category => category.Name).HasMaxLength(120).IsRequired();
         builder.Property(category => category.Description).HasMaxLength(500);
+        builder.Property(category => category.Icon)
+            .HasMaxLength(64)
+            .HasDefaultValue(Category.DefaultIcon)
+            .IsRequired();
         builder.Property(category => category.SortOrder).HasDefaultValue(0);
         builder.Property(category => category.IsActive).HasDefaultValue(true);
         builder.HasCreatedAt(category => category.CreatedAt);
@@ -30,23 +34,24 @@ internal sealed class CategoryConfiguration : IEntityTypeConfiguration<Category>
             .HasDatabaseName("ix_categories_sort_order");
 
         builder.HasData(
-            SeedCategory("00000000-0000-0000-0000-000000000101", "moving", "Moving", 10),
-            SeedCategory("00000000-0000-0000-0000-000000000102", "tutoring", "Tutoring", 20),
-            SeedCategory("00000000-0000-0000-0000-000000000103", "repairs", "Repairs", 30),
-            SeedCategory("00000000-0000-0000-0000-000000000104", "shopping", "Shopping", 40),
-            SeedCategory("00000000-0000-0000-0000-000000000105", "pet_care", "Pet Care", 50),
-            SeedCategory("00000000-0000-0000-0000-000000000106", "cleaning", "Cleaning", 60),
-            SeedCategory("00000000-0000-0000-0000-000000000107", "errands", "Errands", 70),
-            SeedCategory("00000000-0000-0000-0000-000000000108", "other", "Other", 80));
+            SeedCategory("00000000-0000-0000-0000-000000000101", "moving", "Moving", "DeliveryTruck01Icon", 10),
+            SeedCategory("00000000-0000-0000-0000-000000000102", "tutoring", "Tutoring", "Mortarboard02Icon", 20),
+            SeedCategory("00000000-0000-0000-0000-000000000103", "repairs", "Repairs", "Wrench01Icon", 30),
+            SeedCategory("00000000-0000-0000-0000-000000000104", "shopping", "Shopping", "ShoppingBag03Icon", 40),
+            SeedCategory("00000000-0000-0000-0000-000000000105", "pet_care", "Pet Care", "Bone01Icon", 50),
+            SeedCategory("00000000-0000-0000-0000-000000000106", "cleaning", "Cleaning", "SparklesIcon", 60),
+            SeedCategory("00000000-0000-0000-0000-000000000107", "errands", "Errands", "RunningShoesIcon", 70),
+            SeedCategory("00000000-0000-0000-0000-000000000108", "other", "Other", Category.DefaultIcon, 80));
     }
 
-    private static Category SeedCategory(string id, string code, string name, int sortOrder)
+    private static Category SeedCategory(string id, string code, string name, string icon, int sortOrder)
     {
         return new Category
         {
             Id = Guid.Parse(id),
             Code = code,
             Name = name,
+            Icon = icon,
             SortOrder = sortOrder,
             IsActive = true,
             CreatedAt = ConfigurationHelpers.SeedTimestamp,

--- a/backend/Infrastructure/Persistence/Migrations/20260502172754_AddCategoryIcon.Designer.cs
+++ b/backend/Infrastructure/Persistence/Migrations/20260502172754_AddCategoryIcon.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Backend.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NetTopologySuite.Geometries;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Backend.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260502172754_AddCategoryIcon")]
+    partial class AddCategoryIcon
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/Infrastructure/Persistence/Migrations/20260502172754_AddCategoryIcon.cs
+++ b/backend/Infrastructure/Persistence/Migrations/20260502172754_AddCategoryIcon.cs
@@ -1,0 +1,97 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Backend.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddCategoryIcon : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "icon",
+                schema: "config",
+                table: "categories",
+                type: "character varying(64)",
+                maxLength: 64,
+                nullable: false,
+                defaultValue: "MoreHorizontalCircle01Icon");
+
+            migrationBuilder.UpdateData(
+                schema: "config",
+                table: "categories",
+                keyColumn: "id",
+                keyValue: new Guid("00000000-0000-0000-0000-000000000101"),
+                column: "icon",
+                value: "DeliveryTruck01Icon");
+
+            migrationBuilder.UpdateData(
+                schema: "config",
+                table: "categories",
+                keyColumn: "id",
+                keyValue: new Guid("00000000-0000-0000-0000-000000000102"),
+                column: "icon",
+                value: "Mortarboard02Icon");
+
+            migrationBuilder.UpdateData(
+                schema: "config",
+                table: "categories",
+                keyColumn: "id",
+                keyValue: new Guid("00000000-0000-0000-0000-000000000103"),
+                column: "icon",
+                value: "Wrench01Icon");
+
+            migrationBuilder.UpdateData(
+                schema: "config",
+                table: "categories",
+                keyColumn: "id",
+                keyValue: new Guid("00000000-0000-0000-0000-000000000104"),
+                column: "icon",
+                value: "ShoppingBag03Icon");
+
+            migrationBuilder.UpdateData(
+                schema: "config",
+                table: "categories",
+                keyColumn: "id",
+                keyValue: new Guid("00000000-0000-0000-0000-000000000105"),
+                column: "icon",
+                value: "Bone01Icon");
+
+            migrationBuilder.UpdateData(
+                schema: "config",
+                table: "categories",
+                keyColumn: "id",
+                keyValue: new Guid("00000000-0000-0000-0000-000000000106"),
+                column: "icon",
+                value: "SparklesIcon");
+
+            migrationBuilder.UpdateData(
+                schema: "config",
+                table: "categories",
+                keyColumn: "id",
+                keyValue: new Guid("00000000-0000-0000-0000-000000000107"),
+                column: "icon",
+                value: "RunningShoesIcon");
+
+            migrationBuilder.UpdateData(
+                schema: "config",
+                table: "categories",
+                keyColumn: "id",
+                keyValue: new Guid("00000000-0000-0000-0000-000000000108"),
+                column: "icon",
+                value: "MoreHorizontalCircle01Icon");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "icon",
+                schema: "config",
+                table: "categories");
+        }
+    }
+}

--- a/backend/Infrastructure/Persistence/PostgresExceptionHelpers.cs
+++ b/backend/Infrastructure/Persistence/PostgresExceptionHelpers.cs
@@ -22,7 +22,7 @@ public static class PostgresExceptionHelpers
         }
 
         var isUnique = postgresException.SqlState == PostgresErrorCodes.UniqueViolation;
-        
+
         if (constraintName is null)
         {
             return isUnique;

--- a/backend/Infrastructure/Persistence/PostgresExceptionHelpers.cs
+++ b/backend/Infrastructure/Persistence/PostgresExceptionHelpers.cs
@@ -1,0 +1,43 @@
+using Microsoft.EntityFrameworkCore;
+using Npgsql;
+
+namespace Backend.Infrastructure.Persistence;
+
+/// <summary>
+/// Helper methods for handling PostgreSQL-specific exceptions.
+/// </summary>
+public static class PostgresExceptionHelpers
+{
+    /// <summary>
+    /// Checks if a DbUpdateException is due to a unique constraint violation.
+    /// </summary>
+    /// <param name="exception">The DbUpdateException to check.</param>
+    /// <param name="constraintName">The name of the constraint to match (optional).</param>
+    /// <returns>True if the exception is a unique constraint violation, false otherwise.</returns>
+    public static bool IsUniqueConstraintViolation(DbUpdateException exception, string? constraintName = null)
+    {
+        if (exception?.InnerException is not PostgresException postgresException)
+        {
+            return false;
+        }
+
+        var isUnique = postgresException.SqlState == PostgresErrorCodes.UniqueViolation;
+        
+        if (constraintName is null)
+        {
+            return isUnique;
+        }
+
+        return isUnique && postgresException.ConstraintName == constraintName;
+    }
+
+    /// <summary>
+    /// Checks if a DbUpdateException is a duplicate category code violation.
+    /// </summary>
+    /// <param name="exception">The DbUpdateException to check.</param>
+    /// <returns>True if the exception is a duplicate category code violation, false otherwise.</returns>
+    public static bool IsDuplicateCategoryCode(DbUpdateException exception)
+    {
+        return IsUniqueConstraintViolation(exception, "ux_categories_code");
+    }
+}

--- a/backend/Infrastructure/Persistence/Queries/EfListCategoriesQuery.cs
+++ b/backend/Infrastructure/Persistence/Queries/EfListCategoriesQuery.cs
@@ -14,6 +14,7 @@ internal sealed class EfListCategoriesQuery(AppDbContext db) : IListCategoriesQu
                 category.Id,
                 category.Code,
                 category.Name,
+                category.Icon,
                 category.Description))
             .ToListAsync(cancellationToken);
     }

--- a/backend/Infrastructure/Validation/FieldValidator.cs
+++ b/backend/Infrastructure/Validation/FieldValidator.cs
@@ -1,0 +1,37 @@
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+
+namespace Backend.Infrastructure.Validation;
+
+/// <summary>
+/// Provides common field validation helpers for API controllers.
+/// </summary>
+public static class FieldValidator
+{
+    /// <summary>
+    /// Validates that a required field is not empty or whitespace.
+    /// </summary>
+    /// <param name="modelState">The ModelStateDictionary to add errors to.</param>
+    /// <param name="fieldName">The name of the field being validated.</param>
+    /// <param name="value">The value to validate.</param>
+    /// <returns>True if the value is valid (not empty/whitespace), false otherwise.</returns>
+    public static bool ValidateRequired(ModelStateDictionary modelState, string fieldName, string? value)
+    {
+        if (!string.IsNullOrWhiteSpace(value))
+        {
+            return true;
+        }
+
+        modelState.AddModelError(fieldName, $"{fieldName} is required.");
+        return false;
+    }
+
+    /// <summary>
+    /// Checks if a value is empty or whitespace.
+    /// </summary>
+    /// <param name="value">The value to check.</param>
+    /// <returns>True if the value is empty or null, false otherwise.</returns>
+    public static bool IsEmpty(string? value)
+    {
+        return string.IsNullOrWhiteSpace(value);
+    }
+}

--- a/backend/Shared/StringUtilities.cs
+++ b/backend/Shared/StringUtilities.cs
@@ -1,0 +1,21 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace Backend.Shared;
+
+/// <summary>
+/// Utilities for normalizing string values.
+/// </summary>
+public static class StringUtilities
+{
+    /// <summary>
+    /// Normalizes a (nullable) string by trimming whitespace, returning null if empty.
+    /// </summary>
+    /// <param name="value">The string to normalize, or null.</param>
+    /// <returns>The trimmed string, or null if the result would be empty.</returns>
+    [return: NotNullIfNotNull(nameof(value))]
+    public static string? Normalize(string? value)
+    {
+        var normalized = value?.Trim();
+        return string.IsNullOrWhiteSpace(normalized) ? null : normalized;
+    }
+}


### PR DESCRIPTION
## Summary

Implements admin category CRUD and adds category icon support.

## Changes

- Added admin `POST`, `PUT`, and `DELETE` endpoints for categories.
- Evicts cached `GET /api/categories` responses after admin category mutations.
- Added required `Icon` field to `Category`, persistence, seed data, and category API responses.
- Added `AddCategoryIcon` EF migration with seeded icon values.
- Added `AllowedCategoryIcons` as the backend source of truth for valid category icon names.

## Validation

- `dotnet test --configuration Release` passes.
- Targeted `dotnet format --verify-no-changes` passes for changed issue #123 files.

Closes #118  
Closes #123