### PR TITLE
Forgot password 2

### DIFF
--- a/backend/Features/Auth/AuthController.cs
+++ b/backend/Features/Auth/AuthController.cs
@@ -313,7 +313,12 @@ public sealed partial class AuthController(
         var result = await userManager.ResetPasswordAsync(user, token, request.NewPassword);
         if (!result.Succeeded)
         {
-            return BadRequest("Invalid or expired password reset link.");
+            if (result.Errors.Any(e => e.Code == "InvalidToken"))
+            {
+                return BadRequest("Invalid or expired password reset link.");
+            }
+
+            return IdentityValidationProblem(result);
         }
 
         // Auto-confirm email if not already confirmed — a successful reset proves inbox access.

--- a/frontend/components/auth/forgot-password-form.tsx
+++ b/frontend/components/auth/forgot-password-form.tsx
@@ -22,16 +22,23 @@ export function ForgotPasswordForm() {
     mode: "onTouched",
   })
 
-  const { isSubmitting, isSubmitSuccessful } = form.formState
+  const { isSubmitting, isSubmitSuccessful, errors } = form.formState
 
   async function onSubmit(values: ForgotPasswordFormValues) {
-    await fetch(AUTH_API_PATHS.forgotPassword, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ email: values.email }),
-      cache: "no-store",
-    })
-    // Always treat as success to prevent email enumeration.
+    try {
+      await fetch(AUTH_API_PATHS.forgotPassword, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email: values.email }),
+        cache: "no-store",
+      })
+      // Always treat HTTP responses as success to prevent email enumeration.
+    } catch {
+      form.setError("root", {
+        message:
+          "Unable to send the request. Please check your connection and try again.",
+      })
+    }
   }
 
   function handleFormSubmit(event: SubmitEvent<HTMLFormElement>) {
@@ -72,6 +79,12 @@ export function ForgotPasswordForm() {
           placeholder="you@example.com"
           description="We'll send a reset link if that address is registered."
         />
+
+        {errors.root ? (
+          <p role="alert" className="text-sm font-medium text-destructive">
+            {errors.root.message}
+          </p>
+        ) : null}
 
         <Button type="submit" disabled={isSubmitting} className="mt-2">
           {isSubmitting ? "Sending..." : "Send reset link"}

--- a/frontend/components/auth/forgot-password-form.tsx
+++ b/frontend/components/auth/forgot-password-form.tsx
@@ -33,11 +33,12 @@ export function ForgotPasswordForm() {
         cache: "no-store",
       })
       // Always treat HTTP responses as success to prevent email enumeration.
-    } catch {
+    } catch (err) {
       form.setError("root", {
         message:
           "Unable to send the request. Please check your connection and try again.",
       })
+      throw err
     }
   }
 

--- a/frontend/components/auth/reset-password-form.tsx
+++ b/frontend/components/auth/reset-password-form.tsx
@@ -82,28 +82,56 @@ export function ResetPasswordForm() {
   }
 
   async function onSubmit(values: ResetPasswordFormValues) {
-    form.clearErrors("root")
-    const response = await fetch(AUTH_API_PATHS.resetPassword, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        userId,
-        token,
-        newPassword: values.newPassword,
-      }),
-      cache: "no-store",
-    })
-
-    if (!response.ok) {
+    form.clearErrors()
+    let response: Response
+    try {
+      response = await fetch(AUTH_API_PATHS.resetPassword, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          userId,
+          token,
+          newPassword: values.newPassword,
+        }),
+        cache: "no-store",
+      })
+    } catch {
       form.setError("root", {
         message:
-          "This link is invalid or has expired. Please request a new one.",
+          "Unable to send the request. Please check your connection and try again.",
       })
       return
     }
 
-    setSucceeded(true)
-    toast.success("Password updated successfully.")
+    if (response.ok) {
+      setSucceeded(true)
+      toast.success("Password updated successfully.")
+      return
+    }
+
+    if (response.status === 422) {
+      let body: unknown
+      try {
+        body = await response.json()
+      } catch {
+        body = undefined
+      }
+      const errors =
+        typeof body === "object" && body !== null
+          ? (body as { errors?: Record<string, string[]> }).errors
+          : undefined
+      const firstError = errors
+        ? Object.values(errors).find((msgs) => msgs.length > 0)?.[0]
+        : undefined
+      form.setError("newPassword", {
+        message: firstError ?? "The password does not meet the requirements.",
+      })
+      return
+    }
+
+    form.setError("root", {
+      message: "This link is invalid or has expired. Please request a new one.",
+    })
   }
 
   function handleFormSubmit(event: SubmitEvent<HTMLFormElement>) {

--- a/frontend/components/auth/reset-password-form.tsx
+++ b/frontend/components/auth/reset-password-form.tsx
@@ -109,7 +109,7 @@ export function ResetPasswordForm() {
       return
     }
 
-    if (response.status === 422) {
+    if (response.status === 400 || response.status === 422) {
       let body: unknown
       try {
         body = await response.json()

--- a/frontend/lib/auth/constants.ts
+++ b/frontend/lib/auth/constants.ts
@@ -30,8 +30,9 @@ export const APP_AUTH_ROUTES = {
   forgotPassword: "/login/forgot",
   register: "/register",
   verifyEmail: "/verify-email",
-  resetPassword: "/reset-password",
 } as const
+
+export const APP_RESET_PASSWORD_ROUTE = "/reset-password" as const
 
 export const APP_HOME_ROUTES = {
   admin: "/admin",


### PR DESCRIPTION
Address PR reviewes of #195 : network error handling and reset-password routing (I may have forgotten to push it 😄 )

- Remove /reset-password from APP_AUTH_ROUTES so authenticated users following an emailed reset link are not redirected away
- Wrap forgot-password fetch in try/catch; show root error on network failure while keeping non-enumerating success for HTTP responses
- Wrap reset-password fetch in try/catch; handle 422 (password policy) separately from 400 (invalid token) so the right field gets the error
- Map non-token IdentityResult failures in ResetPasswordAsync to ValidationProblem instead of the generic "invalid link" message