### PR TITLE
Attempts at getting the real IP when deployed :)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,9 @@ COSMOS_KEY=C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnq
 AUTH_SIGNING_KEY=change-me-to-a-32-byte-minimum-secret
 API_URL=http://localhost:8080
 
-# Forwarded headers / reverse proxy trust. Set these to your ingress/proxy CIDRs in production.
-ForwardedHeaders__ForwardLimit=2
-ForwardedHeaders__KnownNetworks__0=10.0.0.0/8
+# Shared HMAC secret used to authenticate requests from the Next.js BFF to the backend.
+# Required in non-Development environments; the backend rejects requests without a valid
+# signed X-Frontend-Auth token. Must match BACKEND_PROXY_SIGNING_KEY set on the frontend.
+# Generate a fresh 32+ byte random value per environment.
+FrontendProxyAuth__SigningKey=change-me-to-a-32-byte-minimum-secret
+# Set FrontendProxyAuth__Enabled=false to bypass the check (Development bypasses automatically).

--- a/.env.example
+++ b/.env.example
@@ -8,3 +8,7 @@ COSMOS_ENDPOINT=https://localhost:8081/
 COSMOS_KEY=C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==
 AUTH_SIGNING_KEY=change-me-to-a-32-byte-minimum-secret
 API_URL=http://localhost:8080
+
+# Forwarded headers / reverse proxy trust. Set these to your ingress/proxy CIDRs in production.
+ForwardedHeaders__ForwardLimit=2
+ForwardedHeaders__KnownNetworks__0=10.0.0.0/8

