### PR TITLE
Add admin UI, categories API and providers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,4 +6,4 @@ POSTGRES_DB=collab_dev
 # Local development / Cosmos emulator defaults
 COSMOS_ENDPOINT=https://localhost:8081/
 COSMOS_KEY=C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==
-API_URL=http://localhost:8080
+API_URL=http://localhost:5073

--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -47,8 +47,6 @@ jobs:
 
       - name: Build
         run: npm run build
-        env:
-          NEXT_PUBLIC_API_URL: http://localhost:8080
 
       - name: Start server
         run: |

--- a/backend/Features/Admin/Categories/AdminCategoriesController.cs
+++ b/backend/Features/Admin/Categories/AdminCategoriesController.cs
@@ -20,11 +20,15 @@ public sealed partial class AdminCategoriesController(
     [HttpGet]
     public async Task<IActionResult> GetAllAsync(CancellationToken cancellationToken)
     {
-        var categories = await db.Categories
+        var categoryEntities = await db.Categories
+            .AsNoTracking()
             .OrderBy(category => category.SortOrder)
             .ThenBy(category => category.Name)
-            .Select(category => AdminCategoryResponse.FromCategory(category))
             .ToListAsync(cancellationToken);
+
+        var categories = categoryEntities
+            .Select(category => AdminCategoryResponse.FromCategory(category))
+            .ToList();
 
         return Ok(categories);
     }

--- a/backend/Features/Admin/Categories/AdminCategoriesController.cs
+++ b/backend/Features/Admin/Categories/AdminCategoriesController.cs
@@ -17,6 +17,18 @@ public sealed partial class AdminCategoriesController(
     IOutputCacheStore outputCacheStore)
     : ControllerBase
 {
+    [HttpGet]
+    public async Task<IActionResult> GetAllAsync(CancellationToken cancellationToken)
+    {
+        var categories = await db.Categories
+            .OrderBy(category => category.SortOrder)
+            .ThenBy(category => category.Name)
+            .Select(category => AdminCategoryResponse.FromCategory(category))
+            .ToListAsync(cancellationToken);
+
+        return Ok(categories);
+    }
+
     [HttpGet("{id:guid}")]
     public async Task<IActionResult> GetByIdAsync(Guid id, CancellationToken cancellationToken)
     {

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -32,7 +32,7 @@ services:
     ports:
       - "3000:3000"
     environment:
-      API_URL: ${API_URL:?API_URL is required}
+      API_URL: ${API_URL:-http://backend:8080}
     depends_on:
       - backend
 

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -32,7 +32,7 @@ services:
     ports:
       - "3000:3000"
     environment:
-      NEXT_PUBLIC_API_URL: ${API_URL:?API_URL is required}
+      API_URL: ${API_URL:?API_URL is required}
     depends_on:
       - backend
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,7 +61,7 @@ services:
       - ./frontend:/app
       - frontend_node_modules:/app/node_modules
     environment:
-      NEXT_PUBLIC_API_URL: http://localhost:8080
+      API_URL: http://localhost:8080
     depends_on:
       - backend
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,7 +61,7 @@ services:
       - ./frontend:/app
       - frontend_node_modules:/app/node_modules
     environment:
-      API_URL: http://localhost:8080
+      API_URL: http://backend:8080
     depends_on:
       - backend
 

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -47,7 +47,7 @@ npm run format       # prettier --write "**/*.{ts,tsx}"
 npm run typecheck    # tsc --noEmit
 ```
 
-The `NEXT_PUBLIC_API_URL` env var points at the backend; compose sets it to `http://localhost:8080` and that's the local default.
+The server-only `API_URL` env var points at the backend. The frontend calls relative `/api/*` URLs, and the App Router proxy reads `API_URL` at runtime. Docker Compose sets it to `http://backend:8080`; local non-Docker development defaults to `http://localhost:5073`.
 
 ## Directory layout
 

--- a/frontend/app/(admin)/admin/audit-log/page.tsx
+++ b/frontend/app/(admin)/admin/audit-log/page.tsx
@@ -11,7 +11,10 @@ export default function AdminAuditLogPage() {
     <div className="space-y-6">
       <div>
         <h1 className="text-2xl font-semibold tracking-tight">Audit Log</h1>
-        <p className="mt-1 text-sm text-muted-foreground">Explore the audit trail for admin and safety actions across the platform.</p>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Explore the audit trail for admin and safety actions across the
+          platform.
+        </p>
       </div>
 
       <Card className="border-dashed">
@@ -23,10 +26,12 @@ export default function AdminAuditLogPage() {
               strokeWidth={1.5}
             />
           </div>
-          <div className="space-y-1.5 max-w-sm">
+          <div className="max-w-sm space-y-1.5">
             <p className="font-medium">Audit Log not yet available</p>
             <p className="text-sm text-muted-foreground">
-              Every admin mutation, safety action, verification event, and terms acceptance will appear in a searchable audit trail once the backend audit event model is wired up (issue #67).
+              Every admin mutation, safety action, verification event, and terms
+              acceptance will appear in a searchable audit trail once the
+              backend audit event model is wired up (issue #67).
             </p>
           </div>
           <Badge variant="outline" className="gap-1.5 text-xs">

--- a/frontend/app/(admin)/admin/audit-log/page.tsx
+++ b/frontend/app/(admin)/admin/audit-log/page.tsx
@@ -1,0 +1,39 @@
+import type { Metadata } from "next"
+import { HugeiconsIcon } from "@hugeicons/react"
+import { ArchiveIcon } from "@hugeicons/core-free-icons"
+import { Card, CardContent } from "@/components/ui/card"
+import { Badge } from "@/components/ui/badge"
+
+export const metadata: Metadata = { title: "Audit Log – Admin" }
+
+export default function AdminAuditLogPage() {
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-semibold tracking-tight">Audit Log</h1>
+        <p className="mt-1 text-sm text-muted-foreground">Explore the audit trail for admin and safety actions across the platform.</p>
+      </div>
+
+      <Card className="border-dashed">
+        <CardContent className="flex flex-col items-center gap-4 py-16 text-center">
+          <div className="flex h-14 w-14 items-center justify-center rounded-full bg-muted">
+            <HugeiconsIcon
+              icon={ArchiveIcon}
+              className="size-7 text-muted-foreground"
+              strokeWidth={1.5}
+            />
+          </div>
+          <div className="space-y-1.5 max-w-sm">
+            <p className="font-medium">Audit Log not yet available</p>
+            <p className="text-sm text-muted-foreground">
+              Every admin mutation, safety action, verification event, and terms acceptance will appear in a searchable audit trail once the backend audit event model is wired up (issue #67).
+            </p>
+          </div>
+          <Badge variant="outline" className="gap-1.5 text-xs">
+            Waiting on #67 — security audit
+          </Badge>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/frontend/app/(admin)/admin/categories/page.tsx
+++ b/frontend/app/(admin)/admin/categories/page.tsx
@@ -1,0 +1,8 @@
+import type { Metadata } from "next"
+import { CategoriesManager } from "@/components/admin/categories-manager"
+
+export const metadata: Metadata = { title: "Categories – Admin" }
+
+export default function AdminCategoriesPage() {
+  return <CategoriesManager />
+}

--- a/frontend/app/(admin)/admin/data-library/page.tsx
+++ b/frontend/app/(admin)/admin/data-library/page.tsx
@@ -1,0 +1,39 @@
+import type { Metadata } from "next"
+import { HugeiconsIcon } from "@hugeicons/react"
+import { BookOpen01Icon } from "@hugeicons/core-free-icons"
+import { Card, CardContent } from "@/components/ui/card"
+import { Badge } from "@/components/ui/badge"
+
+export const metadata: Metadata = { title: "Data Library – Admin" }
+
+export default function AdminDataLibraryPage() {
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-semibold tracking-tight">Data Library</h1>
+        <p className="mt-1 text-sm text-muted-foreground">Manage reference data: terms versions, icon lists, and other configuration.</p>
+      </div>
+
+      <Card className="border-dashed">
+        <CardContent className="flex flex-col items-center gap-4 py-16 text-center">
+          <div className="flex h-14 w-14 items-center justify-center rounded-full bg-muted">
+            <HugeiconsIcon
+              icon={BookOpen01Icon}
+              className="size-7 text-muted-foreground"
+              strokeWidth={1.5}
+            />
+          </div>
+          <div className="space-y-1.5 max-w-sm">
+            <p className="font-medium">Data Library not yet available</p>
+            <p className="text-sm text-muted-foreground">
+              Reference data management — terms versions (#116 / #23), icon lists (#125), and other configuration tables — will be accessible here without requiring migrations or redeploys.
+            </p>
+          </div>
+          <Badge variant="outline" className="gap-1.5 text-xs">
+            Waiting on #116 — terms endpoints
+          </Badge>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/frontend/app/(admin)/admin/data-library/page.tsx
+++ b/frontend/app/(admin)/admin/data-library/page.tsx
@@ -11,7 +11,10 @@ export default function AdminDataLibraryPage() {
     <div className="space-y-6">
       <div>
         <h1 className="text-2xl font-semibold tracking-tight">Data Library</h1>
-        <p className="mt-1 text-sm text-muted-foreground">Manage reference data: terms versions, icon lists, and other configuration.</p>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Manage reference data: terms versions, icon lists, and other
+          configuration.
+        </p>
       </div>
 
       <Card className="border-dashed">
@@ -23,10 +26,12 @@ export default function AdminDataLibraryPage() {
               strokeWidth={1.5}
             />
           </div>
-          <div className="space-y-1.5 max-w-sm">
+          <div className="max-w-sm space-y-1.5">
             <p className="font-medium">Data Library not yet available</p>
             <p className="text-sm text-muted-foreground">
-              Reference data management — terms versions (#116 / #23), icon lists (#125), and other configuration tables — will be accessible here without requiring migrations or redeploys.
+              Reference data management — terms versions (#116 / #23), icon
+              lists (#125), and other configuration tables — will be accessible
+              here without requiring migrations or redeploys.
             </p>
           </div>
           <Badge variant="outline" className="gap-1.5 text-xs">

--- a/frontend/app/(admin)/admin/page.tsx
+++ b/frontend/app/(admin)/admin/page.tsx
@@ -1,0 +1,8 @@
+import type { Metadata } from "next"
+import { AdminDashboard } from "@/components/admin/admin-dashboard"
+
+export const metadata: Metadata = { title: "Dashboard – Admin" }
+
+export default function AdminDashboardPage() {
+  return <AdminDashboard />
+}

--- a/frontend/app/(admin)/admin/profile/page.tsx
+++ b/frontend/app/(admin)/admin/profile/page.tsx
@@ -1,0 +1,69 @@
+"use client"
+
+import { Badge } from "@/components/ui/badge"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Separator } from "@/components/ui/separator"
+import { UserAvatar } from "@/components/shared/user-avatar"
+import { useAuth } from "@/lib/auth-context"
+
+export default function AdminProfilePage() {
+  const { user } = useAuth()
+
+  if (!user) return null
+
+  return (
+    <div className="mx-auto max-w-2xl space-y-6 p-6">
+      {/* Identity header */}
+      <div className="flex items-center gap-5">
+        <UserAvatar name={user.name} src={user.avatarUrl} size="lg" />
+        <div className="flex flex-col gap-1">
+          <div className="flex items-center gap-2">
+            <h1 className="text-xl font-semibold leading-tight">{user.name}</h1>
+            <Badge variant="secondary">{user.role}</Badge>
+          </div>
+          <p className="text-sm text-muted-foreground">{user.email}</p>
+        </div>
+      </div>
+
+      <Separator />
+
+      {/* Account details card */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Account details</CardTitle>
+          <CardDescription>
+            Your identity as seen across the platform. Full editing will be
+            available once the authentication system ships.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <dl className="space-y-4 text-sm">
+            <div className="grid grid-cols-3 gap-2">
+              <dt className="font-medium text-muted-foreground">Full name</dt>
+              <dd className="col-span-2">{user.name}</dd>
+            </div>
+            <Separator />
+            <div className="grid grid-cols-3 gap-2">
+              <dt className="font-medium text-muted-foreground">Email</dt>
+              <dd className="col-span-2">{user.email}</dd>
+            </div>
+            <Separator />
+            <div className="grid grid-cols-3 gap-2">
+              <dt className="font-medium text-muted-foreground">Role</dt>
+              <dd className="col-span-2">
+                <Badge variant="secondary">{user.role}</Badge>
+              </dd>
+            </div>
+            <Separator />
+            <div className="grid grid-cols-3 gap-2">
+              <dt className="font-medium text-muted-foreground">User ID</dt>
+              <dd className="col-span-2 font-mono text-xs text-muted-foreground">
+                {user.id}
+              </dd>
+            </div>
+          </dl>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/frontend/app/(admin)/admin/profile/page.tsx
+++ b/frontend/app/(admin)/admin/profile/page.tsx
@@ -1,7 +1,13 @@
 "use client"
 
 import { Badge } from "@/components/ui/badge"
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
 import { Separator } from "@/components/ui/separator"
 import { UserAvatar } from "@/components/shared/user-avatar"
 import { useAuth } from "@/lib/auth-context"
@@ -18,7 +24,7 @@ export default function AdminProfilePage() {
         <UserAvatar name={user.name} src={user.avatarUrl} size="lg" />
         <div className="flex flex-col gap-1">
           <div className="flex items-center gap-2">
-            <h1 className="text-xl font-semibold leading-tight">{user.name}</h1>
+            <h1 className="text-xl leading-tight font-semibold">{user.name}</h1>
             <Badge variant="secondary">{user.role}</Badge>
           </div>
           <p className="text-sm text-muted-foreground">{user.email}</p>

--- a/frontend/app/(admin)/admin/reports/page.tsx
+++ b/frontend/app/(admin)/admin/reports/page.tsx
@@ -1,0 +1,39 @@
+import type { Metadata } from "next"
+import { HugeiconsIcon } from "@hugeicons/react"
+import { ShieldUserIcon } from "@hugeicons/core-free-icons"
+import { Card, CardContent } from "@/components/ui/card"
+import { Badge } from "@/components/ui/badge"
+
+export const metadata: Metadata = { title: "Reports – Admin" }
+
+export default function AdminReportsPage() {
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-semibold tracking-tight">Reports</h1>
+        <p className="mt-1 text-sm text-muted-foreground">Trust and safety reports, disputes, and cancelled-task review queue.</p>
+      </div>
+
+      <Card className="border-dashed">
+        <CardContent className="flex flex-col items-center gap-4 py-16 text-center">
+          <div className="flex h-14 w-14 items-center justify-center rounded-full bg-muted">
+            <HugeiconsIcon
+              icon={ShieldUserIcon}
+              className="size-7 text-muted-foreground"
+              strokeWidth={1.5}
+            />
+          </div>
+          <div className="space-y-1.5 max-w-sm">
+            <p className="font-medium">Reports not yet available</p>
+            <p className="text-sm text-muted-foreground">
+              The reports queue will surface trust-and-safety flags, user disputes, and cancelled task reasons once backend support is in place (issue #55). No placeholder actions are shown — real report data will drive this interface.
+            </p>
+          </div>
+          <Badge variant="outline" className="gap-1.5 text-xs">
+            Waiting on #55 — cancellation reasons + audit log
+          </Badge>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/frontend/app/(admin)/admin/reports/page.tsx
+++ b/frontend/app/(admin)/admin/reports/page.tsx
@@ -11,7 +11,9 @@ export default function AdminReportsPage() {
     <div className="space-y-6">
       <div>
         <h1 className="text-2xl font-semibold tracking-tight">Reports</h1>
-        <p className="mt-1 text-sm text-muted-foreground">Trust and safety reports, disputes, and cancelled-task review queue.</p>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Trust and safety reports, disputes, and cancelled-task review queue.
+        </p>
       </div>
 
       <Card className="border-dashed">
@@ -23,10 +25,13 @@ export default function AdminReportsPage() {
               strokeWidth={1.5}
             />
           </div>
-          <div className="space-y-1.5 max-w-sm">
+          <div className="max-w-sm space-y-1.5">
             <p className="font-medium">Reports not yet available</p>
             <p className="text-sm text-muted-foreground">
-              The reports queue will surface trust-and-safety flags, user disputes, and cancelled task reasons once backend support is in place (issue #55). No placeholder actions are shown — real report data will drive this interface.
+              The reports queue will surface trust-and-safety flags, user
+              disputes, and cancelled task reasons once backend support is in
+              place (issue #55). No placeholder actions are shown — real report
+              data will drive this interface.
             </p>
           </div>
           <Badge variant="outline" className="gap-1.5 text-xs">

--- a/frontend/app/(admin)/admin/skills/page.tsx
+++ b/frontend/app/(admin)/admin/skills/page.tsx
@@ -1,0 +1,39 @@
+import type { Metadata } from "next"
+import { HugeiconsIcon } from "@hugeicons/react"
+import { BookOpen01Icon } from "@hugeicons/core-free-icons"
+import { Card, CardContent } from "@/components/ui/card"
+import { Badge } from "@/components/ui/badge"
+
+export const metadata: Metadata = { title: "Skills – Admin" }
+
+export default function AdminSkillsPage() {
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-semibold tracking-tight">Skills</h1>
+        <p className="mt-1 text-sm text-muted-foreground">Manage the curated skill catalog that helpers can add to their profiles.</p>
+      </div>
+
+      <Card className="border-dashed">
+        <CardContent className="flex flex-col items-center gap-4 py-16 text-center">
+          <div className="flex h-14 w-14 items-center justify-center rounded-full bg-muted">
+            <HugeiconsIcon
+              icon={BookOpen01Icon}
+              className="size-7 text-muted-foreground"
+              strokeWidth={1.5}
+            />
+          </div>
+          <div className="space-y-1.5 max-w-sm">
+            <p className="font-medium">Skills not yet available</p>
+            <p className="text-sm text-muted-foreground">
+              Once the skills endpoint (issue #119) ships, this page will allow you to create, rename, and deactivate skills in the catalog. Helpers will be able to add skills from this list to their profiles.
+            </p>
+          </div>
+          <Badge variant="outline" className="gap-1.5 text-xs">
+            Waiting on #119 — admin skill CRUD
+          </Badge>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/frontend/app/(admin)/admin/skills/page.tsx
+++ b/frontend/app/(admin)/admin/skills/page.tsx
@@ -11,7 +11,10 @@ export default function AdminSkillsPage() {
     <div className="space-y-6">
       <div>
         <h1 className="text-2xl font-semibold tracking-tight">Skills</h1>
-        <p className="mt-1 text-sm text-muted-foreground">Manage the curated skill catalog that helpers can add to their profiles.</p>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Manage the curated skill catalog that helpers can add to their
+          profiles.
+        </p>
       </div>
 
       <Card className="border-dashed">
@@ -23,10 +26,13 @@ export default function AdminSkillsPage() {
               strokeWidth={1.5}
             />
           </div>
-          <div className="space-y-1.5 max-w-sm">
+          <div className="max-w-sm space-y-1.5">
             <p className="font-medium">Skills not yet available</p>
             <p className="text-sm text-muted-foreground">
-              Once the skills endpoint (issue #119) ships, this page will allow you to create, rename, and deactivate skills in the catalog. Helpers will be able to add skills from this list to their profiles.
+              Once the skills endpoint (issue #119) ships, this page will allow
+              you to create, rename, and deactivate skills in the catalog.
+              Helpers will be able to add skills from this list to their
+              profiles.
             </p>
           </div>
           <Badge variant="outline" className="gap-1.5 text-xs">

--- a/frontend/app/(admin)/admin/users/page.tsx
+++ b/frontend/app/(admin)/admin/users/page.tsx
@@ -11,7 +11,10 @@ export default function AdminUsersPage() {
     <div className="space-y-6">
       <div>
         <h1 className="text-2xl font-semibold tracking-tight">Users</h1>
-        <p className="mt-1 text-sm text-muted-foreground">View and manage user accounts, verification status, and profile health.</p>
+        <p className="mt-1 text-sm text-muted-foreground">
+          View and manage user accounts, verification status, and profile
+          health.
+        </p>
       </div>
 
       <Card className="border-dashed">
@@ -23,10 +26,13 @@ export default function AdminUsersPage() {
               strokeWidth={1.5}
             />
           </div>
-          <div className="space-y-1.5 max-w-sm">
+          <div className="max-w-sm space-y-1.5">
             <p className="font-medium">Users not yet available</p>
             <p className="text-sm text-muted-foreground">
-              User management, email verification review, and account health tooling will appear here. Suspension/ban actions require a separate backend authorization and audit design before they can be added.
+              User management, email verification review, and account health
+              tooling will appear here. Suspension/ban actions require a
+              separate backend authorization and audit design before they can be
+              added.
             </p>
           </div>
           <Badge variant="outline" className="gap-1.5 text-xs">

--- a/frontend/app/(admin)/admin/users/page.tsx
+++ b/frontend/app/(admin)/admin/users/page.tsx
@@ -1,0 +1,39 @@
+import type { Metadata } from "next"
+import { HugeiconsIcon } from "@hugeicons/react"
+import { UserMultiple02Icon } from "@hugeicons/core-free-icons"
+import { Card, CardContent } from "@/components/ui/card"
+import { Badge } from "@/components/ui/badge"
+
+export const metadata: Metadata = { title: "Users – Admin" }
+
+export default function AdminUsersPage() {
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-semibold tracking-tight">Users</h1>
+        <p className="mt-1 text-sm text-muted-foreground">View and manage user accounts, verification status, and profile health.</p>
+      </div>
+
+      <Card className="border-dashed">
+        <CardContent className="flex flex-col items-center gap-4 py-16 text-center">
+          <div className="flex h-14 w-14 items-center justify-center rounded-full bg-muted">
+            <HugeiconsIcon
+              icon={UserMultiple02Icon}
+              className="size-7 text-muted-foreground"
+              strokeWidth={1.5}
+            />
+          </div>
+          <div className="space-y-1.5 max-w-sm">
+            <p className="font-medium">Users not yet available</p>
+            <p className="text-sm text-muted-foreground">
+              User management, email verification review, and account health tooling will appear here. Suspension/ban actions require a separate backend authorization and audit design before they can be added.
+            </p>
+          </div>
+          <Badge variant="outline" className="gap-1.5 text-xs">
+            Waiting on #20 — email verification & user lifecycle
+          </Badge>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/frontend/app/(admin)/layout.tsx
+++ b/frontend/app/(admin)/layout.tsx
@@ -1,0 +1,35 @@
+import { AdminGuard } from "@/components/admin/admin-guard"
+import { AdminDesktopSidebar } from "@/components/admin/admin-sidebar"
+import { AdminHeader } from "@/components/admin/admin-header"
+
+/**
+ * Layout for all /admin/* routes.
+ *
+ * Completely separate from the (main) layout — no AppHeader, no MobileNav,
+ * no user-facing chrome. Uses the dashboard-01 pattern: fixed sidebar on
+ * desktop, slide-in drawer on mobile.
+ *
+ * All child routes are guarded by AdminGuard, which redirects non-admin
+ * users to /feed.
+ */
+export default function AdminLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <AdminGuard>
+      <div className="flex h-svh overflow-hidden">
+        <AdminDesktopSidebar />
+        <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
+          <AdminHeader />
+          <main className="flex-1 overflow-y-auto">
+            <div className="mx-auto max-w-7xl px-4 py-6 sm:px-6 lg:px-8">
+              {children}
+            </div>
+          </main>
+        </div>
+      </div>
+    </AdminGuard>
+  )
+}

--- a/frontend/app/api/[...path]/route.ts
+++ b/frontend/app/api/[...path]/route.ts
@@ -1,0 +1,36 @@
+const DEFAULT_API_URL = "http://localhost:5073"
+
+type ApiRouteContext = {
+  params: Promise<{
+    path: string[]
+  }>
+}
+
+function getBackendUrl(path: string[], requestUrl: string): URL {
+  const backendBaseUrl = process.env.API_URL ?? DEFAULT_API_URL
+  const incomingUrl = new URL(requestUrl)
+  const backendUrl = new URL(`/api/${path.join("/")}`, backendBaseUrl)
+
+  backendUrl.search = incomingUrl.search
+
+  return backendUrl
+}
+
+async function proxyRequest(
+  request: Request,
+  context: ApiRouteContext
+): Promise<Response> {
+  const { path } = await context.params
+  const backendUrl = getBackendUrl(path, request.url)
+  const proxyRequest = new Request(backendUrl, request)
+
+  return fetch(proxyRequest)
+}
+
+export const GET = proxyRequest
+export const POST = proxyRequest
+export const PUT = proxyRequest
+export const PATCH = proxyRequest
+export const DELETE = proxyRequest
+export const HEAD = proxyRequest
+export const OPTIONS = proxyRequest

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -2,6 +2,9 @@ import type { Metadata } from "next"
 
 import "./globals.css"
 import { ThemeProvider } from "@/components/theme-provider"
+import { QueryProvider } from "@/components/providers/query-provider"
+import { AuthProvider } from "@/lib/auth-context"
+import { Toaster } from "@/components/ui/sonner"
 import { APP_NAME, APP_TAGLINE } from "@/lib/constants"
 
 export const metadata: Metadata = {
@@ -20,7 +23,14 @@ export default function RootLayout({
   return (
     <html lang="en" suppressHydrationWarning className="font-sans antialiased">
       <body>
-        <ThemeProvider>{children}</ThemeProvider>
+        <ThemeProvider>
+          <QueryProvider>
+            <AuthProvider>
+              {children}
+              <Toaster />
+            </AuthProvider>
+          </QueryProvider>
+        </ThemeProvider>
       </body>
     </html>
   )

--- a/frontend/components/admin/admin-dashboard.tsx
+++ b/frontend/components/admin/admin-dashboard.tsx
@@ -1,0 +1,281 @@
+"use client"
+
+import * as React from "react"
+import { HugeiconsIcon } from "@hugeicons/react"
+import {
+  UserMultiple02Icon,
+  Activity01Icon,
+  TaskDaily01Icon,
+  Tick02Icon,
+  BarChartIcon,
+  InformationCircleIcon,
+} from "@hugeicons/core-free-icons"
+
+import { useAdminKpi, type KpiCurrent } from "@/lib/api/admin/analytics"
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card"
+import { Skeleton } from "@/components/ui/skeleton"
+import { Alert, AlertDescription } from "@/components/ui/alert"
+import { Badge } from "@/components/ui/badge"
+import type { IconSvgElement } from "@hugeicons/react"
+
+// ── KPI card ────────────────────────────────────────────────────────────────
+
+interface KpiCardProps {
+  title: string
+  value: string | number
+  description?: string
+  icon: IconSvgElement
+  isLoading?: boolean
+}
+
+function KpiCard({ title, value, description, icon, isLoading }: KpiCardProps) {
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-center justify-between pb-2">
+        <CardTitle className="text-sm font-medium text-muted-foreground">
+          {title}
+        </CardTitle>
+        <HugeiconsIcon icon={icon} className="size-4 text-muted-foreground" strokeWidth={1.5} />
+      </CardHeader>
+      <CardContent>
+        {isLoading ? (
+          <Skeleton className="h-8 w-24" />
+        ) : (
+          <div className="text-2xl font-bold tracking-tight">{value}</div>
+        )}
+        {description && (
+          <p className="mt-1 text-xs text-muted-foreground">{description}</p>
+        )}
+      </CardContent>
+    </Card>
+  )
+}
+
+function KpiCards({
+  data,
+  isLoading,
+}: {
+  data?: KpiCurrent
+  isLoading: boolean
+}) {
+  const fmt = (n?: number) =>
+    n === undefined ? "—" : n.toLocaleString()
+  const pct = (n?: number) =>
+    n === undefined ? "—" : `${(n * 100).toFixed(1)}%`
+
+  return (
+    <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-5">
+      <KpiCard
+        title="Registered Users"
+        value={fmt(data?.registeredUsers)}
+        description="All-time total"
+        icon={UserMultiple02Icon}
+        isLoading={isLoading}
+      />
+      <KpiCard
+        title="Active Users (7d)"
+        value={fmt(data?.activeUsers7d)}
+        description="Unique users with activity"
+        icon={Activity01Icon}
+        isLoading={isLoading}
+      />
+      <KpiCard
+        title="Tasks Posted (7d)"
+        value={fmt(data?.tasksPosted7d)}
+        description="New tasks this week"
+        icon={TaskDaily01Icon}
+        isLoading={isLoading}
+      />
+      <KpiCard
+        title="Completed Tasks (7d)"
+        value={fmt(data?.completedTasks7d)}
+        description="Marked done this week"
+        icon={Tick02Icon}
+        isLoading={isLoading}
+      />
+      <KpiCard
+        title="Completion Rate (7d)"
+        value={pct(data?.completionRate7d)}
+        description="Completed / posted"
+        icon={BarChartIcon}
+        isLoading={isLoading}
+      />
+    </div>
+  )
+}
+
+// ── Placeholder charts ────────────────────────────────────────────────────────
+
+/** Simple horizontal bar chart using plain CSS */
+function BarChart({
+  data,
+  colorClass = "bg-primary",
+}: {
+  data: { label: string; value: number; pct: number }[]
+  colorClass?: string
+}) {
+  return (
+    <div className="space-y-3">
+      {data.map((row) => (
+        <div key={row.label} className="flex items-center gap-3">
+          <span className="w-28 shrink-0 truncate text-sm text-muted-foreground">
+            {row.label}
+          </span>
+          <div className="flex-1 overflow-hidden rounded-full bg-muted h-2">
+            <div
+              className={`h-full rounded-full ${colorClass} transition-all`}
+              style={{ width: `${row.pct}%` }}
+            />
+          </div>
+          <span className="w-10 shrink-0 text-right text-sm tabular-nums">
+            {row.value}
+          </span>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+// ── Stub chart data (isolated placeholders until real endpoints exist) ───────���
+
+const TASK_STATUS_DATA = [
+  { label: "Open", value: 124, pct: 62 },
+  { label: "In Progress", value: 47, pct: 24 },
+  { label: "Completed", value: 186, pct: 93 },
+  { label: "Cancelled", value: 18, pct: 9 },
+]
+
+const CATEGORY_DEMAND_DATA = [
+  { label: "Household", value: 89, pct: 89 },
+  { label: "Moving", value: 67, pct: 67 },
+  { label: "Tutoring", value: 54, pct: 54 },
+  { label: "Tech Help", value: 43, pct: 43 },
+  { label: "Errands", value: 38, pct: 38 },
+  { label: "Pet Care", value: 22, pct: 22 },
+]
+
+const COMPENSATION_DATA = [
+  { label: "Voluntary", value: 142, pct: 71 },
+  { label: "Points/Credit", value: 78, pct: 39 },
+  { label: "Paid", value: 55, pct: 28 },
+  { label: "Barter", value: 25, pct: 13 },
+]
+
+function PlaceholderBadge() {
+  return (
+    <Badge variant="outline" className="text-[10px] gap-1">
+      <HugeiconsIcon icon={InformationCircleIcon} className="size-3" strokeWidth={1.5} />
+      Placeholder data
+    </Badge>
+  )
+}
+
+// ── Dashboard component ───────────────────────────────────────────────────────
+
+export function AdminDashboard() {
+  const { data, isLoading, isError, error } = useAdminKpi()
+
+  return (
+    <div className="space-y-8">
+      {/* Page heading */}
+      <div>
+        <h1 className="text-2xl font-semibold tracking-tight">Dashboard</h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Marketplace health overview
+        </p>
+      </div>
+
+      {/* KPI error state */}
+      {isError && (
+        <Alert variant="destructive">
+          <AlertDescription>
+            Could not load KPI data —{" "}
+            {error instanceof Error ? error.message : "unknown error"}. The
+            analytics endpoint may not be available yet (issue #72).
+          </AlertDescription>
+        </Alert>
+      )}
+
+      {/* KPI cards */}
+      <KpiCards data={data} isLoading={isLoading && !isError} />
+
+      {/* Charts row */}
+      <div className="grid gap-6 lg:grid-cols-3">
+        {/* Task lifecycle distribution */}
+        <Card>
+          <CardHeader className="pb-3">
+            <div className="flex items-start justify-between gap-2">
+              <div>
+                <CardTitle className="text-base">Task Status</CardTitle>
+                <CardDescription className="mt-1">
+                  Distribution across lifecycle stages
+                </CardDescription>
+              </div>
+              <PlaceholderBadge />
+            </div>
+          </CardHeader>
+          <CardContent>
+            <BarChart data={TASK_STATUS_DATA} colorClass="bg-primary" />
+          </CardContent>
+        </Card>
+
+        {/* Category demand */}
+        <Card>
+          <CardHeader className="pb-3">
+            <div className="flex items-start justify-between gap-2">
+              <div>
+                <CardTitle className="text-base">Category Demand</CardTitle>
+                <CardDescription className="mt-1">
+                  Tasks per category (last 30 days)
+                </CardDescription>
+              </div>
+              <PlaceholderBadge />
+            </div>
+          </CardHeader>
+          <CardContent>
+            <BarChart data={CATEGORY_DEMAND_DATA} colorClass="bg-blue-500" />
+          </CardContent>
+        </Card>
+
+        {/* Compensation mix */}
+        <Card>
+          <CardHeader className="pb-3">
+            <div className="flex items-start justify-between gap-2">
+              <div>
+                <CardTitle className="text-base">Compensation Mix</CardTitle>
+                <CardDescription className="mt-1">
+                  Task compensation type breakdown
+                </CardDescription>
+              </div>
+              <PlaceholderBadge />
+            </div>
+          </CardHeader>
+          <CardContent>
+            <BarChart data={COMPENSATION_DATA} colorClass="bg-emerald-500" />
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Roadmap notice */}
+      <Card className="border-dashed">
+        <CardContent className="py-5">
+          <div className="flex items-start gap-3">
+            <HugeiconsIcon
+              icon={InformationCircleIcon}
+              className="mt-0.5 size-4 shrink-0 text-muted-foreground"
+              strokeWidth={1.5}
+            />
+            <div className="text-sm text-muted-foreground space-y-1">
+              <p className="font-medium text-foreground">More analytics coming soon</p>
+              <p>
+                User growth trend, reputation distribution, cancellation reasons
+                (#55), and message volume will appear here once their backend
+                endpoints are ready (#72 / #73).
+              </p>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/frontend/components/admin/admin-dashboard.tsx
+++ b/frontend/components/admin/admin-dashboard.tsx
@@ -145,7 +145,7 @@ function BarChart({
   )
 }
 
-// ── Stub chart data (isolated placeholders until real endpoints exist) ───────���
+// ── Stub chart data (isolated placeholders until real endpoints exist) ───────
 
 const TASK_STATUS_DATA = [
   { label: "Open", value: 124, pct: 62 },

--- a/frontend/components/admin/admin-dashboard.tsx
+++ b/frontend/components/admin/admin-dashboard.tsx
@@ -12,7 +12,13 @@ import {
 } from "@hugeicons/core-free-icons"
 
 import { useAdminKpi, type KpiCurrent } from "@/lib/api/admin/analytics"
-import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card"
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+} from "@/components/ui/card"
 import { Skeleton } from "@/components/ui/skeleton"
 import { Alert, AlertDescription } from "@/components/ui/alert"
 import { Badge } from "@/components/ui/badge"
@@ -35,7 +41,11 @@ function KpiCard({ title, value, description, icon, isLoading }: KpiCardProps) {
         <CardTitle className="text-sm font-medium text-muted-foreground">
           {title}
         </CardTitle>
-        <HugeiconsIcon icon={icon} className="size-4 text-muted-foreground" strokeWidth={1.5} />
+        <HugeiconsIcon
+          icon={icon}
+          className="size-4 text-muted-foreground"
+          strokeWidth={1.5}
+        />
       </CardHeader>
       <CardContent>
         {isLoading ? (
@@ -58,8 +68,7 @@ function KpiCards({
   data?: KpiCurrent
   isLoading: boolean
 }) {
-  const fmt = (n?: number) =>
-    n === undefined ? "—" : n.toLocaleString()
+  const fmt = (n?: number) => (n === undefined ? "—" : n.toLocaleString())
   const pct = (n?: number) =>
     n === undefined ? "—" : `${(n * 100).toFixed(1)}%`
 
@@ -121,7 +130,7 @@ function BarChart({
           <span className="w-28 shrink-0 truncate text-sm text-muted-foreground">
             {row.label}
           </span>
-          <div className="flex-1 overflow-hidden rounded-full bg-muted h-2">
+          <div className="h-2 flex-1 overflow-hidden rounded-full bg-muted">
             <div
               className={`h-full rounded-full ${colorClass} transition-all`}
               style={{ width: `${row.pct}%` }}
@@ -163,8 +172,12 @@ const COMPENSATION_DATA = [
 
 function PlaceholderBadge() {
   return (
-    <Badge variant="outline" className="text-[10px] gap-1">
-      <HugeiconsIcon icon={InformationCircleIcon} className="size-3" strokeWidth={1.5} />
+    <Badge variant="outline" className="gap-1 text-[10px]">
+      <HugeiconsIcon
+        icon={InformationCircleIcon}
+        className="size-3"
+        strokeWidth={1.5}
+      />
       Placeholder data
     </Badge>
   )
@@ -265,8 +278,10 @@ export function AdminDashboard() {
               className="mt-0.5 size-4 shrink-0 text-muted-foreground"
               strokeWidth={1.5}
             />
-            <div className="text-sm text-muted-foreground space-y-1">
-              <p className="font-medium text-foreground">More analytics coming soon</p>
+            <div className="space-y-1 text-sm text-muted-foreground">
+              <p className="font-medium text-foreground">
+                More analytics coming soon
+              </p>
               <p>
                 User growth trend, reputation distribution, cancellation reasons
                 (#55), and message volume will appear here once their backend

--- a/frontend/components/admin/admin-guard.tsx
+++ b/frontend/components/admin/admin-guard.tsx
@@ -1,0 +1,47 @@
+"use client"
+
+import * as React from "react"
+import { useRouter } from "next/navigation"
+import { useAuth } from "@/lib/auth-context"
+import { Skeleton } from "@/components/ui/skeleton"
+
+/**
+ * Wraps all /admin/* routes. While the session is loading it shows a
+ * skeleton; once settled it redirects non-admin visitors to /feed.
+ *
+ * TODO: once real auth ships, ensure the redirect target is the post-login
+ * landing page for the user's role (currently /feed for regular users).
+ */
+export function AdminGuard({ children }: { children: React.ReactNode }) {
+  const { isLoading, isAdmin } = useAuth()
+  const router = useRouter()
+
+  React.useEffect(() => {
+    if (!isLoading && !isAdmin) {
+      router.replace("/feed")
+    }
+  }, [isLoading, isAdmin, router])
+
+  if (isLoading) {
+    return (
+      <div className="flex h-svh flex-col gap-4 p-8">
+        <Skeleton className="h-8 w-48" />
+        <div className="flex flex-1 gap-4">
+          <Skeleton className="h-full w-56" />
+          <div className="flex-1 space-y-4">
+            <Skeleton className="h-10 w-full" />
+            <Skeleton className="h-32 w-full" />
+            <Skeleton className="h-32 w-full" />
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  if (!isAdmin) {
+    // Will redirect via useEffect; render nothing in the meantime
+    return null
+  }
+
+  return <>{children}</>
+}

--- a/frontend/components/admin/admin-header.tsx
+++ b/frontend/components/admin/admin-header.tsx
@@ -1,0 +1,65 @@
+"use client"
+
+import * as React from "react"
+import Link from "next/link"
+import { usePathname } from "next/navigation"
+import { HugeiconsIcon } from "@hugeicons/react"
+import { ArrowRight01Icon } from "@hugeicons/core-free-icons"
+
+import { Separator } from "@/components/ui/separator"
+import { AdminMobileMenuButton, AdminMobileSidebar } from "./admin-sidebar"
+
+// Page title map  →  href : { label, parent? }
+const PAGE_META: Record<string, { label: string; parent?: string }> = {
+  "/admin": { label: "Dashboard" },
+  "/admin/categories": { label: "Categories", parent: "/admin" },
+  "/admin/skills": { label: "Skills", parent: "/admin" },
+  "/admin/users": { label: "Users", parent: "/admin" },
+  "/admin/reports": { label: "Reports", parent: "/admin" },
+  "/admin/data-library": { label: "Data Library", parent: "/admin" },
+  "/admin/audit-log": { label: "Audit Log", parent: "/admin" },
+  "/admin/profile": { label: "My Account", parent: "/admin" },
+}
+
+function Breadcrumb({ pathname }: { pathname: string }) {
+  const meta = PAGE_META[pathname]
+  if (!meta) return <span className="text-sm font-medium">Admin</span>
+
+  if (!meta.parent) {
+    return <span className="text-sm font-medium">{meta.label}</span>
+  }
+
+  const parentMeta = PAGE_META[meta.parent]
+
+  return (
+    <nav aria-label="Breadcrumb" className="flex items-center gap-1.5 text-sm">
+      <Link
+        href={meta.parent}
+        className="text-muted-foreground hover:text-foreground transition-colors"
+      >
+        {parentMeta?.label ?? "Admin"}
+      </Link>
+      <HugeiconsIcon icon={ArrowRight01Icon} className="size-3.5 text-muted-foreground" strokeWidth={1.5} />
+      <span className="font-medium">{meta.label}</span>
+    </nav>
+  )
+}
+
+export function AdminHeader() {
+  const pathname = usePathname()
+  const [mobileSidebarOpen, setMobileSidebarOpen] = React.useState(false)
+
+  return (
+    <>
+      <header className="sticky top-0 z-40 flex h-14 items-center gap-3 border-b bg-background/95 px-4 backdrop-blur supports-backdrop-filter:bg-background/60 lg:px-6">
+        <AdminMobileMenuButton onClick={() => setMobileSidebarOpen(true)} />
+        <Separator orientation="vertical" className="h-5 lg:hidden" />
+        <Breadcrumb pathname={pathname} />
+      </header>
+      <AdminMobileSidebar
+        open={mobileSidebarOpen}
+        onOpenChange={setMobileSidebarOpen}
+      />
+    </>
+  )
+}

--- a/frontend/components/admin/admin-header.tsx
+++ b/frontend/components/admin/admin-header.tsx
@@ -35,11 +35,15 @@ function Breadcrumb({ pathname }: { pathname: string }) {
     <nav aria-label="Breadcrumb" className="flex items-center gap-1.5 text-sm">
       <Link
         href={meta.parent}
-        className="text-muted-foreground hover:text-foreground transition-colors"
+        className="text-muted-foreground transition-colors hover:text-foreground"
       >
         {parentMeta?.label ?? "Admin"}
       </Link>
-      <HugeiconsIcon icon={ArrowRight01Icon} className="size-3.5 text-muted-foreground" strokeWidth={1.5} />
+      <HugeiconsIcon
+        icon={ArrowRight01Icon}
+        className="size-3.5 text-muted-foreground"
+        strokeWidth={1.5}
+      />
       <span className="font-medium">{meta.label}</span>
     </nav>
   )

--- a/frontend/components/admin/admin-sidebar.tsx
+++ b/frontend/components/admin/admin-sidebar.tsx
@@ -1,0 +1,355 @@
+"use client"
+
+import * as React from "react"
+import Link from "next/link"
+import { usePathname } from "next/navigation"
+import { HugeiconsIcon } from "@hugeicons/react"
+import {
+  Analytics01Icon,
+  Tag01Icon,
+  UserMultiple02Icon,
+  ShieldUserIcon,
+  BookOpen01Icon,
+  ArchiveIcon,
+  FlipBottomIcon,
+  Menu01Icon,
+  BriefcaseIcon,
+  MoreHorizontalCircle01Icon,
+  UserCircle02Icon,
+  Logout01Icon,
+} from "@hugeicons/core-free-icons"
+import type { IconSvgElement } from "@hugeicons/react"
+
+import { cn } from "@/lib/utils"
+import { useAuth } from "@/lib/auth-context"
+import { Button } from "@/components/ui/button"
+import { Separator } from "@/components/ui/separator"
+import { Sheet, SheetContent, SheetTitle } from "@/components/ui/sheet"
+import { Badge } from "@/components/ui/badge"
+import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
+
+// ── Nav definition ──────────────────────────────────────────────────────────
+
+interface AdminNavItem {
+  href: string
+  label: string
+  icon: IconSvgElement
+  badge?: string
+  disabled?: boolean
+  matches?: (pathname: string) => boolean
+}
+
+interface AdminNavSection {
+  title: string
+  items: AdminNavItem[]
+}
+
+const NAV: AdminNavSection[] = [
+  {
+    title: "Overview",
+    items: [
+      {
+        href: "/admin",
+        label: "Dashboard",
+        icon: Analytics01Icon,
+        matches: (p) => p === "/admin",
+      },
+    ],
+  },
+  {
+    title: "Management",
+    items: [
+      {
+        href: "/admin/categories",
+        label: "Categories",
+        icon: Tag01Icon,
+        matches: (p) => p.startsWith("/admin/categories"),
+      },
+      {
+        href: "/admin/skills",
+        label: "Skills",
+        icon: FlipBottomIcon,
+        badge: "Soon",
+        disabled: true,
+        matches: (p) => p.startsWith("/admin/skills"),
+      },
+      {
+        href: "/admin/users",
+        label: "Users",
+        icon: UserMultiple02Icon,
+        badge: "Soon",
+        disabled: true,
+        matches: (p) => p.startsWith("/admin/users"),
+      },
+    ],
+  },
+  {
+    title: "Trust & Safety",
+    items: [
+      {
+        href: "/admin/reports",
+        label: "Reports",
+        icon: ShieldUserIcon,
+        badge: "Soon",
+        disabled: true,
+        matches: (p) => p.startsWith("/admin/reports"),
+      },
+      {
+        href: "/admin/audit-log",
+        label: "Audit Log",
+        icon: ArchiveIcon,
+        badge: "Soon",
+        disabled: true,
+        matches: (p) => p.startsWith("/admin/audit-log"),
+      },
+    ],
+  },
+  {
+    title: "Configuration",
+    items: [
+      {
+        href: "/admin/data-library",
+        label: "Data Library",
+        icon: BookOpen01Icon,
+        badge: "Soon",
+        disabled: true,
+        matches: (p) => p.startsWith("/admin/data-library"),
+      },
+    ],
+  },
+]
+
+// ── Sidebar item ────────────────────────────────────────────────────────────
+
+function SidebarItem({
+  item,
+  onNavigate,
+}: {
+  item: AdminNavItem
+  onNavigate?: () => void
+}) {
+  const pathname = usePathname()
+  const isActive = item.matches ? item.matches(pathname) : pathname === item.href
+
+  const inner = (
+    <span
+      className={cn(
+        "group flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors",
+        isActive
+          ? "bg-primary/10 text-primary"
+          : "text-muted-foreground hover:bg-muted hover:text-foreground",
+        item.disabled && "pointer-events-none opacity-50",
+      )}
+    >
+      <HugeiconsIcon
+        icon={item.icon}
+        className={cn(
+          "size-4 shrink-0",
+          isActive ? "text-primary" : "text-muted-foreground group-hover:text-foreground",
+        )}
+        strokeWidth={isActive ? 2 : 1.5}
+      />
+      <span className="flex-1 truncate">{item.label}</span>
+      {item.badge && (
+        <Badge variant="secondary" className="text-[10px] px-1.5 py-0 h-4">
+          {item.badge}
+        </Badge>
+      )}
+    </span>
+  )
+
+  if (item.disabled) return inner
+
+  return (
+    <Link href={item.href} onClick={onNavigate}>
+      {inner}
+    </Link>
+  )
+}
+
+// ── User profile block ───────────────────────────────────────────────────────
+
+function SidebarUserProfile() {
+  const { user, logout } = useAuth()
+
+  if (!user) return null
+
+  const initials = user.name
+    .split(" ")
+    .map((part) => part[0])
+    .join("")
+    .toUpperCase()
+    .slice(0, 2)
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button
+          className={cn(
+            "flex w-full items-center gap-3 rounded-md px-3 py-2 text-sm",
+            "text-muted-foreground transition-colors hover:bg-muted hover:text-foreground",
+            "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+          )}
+        >
+          <Avatar size="sm">
+            {user.avatarUrl && <AvatarImage src={user.avatarUrl} alt={user.name} />}
+            <AvatarFallback>{initials}</AvatarFallback>
+          </Avatar>
+
+          <div className="flex min-w-0 flex-1 flex-col items-start leading-none">
+            <span className="truncate font-medium text-foreground">{user.name}</span>
+            <span className="truncate text-[11px] text-muted-foreground">{user.email}</span>
+          </div>
+
+          <HugeiconsIcon
+            icon={MoreHorizontalCircle01Icon}
+            className="size-4 shrink-0 text-muted-foreground"
+            strokeWidth={1.5}
+          />
+        </button>
+      </DropdownMenuTrigger>
+
+      <DropdownMenuContent
+        side="top"
+        align="start"
+        sideOffset={8}
+        className="w-56"
+      >
+        <DropdownMenuLabel className="font-normal">
+          <div className="flex flex-col gap-0.5">
+            <span className="truncate text-sm font-medium text-foreground">{user.name}</span>
+            <span className="truncate text-xs text-muted-foreground">{user.email}</span>
+          </div>
+        </DropdownMenuLabel>
+
+        <DropdownMenuSeparator />
+
+        <DropdownMenuGroup>
+          <DropdownMenuItem asChild>
+            <Link href="/admin/profile">
+              <HugeiconsIcon icon={UserCircle02Icon} className="size-4" strokeWidth={1.5} />
+              Account
+            </Link>
+          </DropdownMenuItem>
+        </DropdownMenuGroup>
+
+        <DropdownMenuSeparator />
+
+        <DropdownMenuItem
+          variant="destructive"
+          onSelect={() => logout()}
+        >
+          <HugeiconsIcon icon={Logout01Icon} className="size-4" strokeWidth={1.5} />
+          Log out
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}
+
+// ── Sidebar body ────────────────────────────────────────────────────────────
+
+function SidebarContent({ onNavigate }: { onNavigate?: () => void }) {
+  return (
+    <div className="flex h-full flex-col">
+      {/* Logo / branding */}
+      <div className="flex items-center gap-2 px-4 py-5">
+        <div className="flex h-8 w-8 items-center justify-center rounded-md bg-primary">
+          <HugeiconsIcon icon={BriefcaseIcon} className="size-4 text-primary-foreground" strokeWidth={2} />
+        </div>
+        <div className="flex flex-col leading-none">
+          <span className="text-sm font-semibold">Admin Console</span>
+          <span className="text-[11px] text-muted-foreground">Management</span>
+        </div>
+      </div>
+
+      <Separator />
+
+      {/* Navigation sections */}
+      <nav className="flex-1 overflow-y-auto px-3 py-4">
+        <div className="space-y-6">
+          {NAV.map((section) => (
+            <div key={section.title}>
+              <p className="mb-1.5 px-3 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
+                {section.title}
+              </p>
+              <div className="space-y-0.5">
+                {section.items.map((item) => (
+                  <SidebarItem
+                    key={item.href}
+                    item={item}
+                    onNavigate={onNavigate}
+                  />
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      </nav>
+
+      <Separator />
+
+      {/* User profile */}
+      <div className="p-3">
+        <SidebarUserProfile />
+      </div>
+    </div>
+  )
+}
+
+// ── Exported sidebar components ─────────────────────────────────────────────
+
+/** Fixed desktop sidebar */
+export function AdminDesktopSidebar() {
+  return (
+    <aside className="hidden w-60 shrink-0 border-r bg-card lg:flex lg:flex-col">
+      <SidebarContent />
+    </aside>
+  )
+}
+
+/** Mobile slide-in sidebar via Sheet */
+export function AdminMobileSidebar({
+  open,
+  onOpenChange,
+}: {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}) {
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent side="left" className="w-60 p-0" aria-describedby={undefined}>
+        <SheetTitle className="sr-only">Navigation</SheetTitle>
+        <SidebarContent onNavigate={() => onOpenChange(false)} />
+      </SheetContent>
+    </Sheet>
+  )
+}
+
+/** Mobile menu trigger button */
+export function AdminMobileMenuButton({
+  onClick,
+}: {
+  onClick: () => void
+}) {
+  return (
+    <Button
+      variant="ghost"
+      size="icon"
+      className="lg:hidden"
+      onClick={onClick}
+      aria-label="Open navigation menu"
+    >
+      <HugeiconsIcon icon={Menu01Icon} className="size-5" strokeWidth={1.5} />
+    </Button>
+  )
+}

--- a/frontend/components/admin/admin-sidebar.tsx
+++ b/frontend/components/admin/admin-sidebar.tsx
@@ -138,7 +138,9 @@ function SidebarItem({
   onNavigate?: () => void
 }) {
   const pathname = usePathname()
-  const isActive = item.matches ? item.matches(pathname) : pathname === item.href
+  const isActive = item.matches
+    ? item.matches(pathname)
+    : pathname === item.href
 
   const inner = (
     <span
@@ -147,20 +149,22 @@ function SidebarItem({
         isActive
           ? "bg-primary/10 text-primary"
           : "text-muted-foreground hover:bg-muted hover:text-foreground",
-        item.disabled && "pointer-events-none opacity-50",
+        item.disabled && "pointer-events-none opacity-50"
       )}
     >
       <HugeiconsIcon
         icon={item.icon}
         className={cn(
           "size-4 shrink-0",
-          isActive ? "text-primary" : "text-muted-foreground group-hover:text-foreground",
+          isActive
+            ? "text-primary"
+            : "text-muted-foreground group-hover:text-foreground"
         )}
         strokeWidth={isActive ? 2 : 1.5}
       />
       <span className="flex-1 truncate">{item.label}</span>
       {item.badge && (
-        <Badge variant="secondary" className="text-[10px] px-1.5 py-0 h-4">
+        <Badge variant="secondary" className="h-4 px-1.5 py-0 text-[10px]">
           {item.badge}
         </Badge>
       )}
@@ -197,17 +201,23 @@ function SidebarUserProfile() {
           className={cn(
             "flex w-full items-center gap-3 rounded-md px-3 py-2 text-sm",
             "text-muted-foreground transition-colors hover:bg-muted hover:text-foreground",
-            "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+            "focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none"
           )}
         >
           <Avatar size="sm">
-            {user.avatarUrl && <AvatarImage src={user.avatarUrl} alt={user.name} />}
+            {user.avatarUrl && (
+              <AvatarImage src={user.avatarUrl} alt={user.name} />
+            )}
             <AvatarFallback>{initials}</AvatarFallback>
           </Avatar>
 
           <div className="flex min-w-0 flex-1 flex-col items-start leading-none">
-            <span className="truncate font-medium text-foreground">{user.name}</span>
-            <span className="truncate text-[11px] text-muted-foreground">{user.email}</span>
+            <span className="truncate font-medium text-foreground">
+              {user.name}
+            </span>
+            <span className="truncate text-[11px] text-muted-foreground">
+              {user.email}
+            </span>
           </div>
 
           <HugeiconsIcon
@@ -226,8 +236,12 @@ function SidebarUserProfile() {
       >
         <DropdownMenuLabel className="font-normal">
           <div className="flex flex-col gap-0.5">
-            <span className="truncate text-sm font-medium text-foreground">{user.name}</span>
-            <span className="truncate text-xs text-muted-foreground">{user.email}</span>
+            <span className="truncate text-sm font-medium text-foreground">
+              {user.name}
+            </span>
+            <span className="truncate text-xs text-muted-foreground">
+              {user.email}
+            </span>
           </div>
         </DropdownMenuLabel>
 
@@ -236,7 +250,11 @@ function SidebarUserProfile() {
         <DropdownMenuGroup>
           <DropdownMenuItem asChild>
             <Link href="/admin/profile">
-              <HugeiconsIcon icon={UserCircle02Icon} className="size-4" strokeWidth={1.5} />
+              <HugeiconsIcon
+                icon={UserCircle02Icon}
+                className="size-4"
+                strokeWidth={1.5}
+              />
               Account
             </Link>
           </DropdownMenuItem>
@@ -244,11 +262,12 @@ function SidebarUserProfile() {
 
         <DropdownMenuSeparator />
 
-        <DropdownMenuItem
-          variant="destructive"
-          onSelect={() => logout()}
-        >
-          <HugeiconsIcon icon={Logout01Icon} className="size-4" strokeWidth={1.5} />
+        <DropdownMenuItem variant="destructive" onSelect={() => logout()}>
+          <HugeiconsIcon
+            icon={Logout01Icon}
+            className="size-4"
+            strokeWidth={1.5}
+          />
           Log out
         </DropdownMenuItem>
       </DropdownMenuContent>
@@ -264,7 +283,11 @@ function SidebarContent({ onNavigate }: { onNavigate?: () => void }) {
       {/* Logo / branding */}
       <div className="flex items-center gap-2 px-4 py-5">
         <div className="flex h-8 w-8 items-center justify-center rounded-md bg-primary">
-          <HugeiconsIcon icon={BriefcaseIcon} className="size-4 text-primary-foreground" strokeWidth={2} />
+          <HugeiconsIcon
+            icon={BriefcaseIcon}
+            className="size-4 text-primary-foreground"
+            strokeWidth={2}
+          />
         </div>
         <div className="flex flex-col leading-none">
           <span className="text-sm font-semibold">Admin Console</span>
@@ -279,7 +302,7 @@ function SidebarContent({ onNavigate }: { onNavigate?: () => void }) {
         <div className="space-y-6">
           {NAV.map((section) => (
             <div key={section.title}>
-              <p className="mb-1.5 px-3 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
+              <p className="mb-1.5 px-3 text-[11px] font-semibold tracking-wider text-muted-foreground uppercase">
                 {section.title}
               </p>
               <div className="space-y-0.5">
@@ -327,7 +350,11 @@ export function AdminMobileSidebar({
 }) {
   return (
     <Sheet open={open} onOpenChange={onOpenChange}>
-      <SheetContent side="left" className="w-60 p-0" aria-describedby={undefined}>
+      <SheetContent
+        side="left"
+        className="w-60 p-0"
+        aria-describedby={undefined}
+      >
         <SheetTitle className="sr-only">Navigation</SheetTitle>
         <SidebarContent onNavigate={() => onOpenChange(false)} />
       </SheetContent>
@@ -336,11 +363,7 @@ export function AdminMobileSidebar({
 }
 
 /** Mobile menu trigger button */
-export function AdminMobileMenuButton({
-  onClick,
-}: {
-  onClick: () => void
-}) {
+export function AdminMobileMenuButton({ onClick }: { onClick: () => void }) {
   return (
     <Button
       variant="ghost"

--- a/frontend/components/admin/categories-manager.tsx
+++ b/frontend/components/admin/categories-manager.tsx
@@ -21,7 +21,10 @@ import {
   InformationCircleIcon,
 } from "@hugeicons/core-free-icons"
 
-import { useAdminCategories, type AdminCategoryResponse } from "@/lib/api/admin/categories"
+import {
+  useAdminCategories,
+  type AdminCategoryResponse,
+} from "@/lib/api/admin/categories"
 import { ICON_REGISTRY } from "@/lib/icon-registry"
 
 import {
@@ -37,7 +40,11 @@ import { Input } from "@/components/ui/input"
 import { Badge } from "@/components/ui/badge"
 import { Skeleton } from "@/components/ui/skeleton"
 import { Alert, AlertDescription } from "@/components/ui/alert"
-import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip"
 import { CreateCategoryDialog } from "./category-form-dialog"
 import { EditCategoryDialog } from "./category-form-dialog"
 import { DeleteCategoryDialog } from "./delete-category-dialog"
@@ -50,19 +57,27 @@ function IconCell({ iconName }: { iconName: string }) {
     return (
       <Tooltip>
         <TooltipTrigger asChild>
-          <span className="flex items-center gap-1.5 text-muted-foreground text-xs">
-            <HugeiconsIcon icon={InformationCircleIcon} className="size-4" strokeWidth={1.5} />
+          <span className="flex items-center gap-1.5 text-xs text-muted-foreground">
+            <HugeiconsIcon
+              icon={InformationCircleIcon}
+              className="size-4"
+              strokeWidth={1.5}
+            />
             Unknown
           </span>
         </TooltipTrigger>
-        <TooltipContent>Icon &ldquo;{iconName}&rdquo; not in registry</TooltipContent>
+        <TooltipContent>
+          Icon &ldquo;{iconName}&rdquo; not in registry
+        </TooltipContent>
       </Tooltip>
     )
   }
   return (
     <span className="flex items-center gap-2">
       <HugeiconsIcon icon={icon} className="size-5" strokeWidth={1.5} />
-      <span className="hidden text-xs text-muted-foreground xl:inline">{iconName}</span>
+      <span className="hidden text-xs text-muted-foreground xl:inline">
+        {iconName}
+      </span>
     </span>
   )
 }
@@ -79,15 +94,13 @@ function SortButton({
   return (
     <button
       onClick={onClick}
-      className="flex items-center gap-1 hover:text-foreground transition-colors"
+      className="flex items-center gap-1 transition-colors hover:text-foreground"
     >
       {children}
       <HugeiconsIcon
         icon={ArrowUpDownIcon}
         className={
-          sorted
-            ? "size-3.5 text-primary"
-            : "size-3.5 text-muted-foreground/50"
+          sorted ? "size-3.5 text-primary" : "size-3.5 text-muted-foreground/50"
         }
         strokeWidth={1.5}
       />
@@ -103,10 +116,14 @@ export function CategoriesManager() {
   const [sorting, setSorting] = React.useState<SortingState>([
     { id: "sortOrder", desc: false },
   ])
-  const [columnFilters, setColumnFilters] = React.useState<ColumnFiltersState>([])
+  const [columnFilters, setColumnFilters] = React.useState<ColumnFiltersState>(
+    []
+  )
   const [createOpen, setCreateOpen] = React.useState(false)
-  const [editTarget, setEditTarget] = React.useState<AdminCategoryResponse | null>(null)
-  const [deleteTarget, setDeleteTarget] = React.useState<AdminCategoryResponse | null>(null)
+  const [editTarget, setEditTarget] =
+    React.useState<AdminCategoryResponse | null>(null)
+  const [deleteTarget, setDeleteTarget] =
+    React.useState<AdminCategoryResponse | null>(null)
 
   const columns = React.useMemo<ColumnDef<AdminCategoryResponse>[]>(
     () => [
@@ -130,7 +147,7 @@ export function CategoriesManager() {
           <div>
             <span className="font-medium">{row.original.name}</span>
             {row.original.description && (
-              <p className="mt-0.5 text-xs text-muted-foreground line-clamp-1">
+              <p className="mt-0.5 line-clamp-1 text-xs text-muted-foreground">
                 {row.original.description}
               </p>
             )}
@@ -142,7 +159,7 @@ export function CategoriesManager() {
         accessorKey: "code",
         header: "Code",
         cell: ({ row }) => (
-          <code className="rounded bg-muted px-1.5 py-0.5 text-xs font-mono text-muted-foreground">
+          <code className="rounded bg-muted px-1.5 py-0.5 font-mono text-xs text-muted-foreground">
             {row.original.code}
           </code>
         ),
@@ -158,7 +175,7 @@ export function CategoriesManager() {
           </SortButton>
         ),
         cell: ({ row }) => (
-          <span className="tabular-nums text-sm">{row.original.sortOrder}</span>
+          <span className="text-sm tabular-nums">{row.original.sortOrder}</span>
         ),
       },
       {
@@ -166,9 +183,13 @@ export function CategoriesManager() {
         header: "Status",
         cell: ({ row }) =>
           row.original.isActive ? (
-            <Badge variant="success" className="text-xs">Active</Badge>
+            <Badge variant="success" className="text-xs">
+              Active
+            </Badge>
           ) : (
-            <Badge variant="destructive" className="text-xs">Inactive</Badge>
+            <Badge variant="destructive" className="text-xs">
+              Inactive
+            </Badge>
           ),
       },
       {
@@ -186,7 +207,11 @@ export function CategoriesManager() {
                     className="size-8"
                     onClick={() => setEditTarget(cat)}
                   >
-                    <HugeiconsIcon icon={Edit02Icon} className="size-4" strokeWidth={1.5} />
+                    <HugeiconsIcon
+                      icon={Edit02Icon}
+                      className="size-4"
+                      strokeWidth={1.5}
+                    />
                     <span className="sr-only">Edit {cat.name}</span>
                   </Button>
                 </TooltipTrigger>
@@ -201,7 +226,11 @@ export function CategoriesManager() {
                     onClick={() => setDeleteTarget(cat)}
                     disabled={!cat.isActive}
                   >
-                    <HugeiconsIcon icon={Delete02Icon} className="size-4" strokeWidth={1.5} />
+                    <HugeiconsIcon
+                      icon={Delete02Icon}
+                      className="size-4"
+                      strokeWidth={1.5}
+                    />
                     <span className="sr-only">Deactivate {cat.name}</span>
                   </Button>
                 </TooltipTrigger>
@@ -215,7 +244,7 @@ export function CategoriesManager() {
         enableSorting: false,
       },
     ],
-    [],
+    []
   )
 
   // eslint-disable-next-line react-hooks/incompatible-library
@@ -268,10 +297,10 @@ export function CategoriesManager() {
       <div className="rounded-lg border bg-card">
         {/* Toolbar */}
         <div className="flex items-center gap-3 border-b px-4 py-3">
-          <div className="relative flex-1 max-w-sm">
+          <div className="relative max-w-sm flex-1">
             <HugeiconsIcon
               icon={SearchIcon}
-              className="absolute left-2.5 top-1/2 size-4 -translate-y-1/2 text-muted-foreground"
+              className="absolute top-1/2 left-2.5 size-4 -translate-y-1/2 text-muted-foreground"
               strokeWidth={1.5}
             />
             <Input
@@ -301,7 +330,7 @@ export function CategoriesManager() {
                       ? null
                       : flexRender(
                           header.column.columnDef.header,
-                          header.getContext(),
+                          header.getContext()
                         )}
                   </TableHead>
                 ))}
@@ -312,11 +341,21 @@ export function CategoriesManager() {
             {isLoading ? (
               Array.from({ length: 5 }).map((_, i) => (
                 <TableRow key={i}>
-                  <TableCell className="pl-4"><Skeleton className="size-5 rounded" /></TableCell>
-                  <TableCell><Skeleton className="h-4 w-32" /></TableCell>
-                  <TableCell><Skeleton className="h-4 w-20" /></TableCell>
-                  <TableCell><Skeleton className="h-4 w-8" /></TableCell>
-                  <TableCell><Skeleton className="h-5 w-14 rounded-full" /></TableCell>
+                  <TableCell className="pl-4">
+                    <Skeleton className="size-5 rounded" />
+                  </TableCell>
+                  <TableCell>
+                    <Skeleton className="h-4 w-32" />
+                  </TableCell>
+                  <TableCell>
+                    <Skeleton className="h-4 w-20" />
+                  </TableCell>
+                  <TableCell>
+                    <Skeleton className="h-4 w-8" />
+                  </TableCell>
+                  <TableCell>
+                    <Skeleton className="h-5 w-14 rounded-full" />
+                  </TableCell>
                   <TableCell className="pr-4" />
                 </TableRow>
               ))
@@ -339,7 +378,10 @@ export function CategoriesManager() {
                 >
                   {row.getVisibleCells().map((cell) => (
                     <TableCell key={cell.id} className="first:pl-4 last:pr-4">
-                      {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                      {flexRender(
+                        cell.column.columnDef.cell,
+                        cell.getContext()
+                      )}
                     </TableCell>
                   ))}
                 </TableRow>
@@ -353,11 +395,15 @@ export function CategoriesManager() {
       <CreateCategoryDialog open={createOpen} onOpenChange={setCreateOpen} />
       <EditCategoryDialog
         category={editTarget}
-        onOpenChange={(o) => { if (!o) setEditTarget(null) }}
+        onOpenChange={(o) => {
+          if (!o) setEditTarget(null)
+        }}
       />
       <DeleteCategoryDialog
         category={deleteTarget}
-        onOpenChange={(o) => { if (!o) setDeleteTarget(null) }}
+        onOpenChange={(o) => {
+          if (!o) setDeleteTarget(null)
+        }}
       />
     </div>
   )

--- a/frontend/components/admin/categories-manager.tsx
+++ b/frontend/components/admin/categories-manager.tsx
@@ -1,0 +1,364 @@
+"use client"
+
+import * as React from "react"
+import {
+  useReactTable,
+  getCoreRowModel,
+  getSortedRowModel,
+  getFilteredRowModel,
+  flexRender,
+  type ColumnDef,
+  type SortingState,
+  type ColumnFiltersState,
+} from "@tanstack/react-table"
+import { HugeiconsIcon } from "@hugeicons/react"
+import {
+  Add01Icon,
+  Edit02Icon,
+  Delete02Icon,
+  ArrowUpDownIcon,
+  SearchIcon,
+  InformationCircleIcon,
+} from "@hugeicons/core-free-icons"
+
+import { useAdminCategories, type AdminCategoryResponse } from "@/lib/api/admin/categories"
+import { ICON_REGISTRY } from "@/lib/icon-registry"
+
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Badge } from "@/components/ui/badge"
+import { Skeleton } from "@/components/ui/skeleton"
+import { Alert, AlertDescription } from "@/components/ui/alert"
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
+import { CreateCategoryDialog } from "./category-form-dialog"
+import { EditCategoryDialog } from "./category-form-dialog"
+import { DeleteCategoryDialog } from "./delete-category-dialog"
+
+// ── Column helpers ────────────────────────────────────────────────────────────
+
+function IconCell({ iconName }: { iconName: string }) {
+  const icon = ICON_REGISTRY[iconName as keyof typeof ICON_REGISTRY]
+  if (!icon) {
+    return (
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span className="flex items-center gap-1.5 text-muted-foreground text-xs">
+            <HugeiconsIcon icon={InformationCircleIcon} className="size-4" strokeWidth={1.5} />
+            Unknown
+          </span>
+        </TooltipTrigger>
+        <TooltipContent>Icon &ldquo;{iconName}&rdquo; not in registry</TooltipContent>
+      </Tooltip>
+    )
+  }
+  return (
+    <span className="flex items-center gap-2">
+      <HugeiconsIcon icon={icon} className="size-5" strokeWidth={1.5} />
+      <span className="hidden text-xs text-muted-foreground xl:inline">{iconName}</span>
+    </span>
+  )
+}
+
+function SortButton({
+  children,
+  sorted,
+  onClick,
+}: {
+  children: React.ReactNode
+  sorted: false | "asc" | "desc"
+  onClick: () => void
+}) {
+  return (
+    <button
+      onClick={onClick}
+      className="flex items-center gap-1 hover:text-foreground transition-colors"
+    >
+      {children}
+      <HugeiconsIcon
+        icon={ArrowUpDownIcon}
+        className={
+          sorted
+            ? "size-3.5 text-primary"
+            : "size-3.5 text-muted-foreground/50"
+        }
+        strokeWidth={1.5}
+      />
+    </button>
+  )
+}
+
+// ── Main component ────────────────────────────────────────────────────────────
+
+export function CategoriesManager() {
+  const { data, isLoading, isError, error, refetch } = useAdminCategories()
+
+  const [sorting, setSorting] = React.useState<SortingState>([
+    { id: "sortOrder", desc: false },
+  ])
+  const [columnFilters, setColumnFilters] = React.useState<ColumnFiltersState>([])
+  const [createOpen, setCreateOpen] = React.useState(false)
+  const [editTarget, setEditTarget] = React.useState<AdminCategoryResponse | null>(null)
+  const [deleteTarget, setDeleteTarget] = React.useState<AdminCategoryResponse | null>(null)
+
+  const columns = React.useMemo<ColumnDef<AdminCategoryResponse>[]>(
+    () => [
+      {
+        accessorKey: "icon",
+        header: "Icon",
+        cell: ({ row }) => <IconCell iconName={row.original.icon} />,
+        enableSorting: false,
+      },
+      {
+        accessorKey: "name",
+        header: ({ column }) => (
+          <SortButton
+            sorted={column.getIsSorted()}
+            onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
+          >
+            Name
+          </SortButton>
+        ),
+        cell: ({ row }) => (
+          <div>
+            <span className="font-medium">{row.original.name}</span>
+            {row.original.description && (
+              <p className="mt-0.5 text-xs text-muted-foreground line-clamp-1">
+                {row.original.description}
+              </p>
+            )}
+          </div>
+        ),
+        filterFn: "includesString",
+      },
+      {
+        accessorKey: "code",
+        header: "Code",
+        cell: ({ row }) => (
+          <code className="rounded bg-muted px-1.5 py-0.5 text-xs font-mono text-muted-foreground">
+            {row.original.code}
+          </code>
+        ),
+      },
+      {
+        accessorKey: "sortOrder",
+        header: ({ column }) => (
+          <SortButton
+            sorted={column.getIsSorted()}
+            onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
+          >
+            Order
+          </SortButton>
+        ),
+        cell: ({ row }) => (
+          <span className="tabular-nums text-sm">{row.original.sortOrder}</span>
+        ),
+      },
+      {
+        accessorKey: "isActive",
+        header: "Status",
+        cell: ({ row }) =>
+          row.original.isActive ? (
+            <Badge variant="success" className="text-xs">Active</Badge>
+          ) : (
+            <Badge variant="destructive" className="text-xs">Inactive</Badge>
+          ),
+      },
+      {
+        id: "actions",
+        header: "",
+        cell: ({ row }) => {
+          const cat = row.original
+          return (
+            <div className="flex items-center justify-end gap-1">
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="size-8"
+                    onClick={() => setEditTarget(cat)}
+                  >
+                    <HugeiconsIcon icon={Edit02Icon} className="size-4" strokeWidth={1.5} />
+                    <span className="sr-only">Edit {cat.name}</span>
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>Edit</TooltipContent>
+              </Tooltip>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="size-8 text-destructive hover:text-destructive"
+                    onClick={() => setDeleteTarget(cat)}
+                    disabled={!cat.isActive}
+                  >
+                    <HugeiconsIcon icon={Delete02Icon} className="size-4" strokeWidth={1.5} />
+                    <span className="sr-only">Deactivate {cat.name}</span>
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>
+                  {cat.isActive ? "Deactivate" : "Already inactive"}
+                </TooltipContent>
+              </Tooltip>
+            </div>
+          )
+        },
+        enableSorting: false,
+      },
+    ],
+    [],
+  )
+
+  // eslint-disable-next-line react-hooks/incompatible-library
+  const table = useReactTable({
+    data: data ?? [],
+    columns,
+    state: { sorting, columnFilters },
+    onSortingChange: setSorting,
+    onColumnFiltersChange: setColumnFilters,
+    getCoreRowModel: getCoreRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+    getFilteredRowModel: getFilteredRowModel(),
+  })
+
+  // ── Render ──────────────────────────────────────────────────────────────────
+
+  return (
+    <div className="space-y-6">
+      {/* Header row */}
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold tracking-tight">Categories</h1>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Manage task categories available to seekers
+          </p>
+        </div>
+        <Button onClick={() => setCreateOpen(true)} className="shrink-0">
+          <HugeiconsIcon icon={Add01Icon} className="size-4" strokeWidth={2} />
+          New category
+        </Button>
+      </div>
+
+      {/* Error state */}
+      {isError && (
+        <Alert variant="destructive">
+          <AlertDescription>
+            Failed to load categories —{" "}
+            {error instanceof Error ? error.message : "unknown error"}.{" "}
+            <button
+              className="underline hover:no-underline"
+              onClick={() => void refetch()}
+            >
+              Retry
+            </button>
+          </AlertDescription>
+        </Alert>
+      )}
+
+      {/* Table card */}
+      <div className="rounded-lg border bg-card">
+        {/* Toolbar */}
+        <div className="flex items-center gap-3 border-b px-4 py-3">
+          <div className="relative flex-1 max-w-sm">
+            <HugeiconsIcon
+              icon={SearchIcon}
+              className="absolute left-2.5 top-1/2 size-4 -translate-y-1/2 text-muted-foreground"
+              strokeWidth={1.5}
+            />
+            <Input
+              placeholder="Filter by name…"
+              value={
+                (table.getColumn("name")?.getFilterValue() as string) ?? ""
+              }
+              onChange={(e) =>
+                table.getColumn("name")?.setFilterValue(e.target.value)
+              }
+              className="pl-8"
+            />
+          </div>
+          <span className="shrink-0 text-sm text-muted-foreground">
+            {table.getFilteredRowModel().rows.length} of {data?.length ?? 0}
+          </span>
+        </div>
+
+        {/* Table */}
+        <Table>
+          <TableHeader>
+            {table.getHeaderGroups().map((hg) => (
+              <TableRow key={hg.id}>
+                {hg.headers.map((header) => (
+                  <TableHead key={header.id} className="first:pl-4 last:pr-4">
+                    {header.isPlaceholder
+                      ? null
+                      : flexRender(
+                          header.column.columnDef.header,
+                          header.getContext(),
+                        )}
+                  </TableHead>
+                ))}
+              </TableRow>
+            ))}
+          </TableHeader>
+          <TableBody>
+            {isLoading ? (
+              Array.from({ length: 5 }).map((_, i) => (
+                <TableRow key={i}>
+                  <TableCell className="pl-4"><Skeleton className="size-5 rounded" /></TableCell>
+                  <TableCell><Skeleton className="h-4 w-32" /></TableCell>
+                  <TableCell><Skeleton className="h-4 w-20" /></TableCell>
+                  <TableCell><Skeleton className="h-4 w-8" /></TableCell>
+                  <TableCell><Skeleton className="h-5 w-14 rounded-full" /></TableCell>
+                  <TableCell className="pr-4" />
+                </TableRow>
+              ))
+            ) : table.getRowModel().rows.length === 0 ? (
+              <TableRow>
+                <TableCell
+                  colSpan={columns.length}
+                  className="h-32 text-center text-muted-foreground"
+                >
+                  {(data?.length ?? 0) === 0
+                    ? "No categories yet — create one to get started."
+                    : "No categories match your filter."}
+                </TableCell>
+              </TableRow>
+            ) : (
+              table.getRowModel().rows.map((row) => (
+                <TableRow
+                  key={row.id}
+                  data-state={row.getIsSelected() ? "selected" : undefined}
+                >
+                  {row.getVisibleCells().map((cell) => (
+                    <TableCell key={cell.id} className="first:pl-4 last:pr-4">
+                      {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                    </TableCell>
+                  ))}
+                </TableRow>
+              ))
+            )}
+          </TableBody>
+        </Table>
+      </div>
+
+      {/* Dialogs */}
+      <CreateCategoryDialog open={createOpen} onOpenChange={setCreateOpen} />
+      <EditCategoryDialog
+        category={editTarget}
+        onOpenChange={(o) => { if (!o) setEditTarget(null) }}
+      />
+      <DeleteCategoryDialog
+        category={deleteTarget}
+        onOpenChange={(o) => { if (!o) setDeleteTarget(null) }}
+      />
+    </div>
+  )
+}

--- a/frontend/components/admin/category-form-dialog.tsx
+++ b/frontend/components/admin/category-form-dialog.tsx
@@ -1,0 +1,375 @@
+"use client"
+
+import * as React from "react"
+import { useForm } from "react-hook-form"
+import { zodResolver } from "@hookform/resolvers/zod"
+import { toast } from "sonner"
+import { HugeiconsIcon } from "@hugeicons/react"
+import { Loading03Icon } from "@hugeicons/core-free-icons"
+
+import {
+  createCategorySchema,
+  updateCategorySchema,
+  type CreateCategoryFormValues,
+  type UpdateCategoryFormValues,
+} from "@/lib/api/admin/category-schemas"
+import {
+  useCreateCategory,
+  useUpdateCategory,
+  type AdminCategoryResponse,
+} from "@/lib/api/admin/categories"
+import { ApiError } from "@/lib/api/client"
+import { ICON_REGISTRY } from "@/lib/icon-registry"
+
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from "@/components/ui/dialog"
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form"
+import { Input } from "@/components/ui/input"
+import { Textarea } from "@/components/ui/textarea"
+import { Button } from "@/components/ui/button"
+import { Badge } from "@/components/ui/badge"
+import { IconPicker } from "./icon-picker"
+
+// ── Create dialog ─────────────────────────────────────────────────────────────
+
+interface CreateCategoryDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+export function CreateCategoryDialog({
+  open,
+  onOpenChange,
+}: CreateCategoryDialogProps) {
+  const { mutateAsync, isPending } = useCreateCategory()
+
+  const form = useForm<CreateCategoryFormValues>({
+    resolver: zodResolver(createCategorySchema),
+    defaultValues: {
+      code: "",
+      name: "",
+      icon: Object.keys(ICON_REGISTRY)[0] ?? "",
+      description: "",
+      sortOrder: 0,
+    },
+  })
+
+  async function onSubmit(values: CreateCategoryFormValues) {
+    try {
+      await mutateAsync({
+        ...values,
+        description: values.description || undefined,
+      })
+      toast.success(`Category "${values.name}" created`)
+      form.reset()
+      onOpenChange(false)
+    } catch (err) {
+      if (err instanceof ApiError && err.status === 409) {
+        form.setError("code", {
+          message: `Code "${values.code}" is already in use`,
+        })
+      } else {
+        toast.error(
+          err instanceof Error ? err.message : "Failed to create category",
+        )
+      }
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={(o) => { if (!isPending) onOpenChange(o) }}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Create category</DialogTitle>
+          <DialogDescription>
+            Add a new task category to the marketplace. The code is permanent
+            and cannot be changed after creation.
+          </DialogDescription>
+        </DialogHeader>
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+            <FormField
+              control={form.control}
+              name="code"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Code</FormLabel>
+                  <FormControl>
+                    <div>
+                      <Input
+                        id={field.name}
+                        placeholder="e.g. garden_work"
+                        {...field}
+                      />
+                    </div>
+                  </FormControl>
+                  <FormDescription>
+                    Lowercase letters, numbers, hyphens, underscores. Immutable
+                    after creation.
+                  </FormDescription>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="name"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Name</FormLabel>
+                  <FormControl>
+                    <div>
+                      <Input id={field.name} placeholder="e.g. Garden Work" {...field} />
+                    </div>
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="icon"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Icon</FormLabel>
+                  <FormControl>
+                    <div>
+                      <IconPicker value={field.value} onChange={field.onChange} />
+                    </div>
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="description"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Description <span className="text-muted-foreground font-normal">(optional)</span></FormLabel>
+                  <FormControl>
+                    <div>
+                      <Textarea
+                        id={field.name}
+                        placeholder="Brief description for seekers…"
+                        className="resize-none"
+                        rows={2}
+                        {...field}
+                      />
+                    </div>
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="sortOrder"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Sort order</FormLabel>
+                  <FormControl>
+                    <div>
+                      <Input id={field.name} type="number" min={0} {...field} />
+                    </div>
+                  </FormControl>
+                  <FormDescription>Lower numbers appear first.</FormDescription>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <DialogFooter>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => onOpenChange(false)}
+                disabled={isPending}
+              >
+                Cancel
+              </Button>
+              <Button type="submit" disabled={isPending}>
+                {isPending && (
+                  <HugeiconsIcon
+                    icon={Loading03Icon}
+                    className="size-4 animate-spin"
+                    strokeWidth={2}
+                  />
+                )}
+                Create category
+              </Button>
+            </DialogFooter>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+// ── Edit dialog ───────────────────────────────────────────────────────────────
+
+interface EditCategoryDialogProps {
+  category: AdminCategoryResponse | null
+  onOpenChange: (open: boolean) => void
+}
+
+export function EditCategoryDialog({
+  category,
+  onOpenChange,
+}: EditCategoryDialogProps) {
+  const { mutateAsync, isPending } = useUpdateCategory()
+
+  const form = useForm<UpdateCategoryFormValues>({
+    resolver: zodResolver(updateCategorySchema),
+    values: category
+      ? {
+          name: category.name,
+          icon: category.icon,
+          description: category.description ?? "",
+          sortOrder: category.sortOrder,
+        }
+      : undefined,
+  })
+
+  async function onSubmit(values: UpdateCategoryFormValues) {
+    if (!category) return
+    try {
+      await mutateAsync({
+        id: category.id,
+        data: {
+          ...values,
+          description: values.description || undefined,
+        },
+      })
+      toast.success(`Category "${values.name}" updated`)
+      onOpenChange(false)
+    } catch (err) {
+      toast.error(
+        err instanceof Error ? err.message : "Failed to update category",
+      )
+    }
+  }
+
+  return (
+    <Dialog
+      open={Boolean(category)}
+      onOpenChange={(o) => { if (!isPending) onOpenChange(o) }}
+    >
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Edit category</DialogTitle>
+          <DialogDescription>
+            Update the category details. The code{" "}
+            <Badge variant="secondary" className="font-mono text-xs">
+              {category?.code}
+            </Badge>{" "}
+            is permanent and cannot be changed.
+          </DialogDescription>
+        </DialogHeader>
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+            <FormField
+              control={form.control}
+              name="name"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Name</FormLabel>
+                  <FormControl>
+                    <div>
+                      <Input id={field.name} {...field} />
+                    </div>
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="icon"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Icon</FormLabel>
+                  <FormControl>
+                    <div>
+                      <IconPicker value={field.value} onChange={field.onChange} />
+                    </div>
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="description"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Description <span className="text-muted-foreground font-normal">(optional)</span></FormLabel>
+                  <FormControl>
+                    <div>
+                      <Textarea
+                        id={field.name}
+                        className="resize-none"
+                        rows={2}
+                        {...field}
+                      />
+                    </div>
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="sortOrder"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Sort order</FormLabel>
+                  <FormControl>
+                    <div>
+                      <Input id={field.name} type="number" min={0} {...field} />
+                    </div>
+                  </FormControl>
+                  <FormDescription>Lower numbers appear first.</FormDescription>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <DialogFooter>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => onOpenChange(false)}
+                disabled={isPending}
+              >
+                Cancel
+              </Button>
+              <Button type="submit" disabled={isPending}>
+                {isPending && (
+                  <HugeiconsIcon
+                    icon={Loading03Icon}
+                    className="size-4 animate-spin"
+                    strokeWidth={2}
+                  />
+                )}
+                Save changes
+              </Button>
+            </DialogFooter>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend/components/admin/category-form-dialog.tsx
+++ b/frontend/components/admin/category-form-dialog.tsx
@@ -84,14 +84,19 @@ export function CreateCategoryDialog({
         })
       } else {
         toast.error(
-          err instanceof Error ? err.message : "Failed to create category",
+          err instanceof Error ? err.message : "Failed to create category"
         )
       }
     }
   }
 
   return (
-    <Dialog open={open} onOpenChange={(o) => { if (!isPending) onOpenChange(o) }}>
+    <Dialog
+      open={open}
+      onOpenChange={(o) => {
+        if (!isPending) onOpenChange(o)
+      }}
+    >
       <DialogContent className="max-w-lg">
         <DialogHeader>
           <DialogTitle>Create category</DialogTitle>
@@ -133,7 +138,11 @@ export function CreateCategoryDialog({
                   <FormLabel>Name</FormLabel>
                   <FormControl>
                     <div>
-                      <Input id={field.name} placeholder="e.g. Garden Work" {...field} />
+                      <Input
+                        id={field.name}
+                        placeholder="e.g. Garden Work"
+                        {...field}
+                      />
                     </div>
                   </FormControl>
                   <FormMessage />
@@ -148,7 +157,10 @@ export function CreateCategoryDialog({
                   <FormLabel>Icon</FormLabel>
                   <FormControl>
                     <div>
-                      <IconPicker value={field.value} onChange={field.onChange} />
+                      <IconPicker
+                        value={field.value}
+                        onChange={field.onChange}
+                      />
                     </div>
                   </FormControl>
                   <FormMessage />
@@ -160,7 +172,12 @@ export function CreateCategoryDialog({
               name="description"
               render={({ field }) => (
                 <FormItem>
-                  <FormLabel>Description <span className="text-muted-foreground font-normal">(optional)</span></FormLabel>
+                  <FormLabel>
+                    Description{" "}
+                    <span className="font-normal text-muted-foreground">
+                      (optional)
+                    </span>
+                  </FormLabel>
                   <FormControl>
                     <div>
                       <Textarea
@@ -258,7 +275,7 @@ export function EditCategoryDialog({
       onOpenChange(false)
     } catch (err) {
       toast.error(
-        err instanceof Error ? err.message : "Failed to update category",
+        err instanceof Error ? err.message : "Failed to update category"
       )
     }
   }
@@ -266,7 +283,9 @@ export function EditCategoryDialog({
   return (
     <Dialog
       open={Boolean(category)}
-      onOpenChange={(o) => { if (!isPending) onOpenChange(o) }}
+      onOpenChange={(o) => {
+        if (!isPending) onOpenChange(o)
+      }}
     >
       <DialogContent className="max-w-lg">
         <DialogHeader>
@@ -304,7 +323,10 @@ export function EditCategoryDialog({
                   <FormLabel>Icon</FormLabel>
                   <FormControl>
                     <div>
-                      <IconPicker value={field.value} onChange={field.onChange} />
+                      <IconPicker
+                        value={field.value}
+                        onChange={field.onChange}
+                      />
                     </div>
                   </FormControl>
                   <FormMessage />
@@ -316,7 +338,12 @@ export function EditCategoryDialog({
               name="description"
               render={({ field }) => (
                 <FormItem>
-                  <FormLabel>Description <span className="text-muted-foreground font-normal">(optional)</span></FormLabel>
+                  <FormLabel>
+                    Description{" "}
+                    <span className="font-normal text-muted-foreground">
+                      (optional)
+                    </span>
+                  </FormLabel>
                   <FormControl>
                     <div>
                       <Textarea

--- a/frontend/components/admin/delete-category-dialog.tsx
+++ b/frontend/components/admin/delete-category-dialog.tsx
@@ -4,7 +4,10 @@ import { toast } from "sonner"
 import { HugeiconsIcon } from "@hugeicons/react"
 import { Loading03Icon } from "@hugeicons/core-free-icons"
 
-import { useDeleteCategory, type AdminCategoryResponse } from "@/lib/api/admin/categories"
+import {
+  useDeleteCategory,
+  type AdminCategoryResponse,
+} from "@/lib/api/admin/categories"
 
 import {
   AlertDialog,
@@ -36,19 +39,24 @@ export function DeleteCategoryDialog({
       onOpenChange(false)
     } catch (err) {
       toast.error(
-        err instanceof Error ? err.message : "Failed to deactivate category",
+        err instanceof Error ? err.message : "Failed to deactivate category"
       )
     }
   }
 
   return (
-    <AlertDialog open={Boolean(category)} onOpenChange={(o) => { if (!isPending) onOpenChange(o) }}>
+    <AlertDialog
+      open={Boolean(category)}
+      onOpenChange={(o) => {
+        if (!isPending) onOpenChange(o)
+      }}
+    >
       <AlertDialogContent>
         <AlertDialogHeader>
           <AlertDialogTitle>Deactivate category?</AlertDialogTitle>
           <AlertDialogDescription>
             This will soft-delete <strong>{category?.name}</strong> (code:{" "}
-            <code className="rounded bg-muted px-1 py-0.5 text-xs font-mono">
+            <code className="rounded bg-muted px-1 py-0.5 font-mono text-xs">
               {category?.code}
             </code>
             ). Existing tasks that reference it will be unaffected, but the

--- a/frontend/components/admin/delete-category-dialog.tsx
+++ b/frontend/components/admin/delete-category-dialog.tsx
@@ -1,0 +1,80 @@
+"use client"
+
+import { toast } from "sonner"
+import { HugeiconsIcon } from "@hugeicons/react"
+import { Loading03Icon } from "@hugeicons/core-free-icons"
+
+import { useDeleteCategory, type AdminCategoryResponse } from "@/lib/api/admin/categories"
+
+import {
+  AlertDialog,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog"
+import { Button } from "@/components/ui/button"
+
+interface DeleteCategoryDialogProps {
+  category: AdminCategoryResponse | null
+  onOpenChange: (open: boolean) => void
+}
+
+export function DeleteCategoryDialog({
+  category,
+  onOpenChange,
+}: DeleteCategoryDialogProps) {
+  const { mutateAsync, isPending } = useDeleteCategory()
+
+  async function handleConfirm() {
+    if (!category) return
+    try {
+      await mutateAsync(category.id)
+      toast.success(`Category "${category.name}" deactivated`)
+      onOpenChange(false)
+    } catch (err) {
+      toast.error(
+        err instanceof Error ? err.message : "Failed to deactivate category",
+      )
+    }
+  }
+
+  return (
+    <AlertDialog open={Boolean(category)} onOpenChange={(o) => { if (!isPending) onOpenChange(o) }}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Deactivate category?</AlertDialogTitle>
+          <AlertDialogDescription>
+            This will soft-delete <strong>{category?.name}</strong> (code:{" "}
+            <code className="rounded bg-muted px-1 py-0.5 text-xs font-mono">
+              {category?.code}
+            </code>
+            ). Existing tasks that reference it will be unaffected, but the
+            category will no longer appear in the task creation flow. You can
+            reactivate it later by editing its status directly in the database
+            until a reactivation UI is added.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={isPending}>Cancel</AlertDialogCancel>
+          <Button
+            variant="destructive"
+            onClick={handleConfirm}
+            disabled={isPending}
+          >
+            {isPending && (
+              <HugeiconsIcon
+                icon={Loading03Icon}
+                className="size-4 animate-spin"
+                strokeWidth={2}
+              />
+            )}
+            Deactivate
+          </Button>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}

--- a/frontend/components/admin/icon-picker.tsx
+++ b/frontend/components/admin/icon-picker.tsx
@@ -1,0 +1,96 @@
+"use client"
+
+import * as React from "react"
+import { HugeiconsIcon } from "@hugeicons/react"
+import { ICON_REGISTRY } from "@/lib/icon-registry"
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog"
+import { Input } from "@/components/ui/input"
+
+interface IconPickerProps {
+  value: string
+  onChange: (iconName: string) => void
+  disabled?: boolean
+}
+
+export function IconPicker({ value, onChange, disabled }: IconPickerProps) {
+  const [open, setOpen] = React.useState(false)
+  const [search, setSearch] = React.useState("")
+
+  const allIcons = Object.entries(ICON_REGISTRY)
+  const filtered = allIcons.filter(([name]) =>
+    name.toLowerCase().includes(search.toLowerCase()),
+  )
+
+  const selectedIcon = value ? ICON_REGISTRY[value as keyof typeof ICON_REGISTRY] : undefined
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button
+          type="button"
+          variant="outline"
+          disabled={disabled}
+          className="w-full justify-start gap-2 font-normal"
+        >
+          {selectedIcon ? (
+            <>
+              <HugeiconsIcon icon={selectedIcon} className="size-4 shrink-0" strokeWidth={1.5} />
+              <span className="truncate text-sm">{value}</span>
+            </>
+          ) : (
+            <span className="text-muted-foreground">Select an icon…</span>
+          )}
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>Choose an icon</DialogTitle>
+          <DialogDescription className="sr-only">
+            Select an icon to represent this category.
+          </DialogDescription>
+        </DialogHeader>
+        <Input
+          placeholder="Search icons…"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          autoFocus
+        />
+        <div className="grid grid-cols-4 gap-2 max-h-64 overflow-y-auto pr-1">
+          {filtered.map(([name, icon]) => (
+            <button
+              key={name}
+              type="button"
+              onClick={() => {
+                onChange(name)
+                setOpen(false)
+              }}
+              className={cn(
+                "flex flex-col items-center gap-1.5 rounded-md border p-2.5 text-center transition-colors hover:bg-muted",
+                value === name && "border-primary bg-primary/10 text-primary",
+              )}
+            >
+              <HugeiconsIcon icon={icon} className="size-5" strokeWidth={1.5} />
+              <span className="text-[9px] leading-tight text-muted-foreground truncate w-full">
+                {name.replace("Icon", "")}
+              </span>
+            </button>
+          ))}
+          {filtered.length === 0 && (
+            <p className="col-span-4 py-6 text-center text-sm text-muted-foreground">
+              No icons match &ldquo;{search}&rdquo;
+            </p>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend/components/admin/icon-picker.tsx
+++ b/frontend/components/admin/icon-picker.tsx
@@ -27,10 +27,12 @@ export function IconPicker({ value, onChange, disabled }: IconPickerProps) {
 
   const allIcons = Object.entries(ICON_REGISTRY)
   const filtered = allIcons.filter(([name]) =>
-    name.toLowerCase().includes(search.toLowerCase()),
+    name.toLowerCase().includes(search.toLowerCase())
   )
 
-  const selectedIcon = value ? ICON_REGISTRY[value as keyof typeof ICON_REGISTRY] : undefined
+  const selectedIcon = value
+    ? ICON_REGISTRY[value as keyof typeof ICON_REGISTRY]
+    : undefined
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>
@@ -43,7 +45,11 @@ export function IconPicker({ value, onChange, disabled }: IconPickerProps) {
         >
           {selectedIcon ? (
             <>
-              <HugeiconsIcon icon={selectedIcon} className="size-4 shrink-0" strokeWidth={1.5} />
+              <HugeiconsIcon
+                icon={selectedIcon}
+                className="size-4 shrink-0"
+                strokeWidth={1.5}
+              />
               <span className="truncate text-sm">{value}</span>
             </>
           ) : (
@@ -64,7 +70,7 @@ export function IconPicker({ value, onChange, disabled }: IconPickerProps) {
           onChange={(e) => setSearch(e.target.value)}
           autoFocus
         />
-        <div className="grid grid-cols-4 gap-2 max-h-64 overflow-y-auto pr-1">
+        <div className="grid max-h-64 grid-cols-4 gap-2 overflow-y-auto pr-1">
           {filtered.map(([name, icon]) => (
             <button
               key={name}
@@ -75,11 +81,11 @@ export function IconPicker({ value, onChange, disabled }: IconPickerProps) {
               }}
               className={cn(
                 "flex flex-col items-center gap-1.5 rounded-md border p-2.5 text-center transition-colors hover:bg-muted",
-                value === name && "border-primary bg-primary/10 text-primary",
+                value === name && "border-primary bg-primary/10 text-primary"
               )}
             >
               <HugeiconsIcon icon={icon} className="size-5" strokeWidth={1.5} />
-              <span className="text-[9px] leading-tight text-muted-foreground truncate w-full">
+              <span className="w-full truncate text-[9px] leading-tight text-muted-foreground">
                 {name.replace("Icon", "")}
               </span>
             </button>

--- a/frontend/components/providers/query-provider.tsx
+++ b/frontend/components/providers/query-provider.tsx
@@ -1,0 +1,58 @@
+"use client"
+
+import * as React from "react"
+import {
+  QueryClient,
+  QueryClientProvider,
+} from "@tanstack/react-query"
+import { ReactQueryDevtools } from "@tanstack/react-query-devtools"
+
+function makeQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        // Don't refetch on window focus in development
+        staleTime: 60 * 1000,
+        retry: (failureCount: number, error: unknown) => {
+          // Don't retry on 4xx errors
+          const status =
+            typeof error === "object" &&
+            error !== null &&
+            "status" in error &&
+            typeof (error as { status?: unknown }).status === "number"
+              ? (error as { status: number }).status
+              : undefined
+          if (status !== undefined && status < 500) return false
+          return failureCount < 2
+        },
+      },
+    },
+  })
+}
+
+let browserQueryClient: QueryClient | undefined
+
+function getQueryClient() {
+  if (typeof window === "undefined") {
+    // Server: always make a new query client
+    return makeQueryClient()
+  }
+  // Browser: reuse the same client across renders
+  if (!browserQueryClient) {
+    browserQueryClient = makeQueryClient()
+  }
+  return browserQueryClient
+}
+
+export function QueryProvider({ children }: { children: React.ReactNode }) {
+  const queryClient = getQueryClient()
+
+  return (
+    <QueryClientProvider client={queryClient}>
+      {children}
+      {process.env.NODE_ENV === "development" && (
+        <ReactQueryDevtools initialIsOpen={false} />
+      )}
+    </QueryClientProvider>
+  )
+}

--- a/frontend/components/providers/query-provider.tsx
+++ b/frontend/components/providers/query-provider.tsx
@@ -1,10 +1,7 @@
 "use client"
 
 import * as React from "react"
-import {
-  QueryClient,
-  QueryClientProvider,
-} from "@tanstack/react-query"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools"
 
 function makeQueryClient() {

--- a/frontend/components/ui/alert-dialog.tsx
+++ b/frontend/components/ui/alert-dialog.tsx
@@ -1,0 +1,151 @@
+"use client"
+
+import * as React from "react"
+import { AlertDialog as AlertDialogPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+import { buttonVariants } from "@/components/ui/button"
+
+function AlertDialog({
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Root>) {
+  return <AlertDialogPrimitive.Root data-slot="alert-dialog" {...props} />
+}
+
+function AlertDialogTrigger({
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Trigger>) {
+  return (
+    <AlertDialogPrimitive.Trigger data-slot="alert-dialog-trigger" {...props} />
+  )
+}
+
+function AlertDialogPortal({
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Portal>) {
+  return (
+    <AlertDialogPrimitive.Portal data-slot="alert-dialog-portal" {...props} />
+  )
+}
+
+function AlertDialogOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Overlay>) {
+  return (
+    <AlertDialogPrimitive.Overlay
+      data-slot="alert-dialog-overlay"
+      className={cn(
+        "fixed inset-0 z-50 bg-black/50 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Content>) {
+  return (
+    <AlertDialogPortal>
+      <AlertDialogOverlay />
+      <AlertDialogPrimitive.Content
+        data-slot="alert-dialog-content"
+        className={cn(
+          "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+          className
+        )}
+        {...props}
+      />
+    </AlertDialogPortal>
+  )
+}
+
+function AlertDialogHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-header"
+      className={cn("flex flex-col gap-2 text-center sm:text-left", className)}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-footer"
+      className={cn(
+        "flex flex-col-reverse gap-2 sm:flex-row sm:justify-end",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Title>) {
+  return (
+    <AlertDialogPrimitive.Title
+      data-slot="alert-dialog-title"
+      className={cn("text-lg font-semibold", className)}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Description>) {
+  return (
+    <AlertDialogPrimitive.Description
+      data-slot="alert-dialog-description"
+      className={cn("text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogAction({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Action>) {
+  return (
+    <AlertDialogPrimitive.Action
+      className={cn(buttonVariants(), className)}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogCancel({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Cancel>) {
+  return (
+    <AlertDialogPrimitive.Cancel
+      className={cn(buttonVariants({ variant: "outline" }), className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  AlertDialog,
+  AlertDialogPortal,
+  AlertDialogOverlay,
+  AlertDialogTrigger,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogFooter,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogAction,
+  AlertDialogCancel,
+}

--- a/frontend/components/ui/alert-dialog.tsx
+++ b/frontend/components/ui/alert-dialog.tsx
@@ -36,7 +36,7 @@ function AlertDialogOverlay({
     <AlertDialogPrimitive.Overlay
       data-slot="alert-dialog-overlay"
       className={cn(
-        "fixed inset-0 z-50 bg-black/50 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+        "fixed inset-0 z-50 bg-black/50 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0",
         className
       )}
       {...props}
@@ -54,7 +54,7 @@ function AlertDialogContent({
       <AlertDialogPrimitive.Content
         data-slot="alert-dialog-content"
         className={cn(
-          "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+          "fixed top-[50%] left-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
           className
         )}
         {...props}
@@ -63,7 +63,10 @@ function AlertDialogContent({
   )
 }
 
-function AlertDialogHeader({ className, ...props }: React.ComponentProps<"div">) {
+function AlertDialogHeader({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="alert-dialog-header"
@@ -73,7 +76,10 @@ function AlertDialogHeader({ className, ...props }: React.ComponentProps<"div">)
   )
 }
 
-function AlertDialogFooter({ className, ...props }: React.ComponentProps<"div">) {
+function AlertDialogFooter({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="alert-dialog-footer"

--- a/frontend/components/ui/alert.tsx
+++ b/frontend/components/ui/alert.tsx
@@ -1,0 +1,56 @@
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+import { cn } from "@/lib/utils"
+
+const alertVariants = cva(
+  "relative w-full rounded-lg border px-4 py-3 text-sm grid has-[>svg]:grid-cols-[calc(var(--spacing)*4)_1fr] grid-cols-[0_1fr] has-[>svg]:gap-x-3 gap-y-0.5 items-start [&>svg]:size-4 [&>svg]:translate-y-0.5 [&>svg]:text-current",
+  {
+    variants: {
+      variant: {
+        default: "bg-card text-card-foreground",
+        destructive:
+          "text-destructive bg-card [&>svg]:text-current *:data-[slot=alert-description]:text-destructive/80",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+function Alert({
+  className,
+  variant,
+  ...props
+}: React.ComponentProps<"div"> & VariantProps<typeof alertVariants>) {
+  return (
+    <div
+      data-slot="alert"
+      role="alert"
+      className={cn(alertVariants({ variant }), className)}
+      {...props}
+    />
+  )
+}
+
+function AlertTitle({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-title"
+      className={cn("col-start-2 font-medium leading-none tracking-tight", className)}
+      {...props}
+    />
+  )
+}
+
+function AlertDescription({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-description"
+      className={cn("col-start-2 text-sm [&_p]:leading-relaxed", className)}
+      {...props}
+    />
+  )
+}
+
+export { Alert, AlertTitle, AlertDescription }

--- a/frontend/components/ui/alert.tsx
+++ b/frontend/components/ui/alert.tsx
@@ -3,13 +3,13 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const alertVariants = cva(
-  "relative w-full rounded-lg border px-4 py-3 text-sm grid has-[>svg]:grid-cols-[calc(var(--spacing)*4)_1fr] grid-cols-[0_1fr] has-[>svg]:gap-x-3 gap-y-0.5 items-start [&>svg]:size-4 [&>svg]:translate-y-0.5 [&>svg]:text-current",
+  "relative grid w-full grid-cols-[0_1fr] items-start gap-y-0.5 rounded-lg border px-4 py-3 text-sm has-[>svg]:grid-cols-[calc(var(--spacing)*4)_1fr] has-[>svg]:gap-x-3 [&>svg]:size-4 [&>svg]:translate-y-0.5 [&>svg]:text-current",
   {
     variants: {
       variant: {
         default: "bg-card text-card-foreground",
         destructive:
-          "text-destructive bg-card [&>svg]:text-current *:data-[slot=alert-description]:text-destructive/80",
+          "bg-card text-destructive *:data-[slot=alert-description]:text-destructive/80 [&>svg]:text-current",
       },
     },
     defaultVariants: {
@@ -37,13 +37,19 @@ function AlertTitle({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="alert-title"
-      className={cn("col-start-2 font-medium leading-none tracking-tight", className)}
+      className={cn(
+        "col-start-2 leading-none font-medium tracking-tight",
+        className
+      )}
       {...props}
     />
   )
 }
 
-function AlertDescription({ className, ...props }: React.ComponentProps<"div">) {
+function AlertDescription({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="alert-description"

--- a/frontend/components/ui/dialog.tsx
+++ b/frontend/components/ui/dialog.tsx
@@ -1,0 +1,130 @@
+"use client"
+
+import * as React from "react"
+import { Dialog as DialogPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function Dialog({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Root>) {
+  return <DialogPrimitive.Root data-slot="dialog" {...props} />
+}
+
+function DialogTrigger({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Trigger>) {
+  return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />
+}
+
+function DialogPortal({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Portal>) {
+  return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />
+}
+
+function DialogClose({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Close>) {
+  return <DialogPrimitive.Close data-slot="dialog-close" {...props} />
+}
+
+function DialogOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Overlay>) {
+  return (
+    <DialogPrimitive.Overlay
+      data-slot="dialog-overlay"
+      className={cn(
+        "fixed inset-0 z-50 bg-black/50 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DialogContent({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Content>) {
+  return (
+    <DialogPortal>
+      <DialogOverlay />
+      <DialogPrimitive.Content
+        data-slot="dialog-content"
+        className={cn(
+          "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+          className
+        )}
+        {...props}
+      >
+        {children}
+      </DialogPrimitive.Content>
+    </DialogPortal>
+  )
+}
+
+function DialogHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="dialog-header"
+      className={cn("flex flex-col gap-1.5 text-center sm:text-left", className)}
+      {...props}
+    />
+  )
+}
+
+function DialogFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="dialog-footer"
+      className={cn(
+        "flex flex-col-reverse gap-2 sm:flex-row sm:justify-end",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DialogTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Title>) {
+  return (
+    <DialogPrimitive.Title
+      data-slot="dialog-title"
+      className={cn("text-lg font-semibold leading-none tracking-tight", className)}
+      {...props}
+    />
+  )
+}
+
+function DialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Description>) {
+  return (
+    <DialogPrimitive.Description
+      data-slot="dialog-description"
+      className={cn("text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogOverlay,
+  DialogPortal,
+  DialogTitle,
+  DialogTrigger,
+}

--- a/frontend/components/ui/dialog.tsx
+++ b/frontend/components/ui/dialog.tsx
@@ -37,7 +37,7 @@ function DialogOverlay({
     <DialogPrimitive.Overlay
       data-slot="dialog-overlay"
       className={cn(
-        "fixed inset-0 z-50 bg-black/50 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+        "fixed inset-0 z-50 bg-black/50 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0",
         className
       )}
       {...props}
@@ -56,7 +56,7 @@ function DialogContent({
       <DialogPrimitive.Content
         data-slot="dialog-content"
         className={cn(
-          "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+          "fixed top-[50%] left-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
           className
         )}
         {...props}
@@ -71,7 +71,10 @@ function DialogHeader({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="dialog-header"
-      className={cn("flex flex-col gap-1.5 text-center sm:text-left", className)}
+      className={cn(
+        "flex flex-col gap-1.5 text-center sm:text-left",
+        className
+      )}
       {...props}
     />
   )
@@ -97,7 +100,10 @@ function DialogTitle({
   return (
     <DialogPrimitive.Title
       data-slot="dialog-title"
-      className={cn("text-lg font-semibold leading-none tracking-tight", className)}
+      className={cn(
+        "text-lg leading-none font-semibold tracking-tight",
+        className
+      )}
       {...props}
     />
   )

--- a/frontend/components/ui/form.tsx
+++ b/frontend/components/ui/form.tsx
@@ -99,8 +99,7 @@ function FormLabel({
 }
 
 function FormControl({ ...props }: React.ComponentProps<"div">) {
-  const { error, formItemId, formDescriptionId, formMessageId } =
-    useFormField()
+  const { error, formItemId, formDescriptionId, formMessageId } = useFormField()
   const Slot = React.forwardRef<HTMLDivElement, React.ComponentProps<"div">>(
     ({ ...p }, ref) => <div ref={ref} {...p} />
   )
@@ -133,7 +132,11 @@ function FormDescription({ className, ...props }: React.ComponentProps<"p">) {
   )
 }
 
-function FormMessage({ className, children, ...props }: React.ComponentProps<"p">) {
+function FormMessage({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<"p">) {
   const { error, formMessageId } = useFormField()
   const body = error ? String(error?.message ?? "") : children
 

--- a/frontend/components/ui/form.tsx
+++ b/frontend/components/ui/form.tsx
@@ -10,6 +10,7 @@ import {
   type FieldPath,
   type FieldValues,
 } from "react-hook-form"
+import { Slot } from "radix-ui"
 
 import { cn } from "@/lib/utils"
 import { Label } from "@/components/ui/label"
@@ -106,13 +107,9 @@ function FormLabel({
 
 function FormControl({ ...props }: React.ComponentProps<"div">) {
   const { error, formItemId, formDescriptionId, formMessageId } = useFormField()
-  const Slot = React.forwardRef<HTMLDivElement, React.ComponentProps<"div">>(
-    ({ ...p }, ref) => <div ref={ref} {...p} />
-  )
-  Slot.displayName = "FormControlSlot"
 
   return (
-    <div
+    <Slot.Root
       data-slot="form-control"
       id={formItemId}
       aria-describedby={

--- a/frontend/components/ui/form.tsx
+++ b/frontend/components/ui/form.tsx
@@ -1,0 +1,165 @@
+"use client"
+
+import * as React from "react"
+import {
+  Controller,
+  FormProvider,
+  useFormContext,
+  useFormState,
+  type ControllerProps,
+  type FieldPath,
+  type FieldValues,
+} from "react-hook-form"
+
+import { cn } from "@/lib/utils"
+import { Label } from "@/components/ui/label"
+
+const Form = FormProvider
+
+type FormFieldContextValue<
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
+> = {
+  name: TName
+}
+
+const FormFieldContext = React.createContext<FormFieldContextValue>(
+  {} as FormFieldContextValue
+)
+
+function FormField<
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
+>({ ...props }: ControllerProps<TFieldValues, TName>) {
+  return (
+    <FormFieldContext.Provider value={{ name: props.name }}>
+      <Controller {...props} />
+    </FormFieldContext.Provider>
+  )
+}
+
+function useFormField() {
+  const fieldContext = React.useContext(FormFieldContext)
+  const itemContext = React.useContext(FormItemContext)
+  const { getFieldState } = useFormContext()
+  const formState = useFormState({ name: fieldContext.name })
+  const fieldState = getFieldState(fieldContext.name, formState)
+
+  if (!fieldContext) {
+    throw new Error("useFormField should be used within <FormField>")
+  }
+
+  const { id } = itemContext
+
+  return {
+    id,
+    name: fieldContext.name,
+    formItemId: `${id}-form-item`,
+    formDescriptionId: `${id}-form-item-description`,
+    formMessageId: `${id}-form-item-message`,
+    ...fieldState,
+  }
+}
+
+type FormItemContextValue = {
+  id: string
+}
+
+const FormItemContext = React.createContext<FormItemContextValue>(
+  {} as FormItemContextValue
+)
+
+function FormItem({ className, ...props }: React.ComponentProps<"div">) {
+  const id = React.useId()
+  return (
+    <FormItemContext.Provider value={{ id }}>
+      <div
+        data-slot="form-item"
+        className={cn("grid gap-2", className)}
+        {...props}
+      />
+    </FormItemContext.Provider>
+  )
+}
+
+function FormLabel({
+  className,
+  ...props
+}: React.ComponentProps<typeof Label>) {
+  const { error, formItemId } = useFormField()
+  return (
+    <Label
+      data-slot="form-label"
+      data-error={!!error}
+      className={cn("data-[error=true]:text-destructive", className)}
+      htmlFor={formItemId}
+      {...props}
+    />
+  )
+}
+
+function FormControl({ ...props }: React.ComponentProps<"div">) {
+  const { error, formItemId, formDescriptionId, formMessageId } =
+    useFormField()
+  const Slot = React.forwardRef<HTMLDivElement, React.ComponentProps<"div">>(
+    ({ ...p }, ref) => <div ref={ref} {...p} />
+  )
+  Slot.displayName = "FormControlSlot"
+
+  return (
+    <div
+      data-slot="form-control"
+      id={formItemId}
+      aria-describedby={
+        !error
+          ? `${formDescriptionId}`
+          : `${formDescriptionId} ${formMessageId}`
+      }
+      aria-invalid={!!error}
+      {...props}
+    />
+  )
+}
+
+function FormDescription({ className, ...props }: React.ComponentProps<"p">) {
+  const { formDescriptionId } = useFormField()
+  return (
+    <p
+      data-slot="form-description"
+      id={formDescriptionId}
+      className={cn("text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+function FormMessage({ className, children, ...props }: React.ComponentProps<"p">) {
+  const { error, formMessageId } = useFormField()
+  const body = error ? String(error?.message ?? "") : children
+
+  if (!body) {
+    return null
+  }
+
+  return (
+    <p
+      data-slot="form-message"
+      id={formMessageId}
+      className={cn("text-sm font-medium text-destructive", className)}
+      {...props}
+    >
+      {body}
+    </p>
+  )
+}
+
+export {
+  useFormField,
+  Form,
+  FormItem,
+  FormLabel,
+  FormControl,
+  FormDescription,
+  FormMessage,
+  FormField,
+}

--- a/frontend/components/ui/form.tsx
+++ b/frontend/components/ui/form.tsx
@@ -40,8 +40,10 @@ function useFormField() {
   const fieldContext = React.useContext(FormFieldContext)
   const itemContext = React.useContext(FormItemContext)
   const { getFieldState } = useFormContext()
-  // Always call hooks unconditionally (Rules of Hooks); use optional chaining with
-  // a fallback so the call is safe even when the context is null.
+  // React's Rules of Hooks require hooks to be called unconditionally, so
+  // useFormState must run before the null-guard throws below. The fallback ""
+  // is a safe placeholder: if fieldContext is null the throw that follows
+  // discards this result before it is ever used.
   const formState = useFormState({
     name: (fieldContext?.name ?? "") as FieldPath<FieldValues>,
   })

--- a/frontend/components/ui/form.tsx
+++ b/frontend/components/ui/form.tsx
@@ -23,9 +23,7 @@ type FormFieldContextValue<
   name: TName
 }
 
-const FormFieldContext = React.createContext<FormFieldContextValue>(
-  {} as FormFieldContextValue
-)
+const FormFieldContext = React.createContext<FormFieldContextValue | null>(null)
 
 function FormField<
   TFieldValues extends FieldValues = FieldValues,
@@ -42,13 +40,21 @@ function useFormField() {
   const fieldContext = React.useContext(FormFieldContext)
   const itemContext = React.useContext(FormItemContext)
   const { getFieldState } = useFormContext()
-  const formState = useFormState({ name: fieldContext.name })
-  const fieldState = getFieldState(fieldContext.name, formState)
+  // Always call hooks unconditionally (Rules of Hooks); use optional chaining with
+  // a fallback so the call is safe even when the context is null.
+  const formState = useFormState({
+    name: (fieldContext?.name ?? "") as FieldPath<FieldValues>,
+  })
 
   if (!fieldContext) {
     throw new Error("useFormField should be used within <FormField>")
   }
 
+  if (!itemContext) {
+    throw new Error("useFormField should be used within <FormItem>")
+  }
+
+  const fieldState = getFieldState(fieldContext.name, formState)
   const { id } = itemContext
 
   return {
@@ -65,9 +71,7 @@ type FormItemContextValue = {
   id: string
 }
 
-const FormItemContext = React.createContext<FormItemContextValue>(
-  {} as FormItemContextValue
-)
+const FormItemContext = React.createContext<FormItemContextValue | null>(null)
 
 function FormItem({ className, ...props }: React.ComponentProps<"div">) {
   const id = React.useId()

--- a/frontend/components/ui/sheet.tsx
+++ b/frontend/components/ui/sheet.tsx
@@ -1,0 +1,142 @@
+"use client"
+
+import * as React from "react"
+import { Dialog as SheetPrimitive } from "radix-ui"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+function Sheet({ ...props }: React.ComponentProps<typeof SheetPrimitive.Root>) {
+  return <SheetPrimitive.Root data-slot="sheet" {...props} />
+}
+
+function SheetTrigger({
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Trigger>) {
+  return <SheetPrimitive.Trigger data-slot="sheet-trigger" {...props} />
+}
+
+function SheetClose({
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Close>) {
+  return <SheetPrimitive.Close data-slot="sheet-close" {...props} />
+}
+
+function SheetPortal({
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Portal>) {
+  return <SheetPrimitive.Portal data-slot="sheet-portal" {...props} />
+}
+
+function SheetOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Overlay>) {
+  return (
+    <SheetPrimitive.Overlay
+      data-slot="sheet-overlay"
+      className={cn(
+        "fixed inset-0 z-50 bg-black/50 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+const sheetVariants = cva(
+  "fixed z-50 gap-4 bg-background p-6 shadow-lg transition ease-in-out data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:duration-300 data-[state=open]:duration-500",
+  {
+    variants: {
+      side: {
+        top: "inset-x-0 top-0 border-b data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top",
+        bottom:
+          "inset-x-0 bottom-0 border-t data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom",
+        left: "inset-y-0 left-0 h-full w-3/4 border-r data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left sm:max-w-sm",
+        right:
+          "inset-y-0 right-0 h-full w-3/4 border-l data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right sm:max-w-sm",
+      },
+    },
+    defaultVariants: {
+      side: "right",
+    },
+  }
+)
+
+function SheetContent({
+  side = "right",
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Content> &
+  VariantProps<typeof sheetVariants>) {
+  return (
+    <SheetPortal>
+      <SheetOverlay />
+      <SheetPrimitive.Content
+        data-slot="sheet-content"
+        className={cn(sheetVariants({ side }), className)}
+        {...props}
+      >
+        {children}
+      </SheetPrimitive.Content>
+    </SheetPortal>
+  )
+}
+
+function SheetHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sheet-header"
+      className={cn("flex flex-col gap-1.5 text-center sm:text-left", className)}
+      {...props}
+    />
+  )
+}
+
+function SheetFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sheet-footer"
+      className={cn("flex flex-col-reverse gap-2 sm:flex-row sm:justify-end", className)}
+      {...props}
+    />
+  )
+}
+
+function SheetTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Title>) {
+  return (
+    <SheetPrimitive.Title
+      data-slot="sheet-title"
+      className={cn("text-lg font-semibold text-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+function SheetDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Description>) {
+  return (
+    <SheetPrimitive.Description
+      data-slot="sheet-description"
+      className={cn("text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Sheet,
+  SheetTrigger,
+  SheetClose,
+  SheetContent,
+  SheetHeader,
+  SheetFooter,
+  SheetTitle,
+  SheetDescription,
+}

--- a/frontend/components/ui/sheet.tsx
+++ b/frontend/components/ui/sheet.tsx
@@ -36,7 +36,7 @@ function SheetOverlay({
     <SheetPrimitive.Overlay
       data-slot="sheet-overlay"
       className={cn(
-        "fixed inset-0 z-50 bg-black/50 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+        "fixed inset-0 z-50 bg-black/50 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0",
         className
       )}
       {...props}
@@ -45,7 +45,7 @@ function SheetOverlay({
 }
 
 const sheetVariants = cva(
-  "fixed z-50 gap-4 bg-background p-6 shadow-lg transition ease-in-out data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:duration-300 data-[state=open]:duration-500",
+  "fixed z-50 gap-4 bg-background p-6 shadow-lg transition ease-in-out data-[state=closed]:animate-out data-[state=closed]:duration-300 data-[state=open]:animate-in data-[state=open]:duration-500",
   {
     variants: {
       side: {
@@ -88,7 +88,10 @@ function SheetHeader({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="sheet-header"
-      className={cn("flex flex-col gap-1.5 text-center sm:text-left", className)}
+      className={cn(
+        "flex flex-col gap-1.5 text-center sm:text-left",
+        className
+      )}
       {...props}
     />
   )
@@ -98,7 +101,10 @@ function SheetFooter({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="sheet-footer"
-      className={cn("flex flex-col-reverse gap-2 sm:flex-row sm:justify-end", className)}
+      className={cn(
+        "flex flex-col-reverse gap-2 sm:flex-row sm:justify-end",
+        className
+      )}
       {...props}
     />
   )

--- a/frontend/components/ui/skeleton.tsx
+++ b/frontend/components/ui/skeleton.tsx
@@ -1,0 +1,13 @@
+import { cn } from "@/lib/utils"
+
+function Skeleton({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="skeleton"
+      className={cn("animate-pulse rounded-md bg-muted", className)}
+      {...props}
+    />
+  )
+}
+
+export { Skeleton }

--- a/frontend/components/ui/skeleton.tsx
+++ b/frontend/components/ui/skeleton.tsx
@@ -1,6 +1,7 @@
+import type { ComponentProps } from "react"
 import { cn } from "@/lib/utils"
 
-function Skeleton({ className, ...props }: React.ComponentProps<"div">) {
+function Skeleton({ className, ...props }: ComponentProps<"div">) {
   return (
     <div
       data-slot="skeleton"

--- a/frontend/components/ui/sonner.tsx
+++ b/frontend/components/ui/sonner.tsx
@@ -1,0 +1,31 @@
+"use client"
+
+import { useTheme } from "next-themes"
+import { Toaster as Sonner, type ToasterProps } from "sonner"
+
+function Toaster({ ...props }: ToasterProps) {
+  const { theme = "system" } = useTheme()
+
+  return (
+    <Sonner
+      theme={theme as ToasterProps["theme"]}
+      className="toaster group"
+      style={
+        {
+          "--normal-bg": "var(--popover)",
+          "--normal-border": "var(--border)",
+          "--normal-text": "var(--popover-foreground)",
+          "--success-bg": "var(--popover)",
+          "--success-border": "var(--border)",
+          "--success-text": "var(--popover-foreground)",
+          "--error-bg": "var(--popover)",
+          "--error-border": "var(--border)",
+          "--error-text": "var(--popover-foreground)",
+        } as React.CSSProperties
+      }
+      {...props}
+    />
+  )
+}
+
+export { Toaster }

--- a/frontend/components/ui/sonner.tsx
+++ b/frontend/components/ui/sonner.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import type { CSSProperties } from "react"
 import { useTheme } from "next-themes"
 import { Toaster as Sonner, type ToasterProps } from "sonner"
 
@@ -21,7 +22,7 @@ function Toaster({ ...props }: ToasterProps) {
           "--error-bg": "var(--popover)",
           "--error-border": "var(--border)",
           "--error-text": "var(--popover-foreground)",
-        } as React.CSSProperties
+        } as CSSProperties
       }
       {...props}
     />

--- a/frontend/components/ui/table.tsx
+++ b/frontend/components/ui/table.tsx
@@ -1,0 +1,107 @@
+import * as React from "react"
+import { cn } from "@/lib/utils"
+
+function Table({ className, ...props }: React.ComponentProps<"table">) {
+  return (
+    <div data-slot="table-container" className="relative w-full overflow-x-auto">
+      <table
+        data-slot="table"
+        className={cn("w-full caption-bottom text-sm", className)}
+        {...props}
+      />
+    </div>
+  )
+}
+
+function TableHeader({ className, ...props }: React.ComponentProps<"thead">) {
+  return (
+    <thead
+      data-slot="table-header"
+      className={cn("[&_tr]:border-b", className)}
+      {...props}
+    />
+  )
+}
+
+function TableBody({ className, ...props }: React.ComponentProps<"tbody">) {
+  return (
+    <tbody
+      data-slot="table-body"
+      className={cn("[&_tr:last-child]:border-0", className)}
+      {...props}
+    />
+  )
+}
+
+function TableFooter({ className, ...props }: React.ComponentProps<"tfoot">) {
+  return (
+    <tfoot
+      data-slot="table-footer"
+      className={cn(
+        "border-t bg-muted/50 font-medium [&>tr]:last:border-b-0",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TableRow({ className, ...props }: React.ComponentProps<"tr">) {
+  return (
+    <tr
+      data-slot="table-row"
+      className={cn(
+        "border-b transition-colors hover:bg-muted/50 data-[state=selected]:bg-muted",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TableHead({ className, ...props }: React.ComponentProps<"th">) {
+  return (
+    <th
+      data-slot="table-head"
+      className={cn(
+        "h-10 px-2 text-left align-middle font-medium text-muted-foreground whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TableCell({ className, ...props }: React.ComponentProps<"td">) {
+  return (
+    <td
+      data-slot="table-cell"
+      className={cn(
+        "p-2 align-middle [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TableCaption({ className, ...props }: React.ComponentProps<"caption">) {
+  return (
+    <caption
+      data-slot="table-caption"
+      className={cn("mt-4 text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Table,
+  TableHeader,
+  TableBody,
+  TableFooter,
+  TableHead,
+  TableRow,
+  TableCell,
+  TableCaption,
+}

--- a/frontend/components/ui/table.tsx
+++ b/frontend/components/ui/table.tsx
@@ -3,7 +3,10 @@ import { cn } from "@/lib/utils"
 
 function Table({ className, ...props }: React.ComponentProps<"table">) {
   return (
-    <div data-slot="table-container" className="relative w-full overflow-x-auto">
+    <div
+      data-slot="table-container"
+      className="relative w-full overflow-x-auto"
+    >
       <table
         data-slot="table"
         className={cn("w-full caption-bottom text-sm", className)}
@@ -64,7 +67,7 @@ function TableHead({ className, ...props }: React.ComponentProps<"th">) {
     <th
       data-slot="table-head"
       className={cn(
-        "h-10 px-2 text-left align-middle font-medium text-muted-foreground whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+        "h-10 px-2 text-left align-middle font-medium whitespace-nowrap text-muted-foreground [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
         className
       )}
       {...props}
@@ -85,7 +88,10 @@ function TableCell({ className, ...props }: React.ComponentProps<"td">) {
   )
 }
 
-function TableCaption({ className, ...props }: React.ComponentProps<"caption">) {
+function TableCaption({
+  className,
+  ...props
+}: React.ComponentProps<"caption">) {
   return (
     <caption
       data-slot="table-caption"

--- a/frontend/components/ui/tooltip.tsx
+++ b/frontend/components/ui/tooltip.tsx
@@ -45,7 +45,7 @@ function TooltipContent({
         data-slot="tooltip-content"
         sideOffset={sideOffset}
         className={cn(
-          "z-50 w-fit origin-(--radix-tooltip-content-transform-origin) overflow-hidden rounded-md bg-popover px-3 py-1.5 text-xs text-popover-foreground shadow-md animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+          "z-50 w-fit origin-(--radix-tooltip-content-transform-origin) animate-in overflow-hidden rounded-md bg-popover px-3 py-1.5 text-xs text-popover-foreground shadow-md fade-in-0 zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95",
           className
         )}
         {...props}

--- a/frontend/components/ui/tooltip.tsx
+++ b/frontend/components/ui/tooltip.tsx
@@ -1,0 +1,57 @@
+"use client"
+
+import * as React from "react"
+import { Tooltip as TooltipPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function TooltipProvider({
+  delayDuration = 0,
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Provider>) {
+  return (
+    <TooltipPrimitive.Provider
+      data-slot="tooltip-provider"
+      delayDuration={delayDuration}
+      {...props}
+    />
+  )
+}
+
+function Tooltip({
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Root>) {
+  return (
+    <TooltipProvider>
+      <TooltipPrimitive.Root data-slot="tooltip" {...props} />
+    </TooltipProvider>
+  )
+}
+
+function TooltipTrigger({
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Trigger>) {
+  return <TooltipPrimitive.Trigger data-slot="tooltip-trigger" {...props} />
+}
+
+function TooltipContent({
+  className,
+  sideOffset = 4,
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Content>) {
+  return (
+    <TooltipPrimitive.Portal>
+      <TooltipPrimitive.Content
+        data-slot="tooltip-content"
+        sideOffset={sideOffset}
+        className={cn(
+          "z-50 w-fit origin-(--radix-tooltip-content-transform-origin) overflow-hidden rounded-md bg-popover px-3 py-1.5 text-xs text-popover-foreground shadow-md animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+          className
+        )}
+        {...props}
+      />
+    </TooltipPrimitive.Portal>
+  )
+}
+
+export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider }

--- a/frontend/lib/api/admin/analytics.ts
+++ b/frontend/lib/api/admin/analytics.ts
@@ -1,0 +1,33 @@
+/**
+ * Admin analytics / KPI API types and hooks.
+ *
+ * Endpoint: GET /api/admin/analytics/kpi
+ * Backed by the `analytics.kpi_current_v` database view (issue #72 / #73).
+ *
+ * TODO: wire up once the /api/admin/analytics/kpi endpoint is shipped.
+ */
+
+import { useQuery } from "@tanstack/react-query"
+import { apiClient } from "@/lib/api/client"
+
+export interface KpiCurrent {
+  registeredUsers: number
+  activeUsers7d: number
+  tasksPosted7d: number
+  completedTasks7d: number
+  completionRate7d: number
+}
+
+export const adminAnalyticsKeys = {
+  all: ["admin", "analytics"] as const,
+  kpi: () => [...adminAnalyticsKeys.all, "kpi"] as const,
+}
+
+export function useAdminKpi() {
+  return useQuery({
+    queryKey: adminAnalyticsKeys.kpi(),
+    queryFn: () => apiClient.get<KpiCurrent>("/admin/analytics/kpi"),
+    // Refresh every 5 minutes
+    staleTime: 5 * 60 * 1000,
+  })
+}

--- a/frontend/lib/api/admin/categories.ts
+++ b/frontend/lib/api/admin/categories.ts
@@ -1,0 +1,124 @@
+/**
+ * Admin categories API — types and TanStack Query hooks.
+ *
+ * Backend controller: AdminCategoriesController
+ * Base route: GET|POST /api/admin/categories
+ *             GET|PUT|DELETE /api/admin/categories/{id}
+ */
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import { apiClient } from "@/lib/api/client"
+
+// ── Types (mirror AdminCategoriesController DTOs) ────────────────────────────
+
+/** Shape returned by every admin category endpoint */
+export interface AdminCategoryResponse {
+  id: string
+  /** Immutable slug, set at creation — max 64 chars */
+  code: string
+  /** Display name — max 120 chars */
+  name: string
+  /** HugeIcons identifier from AllowedCategoryIcons — max 64 chars */
+  icon: string
+  /** Optional description — max 500 chars */
+  description?: string
+  /** Controls render order */
+  sortOrder: number
+  /** False when soft-deleted */
+  isActive: boolean
+}
+
+/** POST /api/admin/categories */
+export interface CreateCategoryRequest {
+  code: string
+  name: string
+  icon: string
+  description?: string
+  sortOrder: number
+}
+
+/** PUT /api/admin/categories/{id} — code is immutable, excluded */
+export interface UpdateCategoryRequest {
+  name: string
+  icon: string
+  description?: string
+  sortOrder: number
+}
+
+// ── Query keys ───────────────────────────────────────────────────────────────
+
+export const categoryKeys = {
+  all: ["admin", "categories"] as const,
+  lists: () => [...categoryKeys.all, "list"] as const,
+  detail: (id: string) => [...categoryKeys.all, "detail", id] as const,
+}
+
+// ── Hooks ────────────────────────────────────────────────────────────────────
+
+/**
+ * Fetches the full list of admin categories (active + inactive).
+ * Endpoint: GET /api/admin/categories
+ */
+export function useAdminCategories() {
+  return useQuery({
+    queryKey: categoryKeys.lists(),
+    queryFn: () =>
+      apiClient.get<AdminCategoryResponse[]>("/admin/categories"),
+  })
+}
+
+/**
+ * Creates a new category.
+ * Endpoint: POST /api/admin/categories
+ * Returns 201 with the created category. 409 if code already exists.
+ */
+export function useCreateCategory() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (data: CreateCategoryRequest) =>
+      apiClient.post<AdminCategoryResponse>("/admin/categories", data),
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: categoryKeys.lists() })
+    },
+  })
+}
+
+/**
+ * Updates an existing category. `code` is never sent — it is immutable.
+ * Endpoint: PUT /api/admin/categories/{id}
+ */
+export function useUpdateCategory() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: ({
+      id,
+      data,
+    }: {
+      id: string
+      data: UpdateCategoryRequest
+    }) =>
+      apiClient.put<AdminCategoryResponse>(
+        `/admin/categories/${id}`,
+        data,
+      ),
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: categoryKeys.lists() })
+    },
+  })
+}
+
+/**
+ * Soft-deletes (deactivates) a category.
+ * Endpoint: DELETE /api/admin/categories/{id}
+ * Backend sets IsActive = false; returns 204 No Content.
+ */
+export function useDeleteCategory() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (id: string) =>
+      apiClient.delete(`/admin/categories/${id}`),
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: categoryKeys.lists() })
+    },
+  })
+}

--- a/frontend/lib/api/admin/categories.ts
+++ b/frontend/lib/api/admin/categories.ts
@@ -62,8 +62,7 @@ export const categoryKeys = {
 export function useAdminCategories() {
   return useQuery({
     queryKey: categoryKeys.lists(),
-    queryFn: () =>
-      apiClient.get<AdminCategoryResponse[]>("/admin/categories"),
+    queryFn: () => apiClient.get<AdminCategoryResponse[]>("/admin/categories"),
   })
 }
 
@@ -90,17 +89,8 @@ export function useCreateCategory() {
 export function useUpdateCategory() {
   const qc = useQueryClient()
   return useMutation({
-    mutationFn: ({
-      id,
-      data,
-    }: {
-      id: string
-      data: UpdateCategoryRequest
-    }) =>
-      apiClient.put<AdminCategoryResponse>(
-        `/admin/categories/${id}`,
-        data,
-      ),
+    mutationFn: ({ id, data }: { id: string; data: UpdateCategoryRequest }) =>
+      apiClient.put<AdminCategoryResponse>(`/admin/categories/${id}`, data),
     onSuccess: () => {
       void qc.invalidateQueries({ queryKey: categoryKeys.lists() })
     },
@@ -115,8 +105,7 @@ export function useUpdateCategory() {
 export function useDeleteCategory() {
   const qc = useQueryClient()
   return useMutation({
-    mutationFn: (id: string) =>
-      apiClient.delete(`/admin/categories/${id}`),
+    mutationFn: (id: string) => apiClient.delete(`/admin/categories/${id}`),
     onSuccess: () => {
       void qc.invalidateQueries({ queryKey: categoryKeys.lists() })
     },

--- a/frontend/lib/api/admin/category-schemas.ts
+++ b/frontend/lib/api/admin/category-schemas.ts
@@ -1,0 +1,34 @@
+import { z } from "zod"
+import { ICON_REGISTRY } from "@/lib/icon-registry"
+
+const ALLOWED_ICONS = Object.keys(ICON_REGISTRY) as [string, ...string[]]
+
+export const createCategorySchema = z.object({
+  code: z
+    .string()
+    .min(1, "Code is required")
+    .max(64, "Code must be 64 characters or fewer")
+    .regex(
+      /^[a-z0-9_-]+$/,
+      "Code may only contain lowercase letters, numbers, hyphens, and underscores",
+    ),
+  name: z
+    .string()
+    .min(1, "Name is required")
+    .max(120, "Name must be 120 characters or fewer"),
+  icon: z.enum(ALLOWED_ICONS, { message: "Icon must be from the approved list" }),
+  description: z
+    .string()
+    .max(500, "Description must be 500 characters or fewer")
+    .optional()
+    .or(z.literal("")),
+  sortOrder: z.coerce
+    .number()
+    .int("Sort order must be a whole number")
+    .min(0, "Sort order must be 0 or greater"),
+})
+
+export const updateCategorySchema = createCategorySchema.omit({ code: true })
+
+export type CreateCategoryFormValues = z.infer<typeof createCategorySchema>
+export type UpdateCategoryFormValues = z.infer<typeof updateCategorySchema>

--- a/frontend/lib/api/admin/category-schemas.ts
+++ b/frontend/lib/api/admin/category-schemas.ts
@@ -10,13 +10,15 @@ export const createCategorySchema = z.object({
     .max(64, "Code must be 64 characters or fewer")
     .regex(
       /^[a-z0-9_-]+$/,
-      "Code may only contain lowercase letters, numbers, hyphens, and underscores",
+      "Code may only contain lowercase letters, numbers, hyphens, and underscores"
     ),
   name: z
     .string()
     .min(1, "Name is required")
     .max(120, "Name must be 120 characters or fewer"),
-  icon: z.enum(ALLOWED_ICONS, { message: "Icon must be from the approved list" }),
+  icon: z.enum(ALLOWED_ICONS, {
+    message: "Icon must be from the approved list",
+  }),
   description: z
     .string()
     .max(500, "Description must be 500 characters or fewer")

--- a/frontend/lib/api/client.ts
+++ b/frontend/lib/api/client.ts
@@ -16,11 +16,11 @@ export class ApiError extends Error {
 
 async function request<T>(path: string, options?: RequestInit): Promise<T> {
   const res = await fetch(`/api${path}`, {
+    ...options,
     headers: {
       "Content-Type": "application/json",
       ...(options?.headers ?? {}),
     },
-    ...options,
   })
 
   if (res.status === 204) return undefined as T

--- a/frontend/lib/api/client.ts
+++ b/frontend/lib/api/client.ts
@@ -7,17 +7,14 @@ export class ApiError extends Error {
   constructor(
     public readonly status: number,
     message: string,
-    public readonly body?: unknown,
+    public readonly body?: unknown
   ) {
     super(message)
     this.name = "ApiError"
   }
 }
 
-async function request<T>(
-  path: string,
-  options?: RequestInit,
-): Promise<T> {
+async function request<T>(path: string, options?: RequestInit): Promise<T> {
   const res = await fetch(`/api${path}`, {
     headers: {
       "Content-Type": "application/json",

--- a/frontend/lib/api/client.ts
+++ b/frontend/lib/api/client.ts
@@ -1,6 +1,6 @@
 /**
  * Base API client for all backend requests.
- * All paths are relative — Next.js rewrites them to the backend via /api/* → BACKEND_URL/api/*.
+ * All paths are relative - the App Router API proxy forwards /api/* to the backend.
  */
 
 export class ApiError extends Error {

--- a/frontend/lib/api/client.ts
+++ b/frontend/lib/api/client.ts
@@ -1,0 +1,69 @@
+/**
+ * Base API client for all backend requests.
+ * All paths are relative — Next.js rewrites them to the backend via /api/* → BACKEND_URL/api/*.
+ */
+
+export class ApiError extends Error {
+  constructor(
+    public readonly status: number,
+    message: string,
+    public readonly body?: unknown,
+  ) {
+    super(message)
+    this.name = "ApiError"
+  }
+}
+
+async function request<T>(
+  path: string,
+  options?: RequestInit,
+): Promise<T> {
+  const res = await fetch(`/api${path}`, {
+    headers: {
+      "Content-Type": "application/json",
+      ...(options?.headers ?? {}),
+    },
+    ...options,
+  })
+
+  if (res.status === 204) return undefined as T
+
+  let body: unknown
+  try {
+    body = await res.json()
+  } catch {
+    body = undefined
+  }
+
+  if (!res.ok) {
+    const message =
+      (body as Record<string, string> | undefined)?.message ??
+      (body as Record<string, string> | undefined)?.title ??
+      res.statusText
+    throw new ApiError(res.status, message, body)
+  }
+
+  return body as T
+}
+
+export const apiClient = {
+  get: <T>(path: string, init?: RequestInit) =>
+    request<T>(path, { method: "GET", ...init }),
+
+  post: <T>(path: string, data: unknown, init?: RequestInit) =>
+    request<T>(path, {
+      method: "POST",
+      body: JSON.stringify(data),
+      ...init,
+    }),
+
+  put: <T>(path: string, data: unknown, init?: RequestInit) =>
+    request<T>(path, {
+      method: "PUT",
+      body: JSON.stringify(data),
+      ...init,
+    }),
+
+  delete: <T = void>(path: string, init?: RequestInit) =>
+    request<T>(path, { method: "DELETE", ...init }),
+}

--- a/frontend/lib/auth-context.tsx
+++ b/frontend/lib/auth-context.tsx
@@ -1,0 +1,110 @@
+"use client"
+
+/**
+ * Placeholder authentication context.
+ *
+ * TODO (separate issue): replace with real JWT/session integration once the
+ * auth endpoints (#15, #16) are implemented. The shape of AuthUser and the
+ * useAuth hook must stay stable so the rest of the app can be wired up without
+ * touching every consumer.
+ *
+ * During development, set NEXT_PUBLIC_DEV_ROLE to "Admin" or "User" in
+ * .env.local to simulate different roles:
+ *
+ *   NEXT_PUBLIC_DEV_ROLE=Admin
+ */
+
+import * as React from "react"
+
+export type UserRole = "Admin" | "User"
+
+export interface AuthUser {
+  id: string
+  name: string
+  email: string
+  role: UserRole
+  avatarUrl?: string
+}
+
+interface AuthContextValue {
+  /** null while loading, undefined when logged out */
+  user: AuthUser | null | undefined
+  isLoading: boolean
+  isAdmin: boolean
+  /** TODO: wire to real login endpoint */
+  login: (email: string, password: string) => Promise<void>
+  /** TODO: wire to real logout endpoint */
+  logout: () => Promise<void>
+}
+
+const AuthContext = React.createContext<AuthContextValue | null>(null)
+
+// ---------------------------------------------------------------------------
+// Dev stub — swapped out for a real provider once auth ships
+// ---------------------------------------------------------------------------
+const DEV_ROLE = (process.env.NEXT_PUBLIC_DEV_ROLE ?? "Admin") as UserRole
+
+const STUB_USERS: Record<UserRole, AuthUser> = {
+  Admin: {
+    id: "dev-admin-1",
+    name: "Dev Admin",
+    email: "admin@dev.local",
+    role: "Admin",
+    avatarUrl: undefined,
+  },
+  User: {
+    id: "dev-user-1",
+    name: "Dev User",
+    email: "user@dev.local",
+    role: "User",
+    avatarUrl: undefined,
+  },
+}
+
+export function AuthProvider({ children }: { children: React.ReactNode }) {
+  const [user, setUser] = React.useState<AuthUser | null | undefined>(
+    // Start as null (loading) then settle to the stub after a tick so RSC
+    // hydration is clean.
+    null,
+  )
+
+  React.useEffect(() => {
+    // Simulate an async session check
+    const timer = setTimeout(() => {
+      setUser(STUB_USERS[DEV_ROLE])
+    }, 0)
+    return () => clearTimeout(timer)
+  }, [])
+
+  async function login(_email: string, _password: string) {
+    // TODO: POST /api/auth/login, store JWT, set user from response
+    setUser(STUB_USERS[DEV_ROLE])
+  }
+
+  async function logout() {
+    // TODO: POST /api/auth/logout, clear JWT
+    setUser(undefined)
+  }
+
+  return (
+    <AuthContext.Provider
+      value={{
+        user,
+        isLoading: user === null,
+        isAdmin: user?.role === "Admin",
+        login,
+        logout,
+      }}
+    >
+      {children}
+    </AuthContext.Provider>
+  )
+}
+
+export function useAuth(): AuthContextValue {
+  const ctx = React.useContext(AuthContext)
+  if (!ctx) {
+    throw new Error("useAuth must be used within <AuthProvider>")
+  }
+  return ctx
+}

--- a/frontend/lib/auth-context.tsx
+++ b/frontend/lib/auth-context.tsx
@@ -65,7 +65,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [user, setUser] = React.useState<AuthUser | null | undefined>(
     // Start as null (loading) then settle to the stub after a tick so RSC
     // hydration is clean.
-    null,
+    null
   )
 
   React.useEffect(() => {

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -4,10 +4,20 @@ import { fileURLToPath } from "node:url"
 
 const projectRoot = dirname(fileURLToPath(import.meta.url))
 
+const BACKEND_URL = process.env.API_URL || "http://localhost:5073"
+
 const nextConfig: NextConfig = {
   output: "standalone",
   turbopack: {
     root: projectRoot,
+  },
+  async rewrites() {
+    return [
+      {
+        source: "/api/:path*",
+        destination: `${BACKEND_URL}/api/:path*`,
+      },
+    ]
   },
 }
 

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -4,20 +4,10 @@ import { fileURLToPath } from "node:url"
 
 const projectRoot = dirname(fileURLToPath(import.meta.url))
 
-const BACKEND_URL = process.env.API_URL || "http://localhost:5073"
-
 const nextConfig: NextConfig = {
   output: "standalone",
   turbopack: {
     root: projectRoot,
-  },
-  async rewrites() {
-    return [
-      {
-        source: "/api/:path*",
-        destination: `${BACKEND_URL}/api/:path*`,
-      },
-    ]
   },
 }
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,8 +8,12 @@
       "name": "frontend",
       "version": "0.0.1",
       "dependencies": {
+        "@hookform/resolvers": "^3.10.0",
         "@hugeicons/core-free-icons": "^4.1.1",
         "@hugeicons/react": "^1.1.6",
+        "@tanstack/react-query": "^5.80.0",
+        "@tanstack/react-query-devtools": "^5.80.0",
+        "@tanstack/react-table": "^8.21.3",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "next": "^16.2.4",
@@ -17,9 +21,12 @@
         "radix-ui": "^1.4.3",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
+        "react-hook-form": "^7.56.4",
         "shadcn": "^4.4.0",
+        "sonner": "^2.0.7",
         "tailwind-merge": "^3.5.0",
-        "tw-animate-css": "^1.4.0"
+        "tw-animate-css": "^1.4.0",
+        "zod": "^3.25.28"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
@@ -877,6 +884,15 @@
       },
       "peerDependencies": {
         "hono": "^4"
+      }
+    },
+    "node_modules/@hookform/resolvers": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-3.10.0.tgz",
+      "integrity": "sha512-79Dv+3mDF7i+2ajj7SkypSKHhl1cbln1OGavqrsF7p6mbUv11xpqpacPsGDCTRvCSjEEIez2ef1NveSVL3b0Ag==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react-hook-form": "^7.0.0"
       }
     },
     "node_modules/@hugeicons/core-free-icons": {
@@ -3702,6 +3718,92 @@
         "@tailwindcss/oxide": "4.2.4",
         "postcss": "^8.5.6",
         "tailwindcss": "4.2.4"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.100.9",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.100.9.tgz",
+      "integrity": "sha512-SJSFw1S8+kQ0+knv/XGfrbocWoAlT7vDKsSImtLx3ZPQmEcR46hkDjLSvynSy25N8Ms4tIEini1FuBd5k7IscQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/query-devtools": {
+      "version": "5.100.9",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-devtools/-/query-devtools-5.100.9.tgz",
+      "integrity": "sha512-gqiptrTIhbK2PuCaPRHmWXfJG1NGYVFpAr0HqogEqiSBNB5xDz6fmesQt7w4WgMOqOQPnPHJ3ZDMuhDaXvNO8g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.100.9",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.100.9.tgz",
+      "integrity": "sha512-Oa44XkaI3kCNN6ME0KByU3xT3SEUNOMfZpHxL6+wFoTm+OeUFYHKdeYVe0aOXlRDm/f15sgLwEt2HDorIdW8+A==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.100.9"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
+      }
+    },
+    "node_modules/@tanstack/react-query-devtools": {
+      "version": "5.100.9",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-5.100.9.tgz",
+      "integrity": "sha512-mM3slaVGXJmz+pOLgXdANj75ikgQCyudyl3kmFvm6brI1JyVeY/+IeD17uDHIvZrD8hfoO2sdZ54RFsHdYAuhA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-devtools": "5.100.9"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "@tanstack/react-query": "^5.100.9",
+        "react": "^18 || ^19"
+      }
+    },
+    "node_modules/@tanstack/react-table": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-table/-/react-table-8.21.3.tgz",
+      "integrity": "sha512-5nNMTSETP4ykGegmVkhjcS8tTLW6Vl4axfEGQN3v0zdHYbK4UfoqfPChclTrJ4EoK9QynqAu9oUf8VEmrpZ5Ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/table-core": "8.21.3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@tanstack/table-core": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/table-core/-/table-core-8.21.3.tgz",
+      "integrity": "sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@ts-morph/common": {
@@ -9563,6 +9665,22 @@
         "react": "^19.2.5"
       }
     },
+    "node_modules/react-hook-form": {
+      "version": "7.75.0",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.75.0.tgz",
+      "integrity": "sha512-Ovv94H+0p3sJ7B9B5QxPuCP1u8V/cHuVGyH55cSwodYDtoJwK+fqk3vjfIgSX59I2U/bU4z0nRJ9HMLpNiWEmw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
+      }
+    },
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -10122,15 +10240,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/shadcn/node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
     "node_modules/sharp": {
       "version": "0.34.5",
       "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
@@ -10299,6 +10408,16 @@
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
       "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
       "license": "MIT"
+    },
+    "node_modules/sonner": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.7.tgz",
+      "integrity": "sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      }
     },
     "node_modules/source-map": {
       "version": "0.6.1",
@@ -11529,9 +11648,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
-      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,8 +15,12 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@hookform/resolvers": "^3.10.0",
     "@hugeicons/core-free-icons": "^4.1.1",
     "@hugeicons/react": "^1.1.6",
+    "@tanstack/react-query": "^5.80.0",
+    "@tanstack/react-query-devtools": "^5.80.0",
+    "@tanstack/react-table": "^8.21.3",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "next": "^16.2.4",
@@ -24,9 +28,12 @@
     "radix-ui": "^1.4.3",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
+    "react-hook-form": "^7.56.4",
     "shadcn": "^4.4.0",
+    "sonner": "^2.0.7",
     "tailwind-merge": "^3.5.0",
-    "tw-animate-css": "^1.4.0"
+    "tw-animate-css": "^1.4.0",
+    "zod": "^3.25.28"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",


### PR DESCRIPTION
Introduce a new admin console: multiple admin pages (dashboard, categories, users, skills, reports, data library, audit log, profile) and a set of React components (dashboard, guard, header, sidebar, categories manager, category dialogs, icon picker, admin providers). Wire client-side providers into the root layout (QueryProvider, AuthProvider) and add a Toaster. Backend: add GetAllAsync endpoint for admin categories to return ordered category list. Also update .env.example API_URL to point at localhost:5073 and add frontend API helpers for admin (analytics, categories, category-schemas, client). Many new UI primitives and placeholder pages included to scaffold future admin features.