### PR TITLE
Add icon registry and icon fields

### DIFF
--- a/frontend/app/(main)/tasks/[id]/page.tsx
+++ b/frontend/app/(main)/tasks/[id]/page.tsx
@@ -37,7 +37,7 @@ export default async function TaskDetailPage({ params }: TaskDetailPageProps) {
   return (
     <article className="mx-auto flex max-w-3xl flex-col gap-6">
       <div className="flex flex-wrap items-center gap-2">
-        <CategoryBadge category={task.category} />
+        <CategoryBadge category={task.category} icon={task.icon} />
         <CompensationBadge compensation={task.compensation} />
         <TaskStatusBadge status={task.status} />
       </div>

--- a/frontend/components/profile/task-history.tsx
+++ b/frontend/components/profile/task-history.tsx
@@ -42,7 +42,7 @@ export function TaskHistory({ tasks }: TaskHistoryProps) {
             <div className="flex min-w-0 flex-col gap-1">
               <span className="truncate text-sm font-medium">{task.title}</span>
               <div className="flex items-center gap-2">
-                <CategoryBadge category={task.category} />
+                <CategoryBadge category={task.category} icon={task.icon} />
                 <span className="text-xs text-muted-foreground">
                   {formatRelativeTime(task.createdAt)}
                 </span>

--- a/frontend/components/tasks/category-badge.tsx
+++ b/frontend/components/tasks/category-badge.tsx
@@ -1,15 +1,32 @@
+import { HugeiconsIcon } from "@hugeicons/react"
+
 import { Badge } from "@/components/ui/badge"
 import { TASK_CATEGORIES } from "@/lib/constants"
+import { getIconForKey } from "@/lib/icon-registry"
 import type { TaskCategory } from "@/lib/types"
 
 interface CategoryBadgeProps {
   category: TaskCategory
+  icon?: string
 }
 
 /**
  * Visible label for a task's category.
  *
  */
-export function CategoryBadge({ category }: CategoryBadgeProps) {
-  return <Badge variant="muted">{TASK_CATEGORIES[category].label}</Badge>
+export function CategoryBadge({ category, icon }: CategoryBadgeProps) {
+  const Icon = icon ? getIconForKey(icon) : null
+
+  return (
+    <Badge variant="muted">
+      {Icon ? (
+        <HugeiconsIcon
+          icon={Icon}
+          data-icon="inline-start"
+          aria-hidden="true"
+        />
+      ) : null}
+      {TASK_CATEGORIES[category].label}
+    </Badge>
+  )
 }

--- a/frontend/components/tasks/task-card.tsx
+++ b/frontend/components/tasks/task-card.tsx
@@ -32,7 +32,7 @@ export function TaskCard({ task, hideStatus, className }: TaskCardProps) {
       >
         <CardHeader>
           <div className="flex flex-wrap items-center gap-2">
-            <CategoryBadge category={task.category} />
+            <CategoryBadge category={task.category} icon={task.icon} />
             <CompensationBadge compensation={task.compensation} />
             {!hideStatus ? <TaskStatusBadge status={task.status} /> : null}
             <span className="ml-auto text-xs text-muted-foreground">

--- a/frontend/lib/icon-registry.ts
+++ b/frontend/lib/icon-registry.ts
@@ -1,0 +1,52 @@
+// This list must stay in sync with `backend/Application/Categories/AllowedCategoryIcons.cs`
+// (`Backend.Application.Categories.AllowedCategoryIcons`); drift between the two is a bug.
+import {
+  BabyBottleIcon,
+  Bone01Icon,
+  Briefcase01Icon,
+  BubbleChatIcon,
+  Calendar01Icon,
+  DeliveryTruck01Icon,
+  FavouriteIcon,
+  HandHelpingIcon,
+  MoreHorizontalCircle01Icon,
+  Mortarboard02Icon,
+  RunningShoesIcon,
+  ShoppingBag03Icon,
+  SparklesIcon,
+  StarIcon,
+  ToolboxIcon,
+  Wrench01Icon,
+} from "@hugeicons/core-free-icons"
+import type { IconSvgElement } from "@hugeicons/react"
+
+export const ICON_REGISTRY = {
+  DeliveryTruck01Icon,
+  Mortarboard02Icon,
+  Wrench01Icon,
+  ShoppingBag03Icon,
+  Bone01Icon,
+  SparklesIcon,
+  RunningShoesIcon,
+  MoreHorizontalCircle01Icon,
+  Briefcase01Icon,
+  BubbleChatIcon,
+  HandHelpingIcon,
+  FavouriteIcon,
+  StarIcon,
+  ToolboxIcon,
+  Calendar01Icon,
+  BabyBottleIcon,
+} as const satisfies Record<string, IconSvgElement>
+
+export type IconKey = keyof typeof ICON_REGISTRY
+
+function isIconKey(name: string): name is IconKey {
+  return Object.prototype.hasOwnProperty.call(ICON_REGISTRY, name)
+}
+
+export function getIconForKey(name: string): IconSvgElement {
+  return isIconKey(name)
+    ? ICON_REGISTRY[name]
+    : ICON_REGISTRY.MoreHorizontalCircle01Icon
+}

--- a/frontend/lib/mock-data.ts
+++ b/frontend/lib/mock-data.ts
@@ -78,6 +78,7 @@ export const mockTasks: Task[] = [
     description:
       "Need one extra pair of hands for ~30 minutes. The building has no elevator. Pizza included.",
     category: "moving",
+    icon: "DeliveryTruck01Icon",
     location: "Budapest, District XI",
     compensation: { type: "barter", barterOffer: "Pizza + a beer" },
     status: "open",
@@ -90,6 +91,7 @@ export const mockTasks: Task[] = [
     description:
       "Looking for help with calculus and linear algebra, two sessions before the exam.",
     category: "tutoring",
+    icon: "Mortarboard02Icon",
     location: "Online",
     compensation: { type: "paid", amount: 8000, currency: "HUF" },
     status: "open",
@@ -101,6 +103,7 @@ export const mockTasks: Task[] = [
     title: "Dog sitting this weekend",
     description: "Friendly border collie, two short walks per day. Sat–Sun.",
     category: "petcare",
+    icon: "Bone01Icon",
     location: "Budapest, District V",
     compensation: { type: "voluntary" },
     status: "open",
@@ -113,6 +116,7 @@ export const mockTasks: Task[] = [
     description:
       "Just need it for 2-3 hours to hang shelves. Will return same day.",
     category: "tools",
+    icon: "Wrench01Icon",
     location: "Budapest, District VII",
     compensation: { type: "voluntary" },
     status: "in_progress",

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -41,6 +41,15 @@ export type TaskCategory =
   | "errands"
   | "other"
 
+export interface Category {
+  id: string
+  code: string
+  name: string
+  description?: string | null
+  /** Hugeicons identifier rendered through `getIconForKey`. */
+  icon: string
+}
+
 export type CompensationType = "paid" | "voluntary" | "barter"
 
 export interface Compensation {
@@ -64,6 +73,8 @@ export interface Task {
   title: string
   description: string
   category: TaskCategory
+  /** Category icon identifier rendered through `getIconForKey`. */
+  icon: string
   location: string
   compensation: Compensation
   status: TaskStatus


### PR DESCRIPTION
Introduce ICON_REGISTRY and getIconForKey to map Hugeicons identifiers to IconSvgElement values (defaults to MoreHorizontalCircle01Icon). Add a Category interface with an icon string and add an icon field to Task types so categories/tasks can reference icons. Update mock data to include icon keys for several tasks (e.g. DeliveryTruck01Icon, Mortarboard02Icon, Bone01Icon, Wrench01Icon). The registry must remain in sync with the backend AllowedCategoryIcons list.