--- a/backend.Tests/FrontendProxyAuthMiddlewareTests.cs
+++ b/backend.Tests/FrontendProxyAuthMiddlewareTests.cs
@@ -18,7 +18,7 @@ public sealed class FrontendProxyAuthMiddlewareTests
     [Fact]
     public async Task BypassesInDevelopmentEvenWithoutToken()
     {
-        var (middleware, _) = Build(env: Environments.Development);
+        var middleware = Build(env: Environments.Development);
         var context = NewContext("POST", "/api/auth/login");
 
         await middleware.InvokeAsync(context);
@@ -30,7 +30,7 @@ public sealed class FrontendProxyAuthMiddlewareTests
     [Fact]
     public async Task BypassesHealthEndpointInProduction()
     {
-        var (middleware, _) = Build();
+        var middleware = Build();
         var context = NewContext("GET", "/health");
 
         await middleware.InvokeAsync(context);
@@ -42,7 +42,7 @@ public sealed class FrontendProxyAuthMiddlewareTests
     public async Task AcceptsValidTokenAndStashesIp()
     {
         var fixedNow = DateTimeOffset.FromUnixTimeSeconds(1_700_000_000);
-        var (middleware, _) = Build(time: new FixedTimeProvider(fixedNow));
+        var middleware = Build(time: new FixedTimeProvider(fixedNow));
         var token = MakeToken(fixedNow, "203.0.113.7", "POST", "/api/auth/login");
         var context = NewContext("POST", "/api/auth/login");
         context.Request.Headers["X-Frontend-Auth"] = token;
@@ -56,7 +56,7 @@ public sealed class FrontendProxyAuthMiddlewareTests
     [Fact]
     public async Task RejectsMissingToken()
     {
-        var (middleware, _) = Build();
+        var middleware = Build();
         var context = NewContext("POST", "/api/auth/login");
 
         await middleware.InvokeAsync(context);
@@ -68,7 +68,7 @@ public sealed class FrontendProxyAuthMiddlewareTests
     public async Task RejectsExpiredToken()
     {
         var fixedNow = DateTimeOffset.FromUnixTimeSeconds(1_700_000_000);
-        var (middleware, _) = Build(time: new FixedTimeProvider(fixedNow));
+        var middleware = Build(time: new FixedTimeProvider(fixedNow));
         var staleIssuedAt = fixedNow.AddMinutes(-5);
         var token = MakeToken(staleIssuedAt, "203.0.113.7", "POST", "/api/auth/login");
         var context = NewContext("POST", "/api/auth/login");
@@ -83,7 +83,7 @@ public sealed class FrontendProxyAuthMiddlewareTests
     public async Task RejectsPathMismatch()
     {
         var fixedNow = DateTimeOffset.FromUnixTimeSeconds(1_700_000_000);
-        var (middleware, _) = Build(time: new FixedTimeProvider(fixedNow));
+        var middleware = Build(time: new FixedTimeProvider(fixedNow));
         var token = MakeToken(fixedNow, "203.0.113.7", "POST", "/api/auth/login");
         var context = NewContext("POST", "/api/admin/categories");
         context.Request.Headers["X-Frontend-Auth"] = token;
@@ -97,7 +97,7 @@ public sealed class FrontendProxyAuthMiddlewareTests
     public async Task RejectsMethodMismatch()
     {
         var fixedNow = DateTimeOffset.FromUnixTimeSeconds(1_700_000_000);
-        var (middleware, _) = Build(time: new FixedTimeProvider(fixedNow));
+        var middleware = Build(time: new FixedTimeProvider(fixedNow));
         var token = MakeToken(fixedNow, "203.0.113.7", "POST", "/api/auth/login");
         var context = NewContext("DELETE", "/api/auth/login");
         context.Request.Headers["X-Frontend-Auth"] = token;
@@ -111,7 +111,7 @@ public sealed class FrontendProxyAuthMiddlewareTests
     public async Task RejectsTamperedSignature()
     {
         var fixedNow = DateTimeOffset.FromUnixTimeSeconds(1_700_000_000);
-        var (middleware, _) = Build(time: new FixedTimeProvider(fixedNow));
+        var middleware = Build(time: new FixedTimeProvider(fixedNow));
         var token = MakeToken(fixedNow, "203.0.113.7", "POST", "/api/auth/login");
         var tampered = token[..^1] + (token[^1] == 'A' ? 'B' : 'A');
         var context = NewContext("POST", "/api/auth/login");
@@ -139,7 +139,7 @@ public sealed class FrontendProxyAuthMiddlewareTests
         Assert.NotEqual(StatusCodes.Status404NotFound, context.Response.StatusCode);
     }
 
-    private static (FrontendProxyAuthMiddleware middleware, FrontendProxyAuthOptions options) Build(
+    private static FrontendProxyAuthMiddleware Build(
         string? env = null,
         TimeProvider? time = null)
     {
@@ -150,7 +150,7 @@ public sealed class FrontendProxyAuthMiddlewareTests
             new StubHostEnvironment(env ?? Environments.Production),
             time ?? TimeProvider.System,
             NullLogger<FrontendProxyAuthMiddleware>.Instance);
-        return (middleware, options);
+        return middleware;
     }
 
     private static DefaultHttpContext NewContext(string method, string path)

--- a/backend.Tests/FrontendProxyAuthMiddlewareTests.cs
+++ b/backend.Tests/FrontendProxyAuthMiddlewareTests.cs
@@ -1,0 +1,216 @@
+using System.Buffers.Text;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using Backend.Infrastructure.Security;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace backend.Tests;
+
+public sealed class FrontendProxyAuthMiddlewareTests
+{
+    private const string SigningKey = "test-signing-key-must-be-at-least-32-bytes-long";
+
+    [Fact]
+    public async Task BypassesInDevelopmentEvenWithoutToken()
+    {
+        var (middleware, _) = Build(env: Environments.Development);
+        var context = NewContext("POST", "/api/auth/login");
+
+        await middleware.InvokeAsync(context);
+
+        Assert.NotEqual(StatusCodes.Status404NotFound, context.Response.StatusCode);
+        Assert.False(context.Items.ContainsKey("ClientIp"));
+    }
+
+    [Fact]
+    public async Task BypassesHealthEndpointInProduction()
+    {
+        var (middleware, _) = Build();
+        var context = NewContext("GET", "/health");
+
+        await middleware.InvokeAsync(context);
+
+        Assert.NotEqual(StatusCodes.Status404NotFound, context.Response.StatusCode);
+    }
+
+    [Fact]
+    public async Task AcceptsValidTokenAndStashesIp()
+    {
+        var fixedNow = DateTimeOffset.FromUnixTimeSeconds(1_700_000_000);
+        var (middleware, _) = Build(time: new FixedTimeProvider(fixedNow));
+        var token = MakeToken(fixedNow, "203.0.113.7", "POST", "/api/auth/login");
+        var context = NewContext("POST", "/api/auth/login");
+        context.Request.Headers["X-Frontend-Auth"] = token;
+
+        await middleware.InvokeAsync(context);
+
+        Assert.NotEqual(StatusCodes.Status404NotFound, context.Response.StatusCode);
+        Assert.Equal("203.0.113.7", context.Items["ClientIp"]);
+    }
+
+    [Fact]
+    public async Task RejectsMissingToken()
+    {
+        var (middleware, _) = Build();
+        var context = NewContext("POST", "/api/auth/login");
+
+        await middleware.InvokeAsync(context);
+
+        Assert.Equal(StatusCodes.Status404NotFound, context.Response.StatusCode);
+    }
+
+    [Fact]
+    public async Task RejectsExpiredToken()
+    {
+        var fixedNow = DateTimeOffset.FromUnixTimeSeconds(1_700_000_000);
+        var (middleware, _) = Build(time: new FixedTimeProvider(fixedNow));
+        var staleIssuedAt = fixedNow.AddMinutes(-5);
+        var token = MakeToken(staleIssuedAt, "203.0.113.7", "POST", "/api/auth/login");
+        var context = NewContext("POST", "/api/auth/login");
+        context.Request.Headers["X-Frontend-Auth"] = token;
+
+        await middleware.InvokeAsync(context);
+
+        Assert.Equal(StatusCodes.Status404NotFound, context.Response.StatusCode);
+    }
+
+    [Fact]
+    public async Task RejectsPathMismatch()
+    {
+        var fixedNow = DateTimeOffset.FromUnixTimeSeconds(1_700_000_000);
+        var (middleware, _) = Build(time: new FixedTimeProvider(fixedNow));
+        var token = MakeToken(fixedNow, "203.0.113.7", "POST", "/api/auth/login");
+        var context = NewContext("POST", "/api/admin/categories");
+        context.Request.Headers["X-Frontend-Auth"] = token;
+
+        await middleware.InvokeAsync(context);
+
+        Assert.Equal(StatusCodes.Status404NotFound, context.Response.StatusCode);
+    }
+
+    [Fact]
+    public async Task RejectsMethodMismatch()
+    {
+        var fixedNow = DateTimeOffset.FromUnixTimeSeconds(1_700_000_000);
+        var (middleware, _) = Build(time: new FixedTimeProvider(fixedNow));
+        var token = MakeToken(fixedNow, "203.0.113.7", "POST", "/api/auth/login");
+        var context = NewContext("DELETE", "/api/auth/login");
+        context.Request.Headers["X-Frontend-Auth"] = token;
+
+        await middleware.InvokeAsync(context);
+
+        Assert.Equal(StatusCodes.Status404NotFound, context.Response.StatusCode);
+    }
+
+    [Fact]
+    public async Task RejectsTamperedSignature()
+    {
+        var fixedNow = DateTimeOffset.FromUnixTimeSeconds(1_700_000_000);
+        var (middleware, _) = Build(time: new FixedTimeProvider(fixedNow));
+        var token = MakeToken(fixedNow, "203.0.113.7", "POST", "/api/auth/login");
+        var tampered = token[..^1] + (token[^1] == 'A' ? 'B' : 'A');
+        var context = NewContext("POST", "/api/auth/login");
+        context.Request.Headers["X-Frontend-Auth"] = tampered;
+
+        await middleware.InvokeAsync(context);
+
+        Assert.Equal(StatusCodes.Status404NotFound, context.Response.StatusCode);
+    }
+
+    [Fact]
+    public async Task BypassesWhenDisabled()
+    {
+        var options = new FrontendProxyAuthOptions { Enabled = false, SigningKey = SigningKey };
+        var middleware = new FrontendProxyAuthMiddleware(
+            _ => Task.CompletedTask,
+            Options.Create(options) is var opts ? new StubOptionsMonitor(opts) : null!,
+            new StubHostEnvironment(Environments.Production),
+            TimeProvider.System,
+            NullLogger<FrontendProxyAuthMiddleware>.Instance);
+        var context = NewContext("POST", "/api/auth/login");
+
+        await middleware.InvokeAsync(context);
+
+        Assert.NotEqual(StatusCodes.Status404NotFound, context.Response.StatusCode);
+    }
+
+    private static (FrontendProxyAuthMiddleware middleware, FrontendProxyAuthOptions options) Build(
+        string? env = null,
+        TimeProvider? time = null)
+    {
+        var options = new FrontendProxyAuthOptions { Enabled = true, SigningKey = SigningKey };
+        var middleware = new FrontendProxyAuthMiddleware(
+            _ => Task.CompletedTask,
+            new StubOptionsMonitor(Options.Create(options)),
+            new StubHostEnvironment(env ?? Environments.Production),
+            time ?? TimeProvider.System,
+            NullLogger<FrontendProxyAuthMiddleware>.Instance);
+        return (middleware, options);
+    }
+
+    private static DefaultHttpContext NewContext(string method, string path)
+    {
+        var context = new DefaultHttpContext();
+        context.Request.Method = method;
+        context.Request.Path = path;
+        return context;
+    }
+
+    private static string MakeToken(DateTimeOffset issuedAt, string ip, string method, string path)
+    {
+        var headerJson = "{\"alg\":\"HS256\",\"typ\":\"JWT\"}";
+        var payloadObject = new
+        {
+            iat = issuedAt.ToUnixTimeSeconds(),
+            exp = issuedAt.AddSeconds(30).ToUnixTimeSeconds(),
+            ip,
+            mth = method,
+            pth = path,
+        };
+        var payloadJson = JsonSerializer.Serialize(payloadObject);
+
+        var headerB64 = Base64UrlEncode(Encoding.UTF8.GetBytes(headerJson));
+        var payloadB64 = Base64UrlEncode(Encoding.UTF8.GetBytes(payloadJson));
+        var signingInput = $"{headerB64}.{payloadB64}";
+        var signature = HMACSHA256.HashData(Encoding.UTF8.GetBytes(SigningKey), Encoding.UTF8.GetBytes(signingInput));
+        return $"{signingInput}.{Base64UrlEncode(signature)}";
+    }
+
+    private static string Base64UrlEncode(byte[] bytes)
+    {
+        Span<char> buffer = stackalloc char[Base64Url.GetEncodedLength(bytes.Length)];
+        Base64Url.EncodeToChars(bytes, buffer, out _, out var written);
+        return new string(buffer[..written]);
+    }
+
+    private sealed class StubOptionsMonitor(IOptions<FrontendProxyAuthOptions> options) : IOptionsMonitor<FrontendProxyAuthOptions>
+    {
+        public FrontendProxyAuthOptions CurrentValue => options.Value;
+
+        public FrontendProxyAuthOptions Get(string? name) => options.Value;
+
+        public IDisposable? OnChange(Action<FrontendProxyAuthOptions, string?> listener) => null;
+    }
+
+    private sealed class StubHostEnvironment(string name) : IHostEnvironment
+    {
+        public string EnvironmentName { get; set; } = name;
+
+        public string ApplicationName { get; set; } = "tests";
+
+        public string ContentRootPath { get; set; } = AppContext.BaseDirectory;
+
+        public Microsoft.Extensions.FileProviders.IFileProvider ContentRootFileProvider { get; set; } =
+            new Microsoft.Extensions.FileProviders.NullFileProvider();
+    }
+
+    private sealed class FixedTimeProvider(DateTimeOffset now) : TimeProvider
+    {
+        public override DateTimeOffset GetUtcNow() => now;
+    }
+}

--- a/backend.Tests/TermsControllerTests.cs
+++ b/backend.Tests/TermsControllerTests.cs
@@ -2,6 +2,7 @@ using System.Security.Claims;
 using Backend.Domain.Entities;
 using Backend.Features.Terms;
 using Backend.Infrastructure.Persistence;
+using Backend.Infrastructure.Security;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -244,7 +245,7 @@ public sealed class TermsControllerTests
 
     private static TermsController CreateController(AppDbContext db, Guid userId)
     {
-        var controller = new TermsController(db)
+        var controller = new TermsController(db, new StubClientIpAccessor())
         {
             ControllerContext = new ControllerContext
             {
@@ -259,5 +260,10 @@ public sealed class TermsControllerTests
         };
 
         return controller;
+    }
+
+    private sealed class StubClientIpAccessor : IClientIpAccessor
+    {
+        public string? GetClientIp() => "127.0.0.1";
     }
 }

--- a/backend.Tests/TermsControllerTests.cs
+++ b/backend.Tests/TermsControllerTests.cs
@@ -264,6 +264,6 @@ public sealed class TermsControllerTests
 
     private sealed class StubClientIpAccessor : IClientIpAccessor
     {
-        public string? GetClientIp() => "127.0.0.1";
+        public string GetClientIp() => "127.0.0.1";
     }
 }

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,13 +1,13 @@
 FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 WORKDIR /src
-COPY backend.csproj .
+COPY backend.csproj Directory.Build.props stylecop.json ./
 RUN dotnet restore
 COPY . .
 RUN dotnet publish -c Release -o /app/publish --no-restore
 
 FROM mcr.microsoft.com/dotnet/sdk:10.0 AS dev
 WORKDIR /src
-COPY backend.csproj .
+COPY backend.csproj Directory.Build.props stylecop.json ./
 RUN dotnet restore
 EXPOSE 8080
 ENV ASPNETCORE_URLS=http://+:8080

--- a/backend/Features/Auth/AuthController.Functions.cs
+++ b/backend/Features/Auth/AuthController.Functions.cs
@@ -83,7 +83,7 @@ public sealed partial class AuthController
 
     private string? GetClientIp()
     {
-        return HttpContext.Connection.RemoteIpAddress?.ToString();
+        return clientIpAccessor.GetClientIp();
     }
 
     private void SetRefreshTokenCookie(AuthTokenResult tokens)

--- a/backend/Features/Auth/AuthController.cs
+++ b/backend/Features/Auth/AuthController.cs
@@ -4,6 +4,7 @@ using Backend.Domain.Enums;
 using Backend.Features.Terms;
 using Backend.Infrastructure.Identity;
 using Backend.Infrastructure.Persistence;
+using Backend.Infrastructure.Security;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
@@ -16,7 +17,8 @@ namespace Backend.Features.Auth;
 public sealed partial class AuthController(
     AppDbContext db,
     UserManager<ApplicationUser> userManager,
-    IAuthTokenService tokenService) : ControllerBase
+    IAuthTokenService tokenService,
+    IClientIpAccessor clientIpAccessor) : ControllerBase
 {
     private const string RefreshTokenCookieName = "refreshToken";
 

--- a/backend/Features/Terms/TermsController.cs
+++ b/backend/Features/Terms/TermsController.cs
@@ -1,6 +1,7 @@
 using System.Security.Claims;
 using Backend.Domain.Entities;
 using Backend.Infrastructure.Persistence;
+using Backend.Infrastructure.Security;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
@@ -10,7 +11,7 @@ namespace Backend.Features.Terms;
 [ApiController]
 [Route("api/terms")]
 [Authorize]
-public sealed class TermsController(AppDbContext db) : ControllerBase
+public sealed class TermsController(AppDbContext db, IClientIpAccessor clientIpAccessor) : ControllerBase
 {
     /// <summary>
     /// Get the currently active terms version.
@@ -98,7 +99,7 @@ public sealed class TermsController(AppDbContext db) : ControllerBase
             UserId = userIdGuid,
             TermsVersionId = termsVersionId,
             AcceptedAt = DateTimeOffset.UtcNow,
-            IpAddress = HttpContext.Connection.RemoteIpAddress?.ToString()
+            IpAddress = clientIpAccessor.GetClientIp()
         });
 
         try

--- a/backend/Infrastructure/Security/ClientIpAccessor.cs
+++ b/backend/Infrastructure/Security/ClientIpAccessor.cs
@@ -1,0 +1,44 @@
+namespace Backend.Infrastructure.Security;
+
+/// <summary>
+/// Exposes the end-user IP address attested by the frontend proxy auth middleware.
+/// </summary>
+public interface IClientIpAccessor
+{
+    /// <summary>
+    /// Returns the attested client IP for the current request, or the underlying connection
+    /// address as a last-resort fallback when no attested value is present.
+    /// </summary>
+    /// <returns>The client IP, or <see langword="null"/> when neither source is available.</returns>
+    string? GetClientIp();
+}
+
+internal sealed class ClientIpAccessor(IHttpContextAccessor httpContextAccessor, ILogger<ClientIpAccessor> logger) : IClientIpAccessor
+{
+    internal const string HttpContextItemKey = "ClientIp";
+
+    public string? GetClientIp()
+    {
+        var context = httpContextAccessor.HttpContext;
+        if (context is null)
+        {
+            return null;
+        }
+
+        if (context.Items.TryGetValue(HttpContextItemKey, out var value) && value is string attestedIp)
+        {
+            return attestedIp;
+        }
+
+        // No attested IP available. In production this means the frontend-proxy auth
+        // middleware did not run, or it was misconfigured, so the connection address
+        // is the egress IP of whatever called us, not the end user. Log it and fall
+        // back so we record something rather than nothing.
+        var fallback = context.Connection.RemoteIpAddress?.ToString();
+        logger.LogWarning(
+            "No attested client IP on HttpContext.Items[\"{Key}\"]; falling back to Connection.RemoteIpAddress = {Fallback}.",
+            HttpContextItemKey,
+            fallback ?? "<null>");
+        return fallback;
+    }
+}

--- a/backend/Infrastructure/Security/FrontendProxyAuthExtensions.cs
+++ b/backend/Infrastructure/Security/FrontendProxyAuthExtensions.cs
@@ -1,0 +1,24 @@
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace Backend.Infrastructure.Security;
+
+public static class FrontendProxyAuthExtensions
+{
+    public static IServiceCollection AddFrontendProxyAuth(
+        this IServiceCollection services,
+        IConfiguration configuration)
+    {
+        services.AddHttpContextAccessor();
+        services.TryAddSingleton(TimeProvider.System);
+        services.AddOptions<FrontendProxyAuthOptions>()
+            .Bind(configuration.GetSection(FrontendProxyAuthOptions.SectionName))
+            .ValidateDataAnnotations();
+        services.AddSingleton<IClientIpAccessor, ClientIpAccessor>();
+        return services;
+    }
+
+    public static IApplicationBuilder UseFrontendProxyAuth(this IApplicationBuilder app)
+    {
+        return app.UseMiddleware<FrontendProxyAuthMiddleware>();
+    }
+}

--- a/backend/Infrastructure/Security/FrontendProxyAuthMiddleware.cs
+++ b/backend/Infrastructure/Security/FrontendProxyAuthMiddleware.cs
@@ -77,8 +77,16 @@ public sealed class FrontendProxyAuthMiddleware(
 
         try
         {
-            payload = JsonSerializer.Deserialize<ProxyTokenPayload>(buffer.AsSpan(0, decodedLength), _serializerOptions)!;
-            return payload is not null;
+            var deserializedPayload = JsonSerializer.Deserialize<ProxyTokenPayload>(
+                buffer.AsSpan(0, decodedLength),
+                _serializerOptions);
+            if (deserializedPayload is null)
+            {
+                return false;
+            }
+
+            payload = deserializedPayload;
+            return true;
         }
         catch (JsonException)
         {

--- a/backend/Infrastructure/Security/FrontendProxyAuthMiddleware.cs
+++ b/backend/Infrastructure/Security/FrontendProxyAuthMiddleware.cs
@@ -1,0 +1,211 @@
+using System.Buffers.Text;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.Extensions.Options;
+
+namespace Backend.Infrastructure.Security;
+
+public sealed class FrontendProxyAuthMiddleware(
+    RequestDelegate next,
+    IOptionsMonitor<FrontendProxyAuthOptions> options,
+    IHostEnvironment environment,
+    TimeProvider timeProvider,
+    ILogger<FrontendProxyAuthMiddleware> logger)
+{
+    private const string HeaderName = "X-Frontend-Auth";
+    private const string HealthPath = "/health";
+
+    private static readonly JsonSerializerOptions _serializerOptions = new(JsonSerializerDefaults.Web);
+
+    public async Task InvokeAsync(HttpContext context)
+    {
+        var currentOptions = options.CurrentValue;
+
+        if (ShouldBypass(context, currentOptions))
+        {
+            await next(context);
+            return;
+        }
+
+        if (!TryValidate(context, currentOptions, out var clientIp, out var failureReason))
+        {
+            logger.LogWarning(
+                "Rejected request {Method} {Path} from {RemoteIp}: {Reason}",
+                context.Request.Method,
+                context.Request.Path,
+                context.Connection.RemoteIpAddress,
+                failureReason);
+            context.Response.StatusCode = StatusCodes.Status404NotFound;
+            return;
+        }
+
+        context.Items[ClientIpAccessor.HttpContextItemKey] = clientIp;
+        await next(context);
+    }
+
+    private static bool VerifySignature(ReadOnlySpan<char> signingInput, ReadOnlySpan<char> providedSignature, string signingKey)
+    {
+        Span<byte> expected = stackalloc byte[HMACSHA256.HashSizeInBytes];
+        var inputBytes = Encoding.UTF8.GetBytes(signingInput.ToString());
+        var keyBytes = Encoding.UTF8.GetBytes(signingKey);
+
+        if (!HMACSHA256.TryHashData(keyBytes, inputBytes, expected, out var written) || written != expected.Length)
+        {
+            return false;
+        }
+
+        Span<byte> provided = stackalloc byte[HMACSHA256.HashSizeInBytes];
+        if (!TryBase64UrlDecode(providedSignature, provided, out var providedLength) || providedLength != expected.Length)
+        {
+            return false;
+        }
+
+        return CryptographicOperations.FixedTimeEquals(expected, provided);
+    }
+
+    private static bool TryDecodePayload(ReadOnlySpan<char> payloadSegment, out ProxyTokenPayload payload)
+    {
+        payload = default!;
+
+        var buffer = new byte[payloadSegment.Length];
+        if (!TryBase64UrlDecode(payloadSegment, buffer, out var decodedLength))
+        {
+            return false;
+        }
+
+        try
+        {
+            payload = JsonSerializer.Deserialize<ProxyTokenPayload>(buffer.AsSpan(0, decodedLength), _serializerOptions)!;
+            return payload is not null;
+        }
+        catch (JsonException)
+        {
+            return false;
+        }
+    }
+
+    private static bool TryBase64UrlDecode(ReadOnlySpan<char> input, Span<byte> destination, out int bytesWritten)
+    {
+        var status = Base64Url.DecodeFromChars(input, destination, out _, out bytesWritten);
+        return status == System.Buffers.OperationStatus.Done;
+    }
+
+    private bool ShouldBypass(HttpContext context, FrontendProxyAuthOptions currentOptions)
+    {
+        if (!currentOptions.Enabled)
+        {
+            return true;
+        }
+
+        if (environment.IsDevelopment())
+        {
+            return true;
+        }
+
+        if (context.Request.Path.Equals(HealthPath, StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        return false;
+    }
+
+    private bool TryValidate(
+        HttpContext context,
+        FrontendProxyAuthOptions currentOptions,
+        out string? clientIp,
+        out string failureReason)
+    {
+        clientIp = null;
+
+        if (string.IsNullOrEmpty(currentOptions.SigningKey))
+        {
+            failureReason = "signing key not configured";
+            return false;
+        }
+
+        if (!context.Request.Headers.TryGetValue(HeaderName, out var headerValues)
+            || headerValues.Count != 1
+            || string.IsNullOrEmpty(headerValues[0]))
+        {
+            failureReason = "missing or malformed auth header";
+            return false;
+        }
+
+        var token = headerValues[0]!;
+        var firstDot = token.IndexOf('.');
+        var lastDot = token.LastIndexOf('.');
+        if (firstDot <= 0 || lastDot <= firstDot || lastDot == token.Length - 1)
+        {
+            failureReason = "token structure invalid";
+            return false;
+        }
+
+        var signingInput = token.AsSpan(0, lastDot);
+        var providedSignature = token.AsSpan(lastDot + 1);
+
+        if (!VerifySignature(signingInput, providedSignature, currentOptions.SigningKey!))
+        {
+            failureReason = "signature mismatch";
+            return false;
+        }
+
+        if (!TryDecodePayload(token.AsSpan(firstDot + 1, lastDot - firstDot - 1), out var payload))
+        {
+            failureReason = "payload decode failed";
+            return false;
+        }
+
+        var now = timeProvider.GetUtcNow().ToUnixTimeSeconds();
+        var skew = currentOptions.ClockSkewSeconds;
+
+        if (payload.ExpiresAt + skew < now)
+        {
+            failureReason = "token expired";
+            return false;
+        }
+
+        if (payload.IssuedAt - skew > now)
+        {
+            failureReason = "token issued in the future";
+            return false;
+        }
+
+        if (payload.ExpiresAt - payload.IssuedAt > currentOptions.MaxTokenLifetimeSeconds)
+        {
+            failureReason = "token lifetime exceeds policy";
+            return false;
+        }
+
+        if (!string.Equals(payload.Method, context.Request.Method, StringComparison.OrdinalIgnoreCase))
+        {
+            failureReason = "method mismatch";
+            return false;
+        }
+
+        if (!string.Equals(payload.Path, context.Request.Path.Value, StringComparison.Ordinal))
+        {
+            failureReason = "path mismatch";
+            return false;
+        }
+
+        if (string.IsNullOrEmpty(payload.Ip))
+        {
+            failureReason = "missing ip claim";
+            return false;
+        }
+
+        clientIp = payload.Ip;
+        failureReason = string.Empty;
+        return true;
+    }
+
+    private sealed record ProxyTokenPayload(
+        [property: JsonPropertyName("iat")] long IssuedAt,
+        [property: JsonPropertyName("exp")] long ExpiresAt,
+        [property: JsonPropertyName("ip")] string Ip,
+        [property: JsonPropertyName("mth")] string Method,
+        [property: JsonPropertyName("pth")] string Path);
+}

--- a/backend/Infrastructure/Security/FrontendProxyAuthOptions.cs
+++ b/backend/Infrastructure/Security/FrontendProxyAuthOptions.cs
@@ -1,0 +1,19 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Backend.Infrastructure.Security;
+
+public sealed class FrontendProxyAuthOptions
+{
+    public const string SectionName = "FrontendProxyAuth";
+
+    public bool Enabled { get; set; } = true;
+
+    [MinLength(32)]
+    public string? SigningKey { get; set; }
+
+    [Range(1, 600)]
+    public int MaxTokenLifetimeSeconds { get; set; } = 60;
+
+    [Range(0, 60)]
+    public int ClockSkewSeconds { get; set; } = 5;
+}

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -7,9 +7,11 @@ using Backend.Infrastructure.Identity;
 using Backend.Infrastructure.Persistence;
 using Backend.Infrastructure.Persistence.Queries;
 using Backend.Infrastructure.Persistence.Seeding;
+using Backend.Infrastructure.Security;
 using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.Azure.Cosmos;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
 using Npgsql;
 using Scalar.AspNetCore;
 
@@ -138,25 +140,34 @@ builder.Services.AddControllers();
 builder.Services.AddOutputCache();
 builder.Services.Configure<ForwardedHeadersOptions>(options =>
 {
-    options.ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto;
-    options.ForwardLimit = builder.Configuration.GetValue<int?>("ForwardedHeaders:ForwardLimit") ?? 2;
+    // Only trust X-Forwarded-Proto from upstream proxies so Request.IsHttps reflects the
+    // original scheme (used for Secure cookies). X-Forwarded-For is intentionally not
+    // processed: the real client IP comes from the signed proxy token (FrontendProxyAuth).
+    options.ForwardedHeaders = ForwardedHeaders.XForwardedProto;
 
-    foreach (var proxy in GetConfiguredIpAddresses(builder.Configuration, "ForwardedHeaders:KnownProxies"))
-    {
-        options.KnownProxies.Add(proxy);
-    }
-
-    foreach (var network in GetConfiguredIpNetworks(builder.Configuration, "ForwardedHeaders:KnownNetworks"))
-    {
-        options.KnownIPNetworks.Add(network);
-    }
+    // ACA's Envoy ingress reaches the app pod from a private RFC1918 address; trusting these
+    // ranges lets the framework accept the X-Forwarded-Proto header it sets.
+    options.KnownIPNetworks.Add(new System.Net.IPNetwork(IPAddress.Parse("10.0.0.0"), 8));
+    options.KnownIPNetworks.Add(new System.Net.IPNetwork(IPAddress.Parse("172.16.0.0"), 12));
+    options.KnownIPNetworks.Add(new System.Net.IPNetwork(IPAddress.Parse("192.168.0.0"), 16));
 });
+builder.Services.AddFrontendProxyAuth(builder.Configuration);
 builder.Services.AddApplicationAuthentication(builder.Configuration);
 builder.Services.AddAuthorization();
 
 builder.Services.AddDevelopmentDataSeeders(builder.Configuration, builder.Environment);
 
 var app = builder.Build();
+
+var proxyAuth = app.Services.GetRequiredService<IOptions<FrontendProxyAuthOptions>>().Value;
+if (proxyAuth.Enabled
+    && !app.Environment.IsDevelopment()
+    && string.IsNullOrWhiteSpace(proxyAuth.SigningKey))
+{
+    throw new InvalidOperationException(
+        "FrontendProxyAuth:SigningKey is required when FrontendProxyAuth is enabled outside Development. "
+        + "Set FrontendProxyAuth__SigningKey or disable it via FrontendProxyAuth__Enabled=false.");
+}
 
 using (var scope = app.Services.CreateScope())
 {
@@ -213,8 +224,8 @@ if (!bool.TryParse(Environment.GetEnvironmentVariable("DOTNET_RUNNING_IN_CONTAIN
     app.UseHttpsRedirection();
 }
 
-app.Use(NormalizeRealIpHeaderAsync);
 app.UseForwardedHeaders();
+app.UseFrontendProxyAuth();
 
 app.UseRouting();
 app.UseOutputCache();
@@ -249,45 +260,4 @@ static string GetRequiredEnvironmentVariable(string name)
 {
     return Environment.GetEnvironmentVariable(name)
         ?? throw new InvalidOperationException($"Missing required environment variable: {name}.");
-}
-
-static Task NormalizeRealIpHeaderAsync(HttpContext context, RequestDelegate next)
-{
-    if (!context.Request.Headers.ContainsKey(ForwardedHeadersDefaults.XForwardedForHeaderName)
-        && context.Request.Headers.TryGetValue("X-Real-IP", out var realIp))
-    {
-        context.Request.Headers[ForwardedHeadersDefaults.XForwardedForHeaderName] = realIp;
-    }
-
-    return next(context);
-}
-
-static IEnumerable<IPAddress> GetConfiguredIpAddresses(IConfiguration configuration, string sectionName)
-{
-    foreach (var value in configuration.GetSection(sectionName).Get<string[]>() ?? [])
-    {
-        if (IPAddress.TryParse(value, out var address))
-        {
-            yield return address;
-            continue;
-        }
-
-        throw new InvalidOperationException(
-            $"Configuration value '{sectionName}' contains invalid IP address '{value}'.");
-    }
-}
-
-static IEnumerable<System.Net.IPNetwork> GetConfiguredIpNetworks(IConfiguration configuration, string sectionName)
-{
-    foreach (var value in configuration.GetSection(sectionName).Get<string[]>() ?? [])
-    {
-        if (System.Net.IPNetwork.TryParse(value, out var network))
-        {
-            yield return network;
-            continue;
-        }
-
-        throw new InvalidOperationException(
-            $"Configuration value '{sectionName}' contains invalid CIDR network '{value}'.");
-    }
 }

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -218,14 +218,14 @@ if (app.Environment.IsDevelopment())
     await seedScope.ServiceProvider.RunDataSeedersAsync();
 }
 
+app.UseForwardedHeaders();
+app.UseFrontendProxyAuth();
+
 // Skip HTTPS redirect inside Docker containers (HTTP-only on port 8080)
 if (!bool.TryParse(Environment.GetEnvironmentVariable("DOTNET_RUNNING_IN_CONTAINER"), out var inContainer) || !inContainer)
 {
     app.UseHttpsRedirection();
 }
-
-app.UseForwardedHeaders();
-app.UseFrontendProxyAuth();
 
 app.UseRouting();
 app.UseOutputCache();

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using Azure.Core;
 using Azure.Identity;
 using Backend.Application.Categories;
@@ -6,6 +7,7 @@ using Backend.Infrastructure.Identity;
 using Backend.Infrastructure.Persistence;
 using Backend.Infrastructure.Persistence.Queries;
 using Backend.Infrastructure.Persistence.Seeding;
+using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.Azure.Cosmos;
 using Microsoft.EntityFrameworkCore;
 using Npgsql;
@@ -134,6 +136,21 @@ builder.Services.AddApplicationIdentity();
 
 builder.Services.AddControllers();
 builder.Services.AddOutputCache();
+builder.Services.Configure<ForwardedHeadersOptions>(options =>
+{
+    options.ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto;
+    options.ForwardLimit = builder.Configuration.GetValue<int?>("ForwardedHeaders:ForwardLimit") ?? 2;
+
+    foreach (var proxy in GetConfiguredIpAddresses(builder.Configuration, "ForwardedHeaders:KnownProxies"))
+    {
+        options.KnownProxies.Add(proxy);
+    }
+
+    foreach (var network in GetConfiguredIpNetworks(builder.Configuration, "ForwardedHeaders:KnownNetworks"))
+    {
+        options.KnownIPNetworks.Add(network);
+    }
+});
 builder.Services.AddApplicationAuthentication(builder.Configuration);
 builder.Services.AddAuthorization();
 
@@ -196,6 +213,9 @@ if (!bool.TryParse(Environment.GetEnvironmentVariable("DOTNET_RUNNING_IN_CONTAIN
     app.UseHttpsRedirection();
 }
 
+app.Use(NormalizeRealIpHeaderAsync);
+app.UseForwardedHeaders();
+
 app.UseRouting();
 app.UseOutputCache();
 app.UseAuthentication();
@@ -229,4 +249,45 @@ static string GetRequiredEnvironmentVariable(string name)
 {
     return Environment.GetEnvironmentVariable(name)
         ?? throw new InvalidOperationException($"Missing required environment variable: {name}.");
+}
+
+static Task NormalizeRealIpHeaderAsync(HttpContext context, RequestDelegate next)
+{
+    if (!context.Request.Headers.ContainsKey(ForwardedHeadersDefaults.XForwardedForHeaderName)
+        && context.Request.Headers.TryGetValue("X-Real-IP", out var realIp))
+    {
+        context.Request.Headers[ForwardedHeadersDefaults.XForwardedForHeaderName] = realIp;
+    }
+
+    return next(context);
+}
+
+static IEnumerable<IPAddress> GetConfiguredIpAddresses(IConfiguration configuration, string sectionName)
+{
+    foreach (var value in configuration.GetSection(sectionName).Get<string[]>() ?? [])
+    {
+        if (IPAddress.TryParse(value, out var address))
+        {
+            yield return address;
+            continue;
+        }
+
+        throw new InvalidOperationException(
+            $"Configuration value '{sectionName}' contains invalid IP address '{value}'.");
+    }
+}
+
+static IEnumerable<System.Net.IPNetwork> GetConfiguredIpNetworks(IConfiguration configuration, string sectionName)
+{
+    foreach (var value in configuration.GetSection(sectionName).Get<string[]>() ?? [])
+    {
+        if (System.Net.IPNetwork.TryParse(value, out var network))
+        {
+            yield return network;
+            continue;
+        }
+
+        throw new InvalidOperationException(
+            $"Configuration value '{sectionName}' contains invalid CIDR network '{value}'.");
+    }
 }

--- a/backend/appsettings.json
+++ b/backend/appsettings.json
@@ -14,14 +14,10 @@
     "IntervalHours": 24,
     "RetentionDays": 7
   },
-  "ForwardedHeaders": {
-    "ForwardLimit": 2,
-    "KnownNetworks": [
-      "10.0.0.0/8",
-      "172.16.0.0/12",
-      "192.168.0.0/16"
-    ],
-    "KnownProxies": []
+  "FrontendProxyAuth": {
+    "Enabled": true,
+    "MaxTokenLifetimeSeconds": 60,
+    "ClockSkewSeconds": 5
   },
   "Logging": {
     "LogLevel": {

--- a/backend/appsettings.json
+++ b/backend/appsettings.json
@@ -14,6 +14,15 @@
     "IntervalHours": 24,
     "RetentionDays": 7
   },
+  "ForwardedHeaders": {
+    "ForwardLimit": 2,
+    "KnownNetworks": [
+      "10.0.0.0/8",
+      "172.16.0.0/12",
+      "192.168.0.0/16"
+    ],
+    "KnownProxies": []
+  },
   "Logging": {
     "LogLevel": {
       "Default": "Information",

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -24,6 +24,7 @@ services:
       CosmosDb__AccountEndpoint: ${COSMOS_ENDPOINT:?COSMOS_ENDPOINT is required}
       CosmosDb__AccountKey: ${COSMOS_KEY:?COSMOS_KEY is required}
       AUTH_SIGNING_KEY: ${AUTH_SIGNING_KEY:?AUTH_SIGNING_KEY is required}
+      FrontendProxyAuth__SigningKey: ${FRONTEND_PROXY_SIGNING_KEY:?FRONTEND_PROXY_SIGNING_KEY is required}
     depends_on:
       db:
         condition: service_healthy
@@ -34,6 +35,7 @@ services:
       - "3000:3000"
     environment:
       API_URL: ${API_URL:-http://backend:8080}
+      BACKEND_PROXY_SIGNING_KEY: ${FRONTEND_PROXY_SIGNING_KEY:?FRONTEND_PROXY_SIGNING_KEY is required}
     depends_on:
       - backend
 

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -107,6 +107,12 @@ Configuration lives in [`components.json`](./components.json) (style `radix-vega
 
 Custom components go in `components/<feature>/` (one folder per feature area: `auth`, `layout`, `messages`, `profile`, `shared`, `tasks`).
 
+## Deployment constraint: Vercel required for IP attestation
+
+`lib/auth/frontend-proxy-jws.ts` reads the client IP exclusively from the `x-vercel-forwarded-for` header, which Vercel injects server-side and strips from any client-supplied value. This is intentional: `x-forwarded-for` and `x-real-ip` are user-controllable in topologies without a strict outer proxy, so trusting them would let callers forge their audit IP.
+
+The consequence is a hard deployment dependency: **the frontend must run on Vercel** for the backend's IP attestation to work. If the frontend is ever moved to a different host (e.g. self-hosted Docker, Railway, Fly.io), `getClientIpFromRequest` will return `null` for every request, `applyProxyAuth` will not set `X-Frontend-Auth`, and the backend will reject all proxied API calls in production. To support a non-Vercel host you would need to identify which header that platform injects as a trusted, non-forgeable client IP source and update `getClientIpFromRequest` accordingly.
+
 ## Mock data
 
 `lib/mock-data.ts` provides fixtures for screens that aren't wired to the backend yet. Treat it as a stand-in until the corresponding endpoint exists; don't ship it in production code paths. `lib/types.ts` holds the shared TypeScript types those fixtures and components depend on.

--- a/frontend/app/api/[...path]/route.ts
+++ b/frontend/app/api/[...path]/route.ts
@@ -18,6 +18,7 @@ import {
   setAccessTokenCookie,
   toSafeAuthResponse,
 } from "@/lib/auth/backend"
+import { applyProxyAuth } from "@/lib/auth/frontend-proxy-jws"
 import type { BackendAuthResponse } from "@/lib/auth/types"
 
 type ApiRouteContext = {
@@ -150,7 +151,10 @@ async function fetchBackend(
     headers.set("authorization", `Bearer ${accessToken}`)
   }
 
-  return fetch(getBackendUrl(path, request.url), {
+  const backendUrl = getBackendUrl(path, request.url)
+  await applyProxyAuth(request, headers, backendUrl, request.method)
+
+  return fetch(backendUrl, {
     method: request.method,
     headers,
     body: requestBody ? requestBody.slice(0) : undefined,

--- a/frontend/app/api/auth/session/route.ts
+++ b/frontend/app/api/auth/session/route.ts
@@ -17,7 +17,7 @@ export async function GET(request: NextRequest): Promise<Response> {
   const accessToken = request.cookies.get(ACCESS_TOKEN_COOKIE)?.value
 
   if (accessToken) {
-    const user = await getSessionUser(accessToken)
+    const user = await getSessionUser(request, accessToken)
     if (user) {
       return NextResponse.json<SessionResponse>({
         user,
@@ -32,7 +32,7 @@ export async function GET(request: NextRequest): Promise<Response> {
     return response
   }
 
-  const user = await getSessionUser(refreshResult.auth.accessToken)
+  const user = await getSessionUser(request, refreshResult.auth.accessToken)
   if (!user) {
     const response = NextResponse.json<SessionResponse>({ user: null })
     appendBackendSetCookie(refreshResult.response, response)
@@ -49,7 +49,10 @@ export async function GET(request: NextRequest): Promise<Response> {
   return response
 }
 
-async function getSessionUser(accessToken: string): Promise<AuthUser | null> {
+async function getSessionUser(
+  request: NextRequest,
+  accessToken: string
+): Promise<AuthUser | null> {
   if (!isJwtFresh(accessToken)) {
     return null
   }
@@ -59,7 +62,7 @@ async function getSessionUser(accessToken: string): Promise<AuthUser | null> {
     return null
   }
 
-  const profileResult = await fetchOwnProfile(accessToken)
+  const profileResult = await fetchOwnProfile(request, accessToken)
   if (profileResult.status === "unauthorized") {
     return null
   }

--- a/frontend/lib/auth/backend.ts
+++ b/frontend/lib/auth/backend.ts
@@ -11,6 +11,7 @@ import {
   BACKEND_PROFILE_PATHS,
   DEFAULT_BACKEND_API_URL,
 } from "@/lib/auth/constants"
+import { applyProxyAuth } from "@/lib/auth/frontend-proxy-jws"
 import type { JwtUserClaims } from "@/lib/auth/jwt"
 import type {
   AuthUser,
@@ -123,11 +124,13 @@ export async function refreshBackendToken(
     return null
   }
 
-  const response = await fetch(getBackendUrl([...BACKEND_AUTH_PATHS.refresh]), {
+  const backendUrl = getBackendUrl([...BACKEND_AUTH_PATHS.refresh])
+  const headers = new Headers({ cookie })
+  await applyProxyAuth(request, headers, backendUrl, "POST")
+
+  const response = await fetch(backendUrl, {
     method: "POST",
-    headers: {
-      cookie,
-    },
+    headers,
     cache: "no-store",
   })
 
@@ -144,13 +147,16 @@ export async function refreshBackendToken(
 }
 
 export async function fetchOwnProfile(
+  request: NextRequest,
   accessToken: string
 ): Promise<OwnProfileFetchResult> {
-  const response = await fetch(getBackendUrl([...BACKEND_PROFILE_PATHS.me]), {
+  const backendUrl = getBackendUrl([...BACKEND_PROFILE_PATHS.me])
+  const headers = new Headers({ authorization: `Bearer ${accessToken}` })
+  await applyProxyAuth(request, headers, backendUrl, "GET")
+
+  const response = await fetch(backendUrl, {
     method: "GET",
-    headers: {
-      authorization: `Bearer ${accessToken}`,
-    },
+    headers,
     cache: "no-store",
   })
 

--- a/frontend/lib/auth/frontend-proxy-jws.ts
+++ b/frontend/lib/auth/frontend-proxy-jws.ts
@@ -80,24 +80,17 @@ function base64UrlEncode(bytes: Uint8Array): string {
   return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "")
 }
 
-export function getClientIpFromRequest(request: NextRequest): string {
-  const candidates = [
-    request.headers.get("x-vercel-forwarded-for"),
-    request.headers.get("x-forwarded-for"),
-    request.headers.get("x-real-ip"),
-  ]
-
-  for (const candidate of candidates) {
-    if (!candidate) {
-      continue
-    }
-    const first = candidate.split(",")[0]?.trim()
-    if (first) {
-      return first
-    }
+export function getClientIpFromRequest(request: NextRequest): string | null {
+  // Only trust x-vercel-forwarded-for: Vercel injects this server-side and
+  // strips any client-supplied value, so it cannot be forged by the caller.
+  // x-forwarded-for and x-real-ip are user-controllable in topologies where
+  // the outer proxy does not overwrite them.
+  const header = request.headers.get("x-vercel-forwarded-for")
+  if (!header) {
+    return null
   }
-
-  return ""
+  const first = header.split(",")[0]?.trim()
+  return first || null
 }
 
 export async function applyProxyAuth(
@@ -110,8 +103,13 @@ export async function applyProxyAuth(
     outbound.delete(header)
   }
 
+  const ip = getClientIpFromRequest(request)
+  if (!ip) {
+    return
+  }
+
   const token = await signProxyToken({
-    ip: getClientIpFromRequest(request),
+    ip,
     method,
     path: backendUrl.pathname,
   })

--- a/frontend/lib/auth/frontend-proxy-jws.ts
+++ b/frontend/lib/auth/frontend-proxy-jws.ts
@@ -1,0 +1,122 @@
+import type { NextRequest } from "next/server"
+
+export const PROXY_AUTH_HEADER = "X-Frontend-Auth"
+
+const FORWARDED_HEADER_BLOCKLIST = [
+  "x-forwarded-for",
+  "x-real-ip",
+  "x-vercel-forwarded-for",
+  "x-vercel-ip",
+  PROXY_AUTH_HEADER.toLowerCase(),
+] as const
+
+const HEADER_B64 = base64UrlEncode(
+  new TextEncoder().encode(JSON.stringify({ alg: "HS256", typ: "JWT" }))
+)
+
+const TOKEN_LIFETIME_SECONDS = 30
+
+type SignProxyTokenInput = {
+  ip: string
+  method: string
+  path: string
+}
+
+let cachedKey: { material: string; key: CryptoKey } | null = null
+
+export async function signProxyToken(
+  input: SignProxyTokenInput
+): Promise<string | null> {
+  const keyMaterial = process.env.BACKEND_PROXY_SIGNING_KEY
+  if (!keyMaterial) {
+    return null
+  }
+
+  const cryptoKey = await getCryptoKey(keyMaterial)
+  const now = Math.floor(Date.now() / 1000)
+  const payload = {
+    iat: now,
+    exp: now + TOKEN_LIFETIME_SECONDS,
+    ip: input.ip,
+    mth: input.method.toUpperCase(),
+    pth: input.path,
+  }
+
+  const payloadB64 = base64UrlEncode(
+    new TextEncoder().encode(JSON.stringify(payload))
+  )
+  const signingInput = `${HEADER_B64}.${payloadB64}`
+  const signature = await crypto.subtle.sign(
+    "HMAC",
+    cryptoKey,
+    new TextEncoder().encode(signingInput)
+  )
+
+  return `${signingInput}.${base64UrlEncode(new Uint8Array(signature))}`
+}
+
+async function getCryptoKey(material: string): Promise<CryptoKey> {
+  if (cachedKey && cachedKey.material === material) {
+    return cachedKey.key
+  }
+
+  const key = await crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(material),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"]
+  )
+
+  cachedKey = { material, key }
+  return key
+}
+
+function base64UrlEncode(bytes: Uint8Array): string {
+  let binary = ""
+  for (let i = 0; i < bytes.byteLength; i += 1) {
+    binary += String.fromCharCode(bytes[i])
+  }
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "")
+}
+
+export function getClientIpFromRequest(request: NextRequest): string {
+  const candidates = [
+    request.headers.get("x-vercel-forwarded-for"),
+    request.headers.get("x-forwarded-for"),
+    request.headers.get("x-real-ip"),
+  ]
+
+  for (const candidate of candidates) {
+    if (!candidate) {
+      continue
+    }
+    const first = candidate.split(",")[0]?.trim()
+    if (first) {
+      return first
+    }
+  }
+
+  return ""
+}
+
+export async function applyProxyAuth(
+  request: NextRequest,
+  outbound: Headers,
+  backendUrl: URL,
+  method: string
+): Promise<void> {
+  for (const header of FORWARDED_HEADER_BLOCKLIST) {
+    outbound.delete(header)
+  }
+
+  const token = await signProxyToken({
+    ip: getClientIpFromRequest(request),
+    method,
+    path: backendUrl.pathname,
+  })
+
+  if (token) {
+    outbound.set(PROXY_AUTH_HEADER, token)
+  }
+}


### PR DESCRIPTION
The frontend proxy reads the real client IP from Vercel's headers, signs it into a short-lived HMAC-SHA256 JWT bound to the specific request method and path, and attaches it as `X-Frontend-Auth`. The backend middleware verifies the signature on every request and stores the attested IP in `HttpContext.Items`, where `IClientIpAccessor` reads it — so the backend never trusts `X-Forwarded-For` directly.

Closes #133