### PR TITLE
Messaging

### DIFF
--- a/backend.Tests/ConversationsControllerTests.cs
+++ b/backend.Tests/ConversationsControllerTests.cs
@@ -273,7 +273,7 @@ public sealed class ConversationsControllerTests
             Title = "Test task",
             Description = "Description",
             CompensationType = CompensationType.Voluntary,
-            Status = TaskStatus.Open,
+            Status = Backend.Domain.Enums.TaskStatus.Open,
             CreatedAt = DateTimeOffset.UtcNow,
             UpdatedAt = DateTimeOffset.UtcNow,
         };

--- a/backend.Tests/ConversationsControllerTests.cs
+++ b/backend.Tests/ConversationsControllerTests.cs
@@ -1,0 +1,296 @@
+using System.Security.Claims;
+using Backend.Domain.Entities;
+using Backend.Domain.Enums;
+using Backend.Features.Conversations;
+using Backend.Infrastructure.Persistence;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace backend.Tests;
+
+public sealed class ConversationsControllerTests
+{
+    // ── HasUnread calculation ────────────────────────────────────────────────
+
+    [Fact]
+    public async Task ListAsync_ReturnsHasUnreadTrue_WhenLastReadAtIsNull()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await using var db = CreateDbContext();
+
+        var (seeker, helper, conversation) = await SeedConversationAsync(db, ct);
+        conversation.LastMessageAt = DateTimeOffset.UtcNow;
+        conversation.SeekerLastReadAt = null;
+        await db.SaveChangesAsync(ct);
+
+        var controller = CreateController(db, seeker.UserId);
+        var result = await controller.ListAsync(ct);
+
+        var ok = Assert.IsType<OkObjectResult>(result);
+        var previews = Assert.IsAssignableFrom<IEnumerable<ConversationPreviewResponse>>(ok.Value);
+        var preview = Assert.Single(previews);
+        Assert.True(preview.HasUnread);
+    }
+
+    [Fact]
+    public async Task ListAsync_ReturnsHasUnreadTrue_WhenLastMessageAtIsAfterLastReadAt()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await using var db = CreateDbContext();
+
+        var base_ = DateTimeOffset.UtcNow;
+        var (seeker, helper, conversation) = await SeedConversationAsync(db, ct);
+        conversation.LastMessageAt = base_.AddMinutes(1);
+        conversation.SeekerLastReadAt = base_;
+        await db.SaveChangesAsync(ct);
+
+        var controller = CreateController(db, seeker.UserId);
+        var result = await controller.ListAsync(ct);
+
+        var ok = Assert.IsType<OkObjectResult>(result);
+        var previews = Assert.IsAssignableFrom<IEnumerable<ConversationPreviewResponse>>(ok.Value);
+        Assert.True(Assert.Single(previews).HasUnread);
+    }
+
+    [Fact]
+    public async Task ListAsync_ReturnsHasUnreadFalse_WhenLastReadAtIsAfterLastMessageAt()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await using var db = CreateDbContext();
+
+        var base_ = DateTimeOffset.UtcNow;
+        var (seeker, helper, conversation) = await SeedConversationAsync(db, ct);
+        conversation.LastMessageAt = base_;
+        conversation.SeekerLastReadAt = base_.AddSeconds(1);
+        await db.SaveChangesAsync(ct);
+
+        var controller = CreateController(db, seeker.UserId);
+        var result = await controller.ListAsync(ct);
+
+        var ok = Assert.IsType<OkObjectResult>(result);
+        var previews = Assert.IsAssignableFrom<IEnumerable<ConversationPreviewResponse>>(ok.Value);
+        Assert.False(Assert.Single(previews).HasUnread);
+    }
+
+    [Fact]
+    public async Task ListAsync_ReturnsHasUnreadFalse_WhenNoMessagesSent()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await using var db = CreateDbContext();
+
+        var (seeker, _, _) = await SeedConversationAsync(db, ct);
+
+        var controller = CreateController(db, seeker.UserId);
+        var result = await controller.ListAsync(ct);
+
+        var ok = Assert.IsType<OkObjectResult>(result);
+        var previews = Assert.IsAssignableFrom<IEnumerable<ConversationPreviewResponse>>(ok.Value);
+        Assert.False(Assert.Single(previews).HasUnread);
+    }
+
+    [Fact]
+    public async Task ListAsync_ComputesHasUnreadPerUser_SeekerAndHelperIndependently()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await using var db = CreateDbContext();
+
+        var base_ = DateTimeOffset.UtcNow;
+        var (seeker, helper, conversation) = await SeedConversationAsync(db, ct);
+        conversation.LastMessageAt = base_.AddMinutes(1);
+        conversation.SeekerLastReadAt = base_.AddMinutes(2); // seeker already read it
+        conversation.HelperLastReadAt = null;                // helper has not
+        await db.SaveChangesAsync(ct);
+
+        var seekerController = CreateController(db, seeker.UserId);
+        var seekerResult = await seekerController.ListAsync(ct);
+        var seekerOk = Assert.IsType<OkObjectResult>(seekerResult);
+        var seekerPreviews = Assert.IsAssignableFrom<IEnumerable<ConversationPreviewResponse>>(seekerOk.Value);
+        Assert.False(Assert.Single(seekerPreviews).HasUnread);
+
+        var helperController = CreateController(db, helper.UserId);
+        var helperResult = await helperController.ListAsync(ct);
+        var helperOk = Assert.IsType<OkObjectResult>(helperResult);
+        var helperPreviews = Assert.IsAssignableFrom<IEnumerable<ConversationPreviewResponse>>(helperOk.Value);
+        Assert.True(Assert.Single(helperPreviews).HasUnread);
+    }
+
+    // ── MarkReadAsync ────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task MarkReadAsync_UpdatesSeekerLastReadAt_WhenCallerIsSeeker()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await using var db = CreateDbContext();
+
+        var (seeker, _, conversation) = await SeedConversationAsync(db, ct);
+
+        var controller = CreateController(db, seeker.UserId);
+        var result = await controller.MarkReadAsync(conversation.Id, ct);
+
+        Assert.IsType<NoContentResult>(result);
+
+        var updated = await db.TaskConversations.FindAsync([conversation.Id], ct);
+        Assert.NotNull(updated!.SeekerLastReadAt);
+        Assert.Null(updated.HelperLastReadAt);
+    }
+
+    [Fact]
+    public async Task MarkReadAsync_UpdatesHelperLastReadAt_WhenCallerIsHelper()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await using var db = CreateDbContext();
+
+        var (_, helper, conversation) = await SeedConversationAsync(db, ct);
+
+        var controller = CreateController(db, helper.UserId);
+        var result = await controller.MarkReadAsync(conversation.Id, ct);
+
+        Assert.IsType<NoContentResult>(result);
+
+        var updated = await db.TaskConversations.FindAsync([conversation.Id], ct);
+        Assert.NotNull(updated!.HelperLastReadAt);
+        Assert.Null(updated.SeekerLastReadAt);
+    }
+
+    [Fact]
+    public async Task MarkReadAsync_ReturnsForbid_WhenCallerIsNotParticipant()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await using var db = CreateDbContext();
+
+        var (_, _, conversation) = await SeedConversationAsync(db, ct);
+
+        var outsider = CreateProfile("Outsider");
+        db.Profiles.Add(outsider);
+        await db.SaveChangesAsync(ct);
+
+        var controller = CreateController(db, outsider.UserId);
+        var result = await controller.MarkReadAsync(conversation.Id, ct);
+
+        Assert.IsType<ForbidResult>(result);
+    }
+
+    [Fact]
+    public async Task MarkReadAsync_ReturnsNotFound_WhenConversationDoesNotExist()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await using var db = CreateDbContext();
+
+        var profile = CreateProfile("User");
+        db.Profiles.Add(profile);
+        await db.SaveChangesAsync(ct);
+
+        var controller = CreateController(db, profile.UserId);
+        var result = await controller.MarkReadAsync(Guid.NewGuid(), ct);
+
+        Assert.IsType<NotFoundResult>(result);
+    }
+
+    // ── GetMessagesAsync access control ──────────────────────────────────────
+
+    [Fact]
+    public async Task GetMessagesAsync_ReturnsForbid_WhenCallerIsNotParticipant()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await using var db = CreateDbContext();
+
+        var (_, _, conversation) = await SeedConversationAsync(db, ct);
+
+        var outsider = CreateProfile("Outsider");
+        db.Profiles.Add(outsider);
+        await db.SaveChangesAsync(ct);
+
+        var controller = CreateController(db, outsider.UserId);
+        var result = await controller.GetMessagesAsync(conversation.Id, ct);
+
+        Assert.IsType<ForbidResult>(result);
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    private static AppDbContext CreateDbContext()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString(), o => o.EnableNullChecks(false))
+            .Options;
+        return new AppDbContext(options);
+    }
+
+    private static ConversationsController CreateController(AppDbContext db, Guid userId) =>
+        new(db, null!, null!)
+        {
+            ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext
+                {
+                    User = new ClaimsPrincipal(new ClaimsIdentity(
+                    [
+                        new Claim(ClaimTypes.NameIdentifier, userId.ToString()),
+                    ], "TestAuth")),
+                },
+            },
+        };
+
+    private static UserProfile CreateProfile(string displayName) => new()
+    {
+        Id = Guid.NewGuid(),
+        UserId = Guid.NewGuid(),
+        DisplayName = displayName,
+        CreatedAt = DateTimeOffset.UtcNow,
+        UpdatedAt = DateTimeOffset.UtcNow,
+    };
+
+    private static async Task<(UserProfile Seeker, UserProfile Helper, TaskConversation Conversation)>
+        SeedConversationAsync(AppDbContext db, CancellationToken ct)
+    {
+        var seeker = CreateProfile("Seeker");
+        var helper = CreateProfile("Helper");
+
+        var categoryId = Guid.NewGuid();
+        db.Categories.Add(new Category
+        {
+            Id = categoryId,
+            Code = "test",
+            Name = "Test",
+            Icon = Category.DefaultIcon,
+            IsActive = true,
+            CreatedAt = DateTimeOffset.UtcNow,
+            UpdatedAt = DateTimeOffset.UtcNow,
+        });
+
+        db.Profiles.Add(seeker);
+        db.Profiles.Add(helper);
+        await db.SaveChangesAsync(ct);
+
+        var task = new CommunityTask
+        {
+            Id = Guid.NewGuid(),
+            SeekerProfileId = seeker.Id,
+            CategoryId = categoryId,
+            Title = "Test task",
+            Description = "Description",
+            CompensationType = CompensationType.Voluntary,
+            Status = TaskStatus.Open,
+            CreatedAt = DateTimeOffset.UtcNow,
+            UpdatedAt = DateTimeOffset.UtcNow,
+        };
+        db.Tasks.Add(task);
+
+        var conversation = new TaskConversation
+        {
+            Id = Guid.NewGuid(),
+            TaskId = task.Id,
+            SeekerProfileId = seeker.Id,
+            HelperProfileId = helper.Id,
+            CosmosConversationId = Guid.NewGuid().ToString(),
+            CreatedAt = DateTimeOffset.UtcNow,
+        };
+        db.TaskConversations.Add(conversation);
+
+        await db.SaveChangesAsync(ct);
+        return (seeker, helper, conversation);
+    }
+}

--- a/backend.Tests/ConversationsControllerTests.cs
+++ b/backend.Tests/ConversationsControllerTests.cs
@@ -206,7 +206,7 @@ public sealed class ConversationsControllerTests
         await db.SaveChangesAsync(ct);
 
         var controller = CreateController(db, outsider.UserId);
-        var result = await controller.GetMessagesAsync(conversation.Id, ct);
+        var result = await controller.GetMessagesAsync(conversation.Id, null, 0, ct);
 
         Assert.IsType<ForbidResult>(result);
     }

--- a/backend.Tests/ConversationsControllerTests.cs
+++ b/backend.Tests/ConversationsControllerTests.cs
@@ -5,7 +5,6 @@ using Backend.Features.Conversations;
 using Backend.Infrastructure.Persistence;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.SignalR;
 using Microsoft.EntityFrameworkCore;
 using Xunit;
 
@@ -21,7 +20,7 @@ public sealed class ConversationsControllerTests
         var ct = TestContext.Current.CancellationToken;
         await using var db = CreateDbContext();
 
-        var (seeker, helper, conversation) = await SeedConversationAsync(db, ct);
+        (UserProfile seeker, _, TaskConversation conversation) = await SeedConversationAsync(db, ct);
         conversation.LastMessageAt = DateTimeOffset.UtcNow;
         conversation.SeekerLastReadAt = null;
         await db.SaveChangesAsync(ct);
@@ -41,8 +40,9 @@ public sealed class ConversationsControllerTests
         var ct = TestContext.Current.CancellationToken;
         await using var db = CreateDbContext();
 
+        // ReSharper disable once InconsistentNaming
         var base_ = DateTimeOffset.UtcNow;
-        var (seeker, helper, conversation) = await SeedConversationAsync(db, ct);
+        (UserProfile seeker, _, TaskConversation conversation) = await SeedConversationAsync(db, ct);
         conversation.LastMessageAt = base_.AddMinutes(1);
         conversation.SeekerLastReadAt = base_;
         await db.SaveChangesAsync(ct);
@@ -51,7 +51,7 @@ public sealed class ConversationsControllerTests
         var result = await controller.ListAsync(ct);
 
         var ok = Assert.IsType<OkObjectResult>(result);
-        var previews = Assert.IsAssignableFrom<IEnumerable<ConversationPreviewResponse>>(ok.Value);
+        var previews = Assert.IsType<IEnumerable<ConversationPreviewResponse>>(ok.Value, exactMatch: false);
         Assert.True(Assert.Single(previews).HasUnread);
     }
 
@@ -61,8 +61,9 @@ public sealed class ConversationsControllerTests
         var ct = TestContext.Current.CancellationToken;
         await using var db = CreateDbContext();
 
+        // ReSharper disable once InconsistentNaming
         var base_ = DateTimeOffset.UtcNow;
-        var (seeker, helper, conversation) = await SeedConversationAsync(db, ct);
+        (UserProfile seeker, _, TaskConversation conversation) = await SeedConversationAsync(db, ct);
         conversation.LastMessageAt = base_;
         conversation.SeekerLastReadAt = base_.AddSeconds(1);
         await db.SaveChangesAsync(ct);
@@ -71,7 +72,7 @@ public sealed class ConversationsControllerTests
         var result = await controller.ListAsync(ct);
 
         var ok = Assert.IsType<OkObjectResult>(result);
-        var previews = Assert.IsAssignableFrom<IEnumerable<ConversationPreviewResponse>>(ok.Value);
+        var previews = Assert.IsType<IEnumerable<ConversationPreviewResponse>>(ok.Value, exactMatch: false);
         Assert.False(Assert.Single(previews).HasUnread);
     }
 
@@ -97,8 +98,9 @@ public sealed class ConversationsControllerTests
         var ct = TestContext.Current.CancellationToken;
         await using var db = CreateDbContext();
 
+        // ReSharper disable once InconsistentNaming
         var base_ = DateTimeOffset.UtcNow;
-        var (seeker, helper, conversation) = await SeedConversationAsync(db, ct);
+        (UserProfile seeker, UserProfile helper, TaskConversation conversation) = await SeedConversationAsync(db, ct);
         conversation.LastMessageAt = base_.AddMinutes(1);
         conversation.SeekerLastReadAt = base_.AddMinutes(2); // seeker already read it
         conversation.HelperLastReadAt = null;                // helper has not
@@ -113,7 +115,7 @@ public sealed class ConversationsControllerTests
         var helperController = CreateController(db, helper.UserId);
         var helperResult = await helperController.ListAsync(ct);
         var helperOk = Assert.IsType<OkObjectResult>(helperResult);
-        var helperPreviews = Assert.IsAssignableFrom<IEnumerable<ConversationPreviewResponse>>(helperOk.Value);
+        var helperPreviews = Assert.IsType<IEnumerable<ConversationPreviewResponse>>(helperOk.Value, exactMatch: false);
         Assert.True(Assert.Single(helperPreviews).HasUnread);
     }
 
@@ -125,7 +127,7 @@ public sealed class ConversationsControllerTests
         var ct = TestContext.Current.CancellationToken;
         await using var db = CreateDbContext();
 
-        var (seeker, _, conversation) = await SeedConversationAsync(db, ct);
+        (UserProfile seeker, _, TaskConversation conversation) = await SeedConversationAsync(db, ct);
 
         var controller = CreateController(db, seeker.UserId);
         var result = await controller.MarkReadAsync(conversation.Id, ct);
@@ -143,7 +145,7 @@ public sealed class ConversationsControllerTests
         var ct = TestContext.Current.CancellationToken;
         await using var db = CreateDbContext();
 
-        var (_, helper, conversation) = await SeedConversationAsync(db, ct);
+        (_, UserProfile helper, TaskConversation conversation) = await SeedConversationAsync(db, ct);
 
         var controller = CreateController(db, helper.UserId);
         var result = await controller.MarkReadAsync(conversation.Id, ct);
@@ -161,7 +163,7 @@ public sealed class ConversationsControllerTests
         var ct = TestContext.Current.CancellationToken;
         await using var db = CreateDbContext();
 
-        var (_, _, conversation) = await SeedConversationAsync(db, ct);
+        (_, _, TaskConversation conversation) = await SeedConversationAsync(db, ct);
 
         var outsider = CreateProfile("Outsider");
         db.Profiles.Add(outsider);
@@ -197,7 +199,7 @@ public sealed class ConversationsControllerTests
         var ct = TestContext.Current.CancellationToken;
         await using var db = CreateDbContext();
 
-        var (_, _, conversation) = await SeedConversationAsync(db, ct);
+        (_, _, TaskConversation conversation) = await SeedConversationAsync(db, ct);
 
         var outsider = CreateProfile("Outsider");
         db.Profiles.Add(outsider);

--- a/backend/Domain/Entities/CommunityTask.cs
+++ b/backend/Domain/Entities/CommunityTask.cs
@@ -33,7 +33,7 @@ public sealed class CommunityTask
 
     public ICollection<TaskApplication> Applications { get; } = new List<TaskApplication>();
     public ICollection<TaskCompletionConfirmation> CompletionConfirmations { get; } = new List<TaskCompletionConfirmation>();
-    public TaskConversation? Conversation { get; set; }
+    public ICollection<TaskConversation> Conversations { get; } = new List<TaskConversation>();
     public ICollection<TaskStatusHistoryEntry> StatusHistory { get; } = new List<TaskStatusHistoryEntry>();
     public ICollection<Review> Reviews { get; } = new List<Review>();
     public ICollection<PointsLedgerEntry> PointsLedgerEntries { get; } = new List<PointsLedgerEntry>();

--- a/backend/Domain/Entities/TaskConversation.cs
+++ b/backend/Domain/Entities/TaskConversation.cs
@@ -10,6 +10,8 @@ public sealed class TaskConversation
     public DateTimeOffset CreatedAt { get; set; }
     public string? LastMessageContent { get; set; }
     public DateTimeOffset? LastMessageAt { get; set; }
+    public DateTimeOffset? SeekerLastReadAt { get; set; }
+    public DateTimeOffset? HelperLastReadAt { get; set; }
 
     public CommunityTask Task { get; set; } = null!;
     public UserProfile SeekerProfile { get; set; } = null!;

--- a/backend/Features/Conversations/ChatHub.cs
+++ b/backend/Features/Conversations/ChatHub.cs
@@ -44,4 +44,24 @@ public sealed class ChatHub(AppDbContext db) : Hub
 
         await Groups.AddToGroupAsync(Context.ConnectionId, $"conversation-{id}");
     }
+
+    public async Task JoinUserGroupAsync()
+    {
+        var userIdClaim = Context.User?.FindFirstValue(ClaimTypes.NameIdentifier);
+        if (!Guid.TryParse(userIdClaim, out var userId))
+        {
+            return;
+        }
+
+        var profile = await db.Profiles
+            .AsNoTracking()
+            .FirstOrDefaultAsync(p => p.UserId == userId);
+
+        if (profile is null)
+        {
+            return;
+        }
+
+        await Groups.AddToGroupAsync(Context.ConnectionId, $"user-{profile.Id}");
+    }
 }

--- a/backend/Features/Conversations/ConversationDtos.cs
+++ b/backend/Features/Conversations/ConversationDtos.cs
@@ -49,6 +49,11 @@ public sealed record MessageResponse(
     string SenderDisplayName,
     bool IsMine);
 
+[PublicAPI]
+public sealed record MessagesPageResponse(
+    IEnumerable<MessageResponse> Messages,
+    bool HasMore);
+
 // Sent over SignalR — omits IsMine so each client computes it from SenderProfileId.
 [PublicAPI]
 public sealed record HubMessageEvent(

--- a/backend/Features/Conversations/ConversationDtos.cs
+++ b/backend/Features/Conversations/ConversationDtos.cs
@@ -30,7 +30,15 @@ public sealed record ConversationPreviewResponse(
     string TaskTitle,
     ParticipantInfo OtherParticipant,
     string? LastMessageContent,
-    DateTimeOffset? LastMessageAt);
+    DateTimeOffset? LastMessageAt,
+    bool HasUnread);
+
+// Sent over SignalR to the recipient's personal user group when they receive a new message.
+[PublicAPI]
+public sealed record NewMessageNotification(
+    Guid ConversationId,
+    string SenderDisplayName,
+    string ContentPreview);
 
 [PublicAPI]
 public sealed record MessageResponse(

--- a/backend/Features/Conversations/ConversationsController.cs
+++ b/backend/Features/Conversations/ConversationsController.cs
@@ -98,6 +98,8 @@ public sealed partial class ConversationsController(
                 HelperPhotoUrl = c.HelperProfile.PhotoUrl,
                 c.LastMessageContent,
                 c.LastMessageAt,
+                c.SeekerLastReadAt,
+                c.HelperLastReadAt,
                 c.CreatedAt,
             })
             .OrderByDescending(x => x.LastMessageAt.HasValue ? x.LastMessageAt.Value : x.CreatedAt)
@@ -110,13 +112,18 @@ public sealed partial class ConversationsController(
                 ? new ParticipantInfo(r.HelperProfileId, r.HelperDisplayName, r.HelperPhotoUrl)
                 : new ParticipantInfo(r.SeekerProfileId, r.SeekerDisplayName, r.SeekerPhotoUrl);
 
+            var lastReadAt = isSeeker ? r.SeekerLastReadAt : r.HelperLastReadAt;
+            var hasUnread = r.LastMessageAt.HasValue &&
+                            (lastReadAt is null || r.LastMessageAt.Value > lastReadAt.Value);
+
             return new ConversationPreviewResponse(
                 r.Id,
                 r.TaskId,
                 r.TaskTitle,
                 other,
                 r.LastMessageContent,
-                r.LastMessageAt);
+                r.LastMessageAt,
+                hasUnread);
         });
 
         return Ok(result);
@@ -132,7 +139,6 @@ public sealed partial class ConversationsController(
         }
 
         var conversation = await db.TaskConversations
-            .AsNoTracking()
             .FirstOrDefaultAsync(c => c.Id == id, cancellationToken);
 
         if (conversation is null)
@@ -144,6 +150,18 @@ public sealed partial class ConversationsController(
         {
             return Forbid();
         }
+
+        var now = DateTimeOffset.UtcNow;
+        if (conversation.SeekerProfileId == profile.Id)
+        {
+            conversation.SeekerLastReadAt = now;
+        }
+        else
+        {
+            conversation.HelperLastReadAt = now;
+        }
+
+        await db.SaveChangesAsync(cancellationToken);
 
         var documents = await cosmosMessages.GetByConversationAsync(
             id.ToString(),
@@ -229,6 +247,55 @@ public sealed partial class ConversationsController(
             .Group($"conversation-{id}")
             .SendAsync("ReceiveMessage", hubEvent, cancellationToken);
 
+        var recipientProfileId = conversation.SeekerProfileId == profile.Id
+            ? conversation.HelperProfileId
+            : conversation.SeekerProfileId;
+
+        var notification = new NewMessageNotification(
+            id,
+            profile.DisplayName,
+            document.Content.Length > 100 ? document.Content[..100] : document.Content);
+
+        await chatHub.Clients
+            .Group($"user-{recipientProfileId}")
+            .SendAsync("NewMessageNotification", notification, cancellationToken);
+
         return Ok(response);
+    }
+
+    [HttpPut("{id:guid}/read")]
+    public async Task<IActionResult> MarkReadAsync(Guid id, CancellationToken cancellationToken)
+    {
+        var profile = await GetCurrentProfileAsync(cancellationToken);
+        if (profile is null)
+        {
+            return Unauthorized();
+        }
+
+        var conversation = await db.TaskConversations
+            .FirstOrDefaultAsync(c => c.Id == id, cancellationToken);
+
+        if (conversation is null)
+        {
+            return NotFound();
+        }
+
+        if (conversation.SeekerProfileId != profile.Id && conversation.HelperProfileId != profile.Id)
+        {
+            return Forbid();
+        }
+
+        var now = DateTimeOffset.UtcNow;
+        if (conversation.SeekerProfileId == profile.Id)
+        {
+            conversation.SeekerLastReadAt = now;
+        }
+        else
+        {
+            conversation.HelperLastReadAt = now;
+        }
+
+        await db.SaveChangesAsync(cancellationToken);
+        return NoContent();
     }
 }

--- a/backend/Features/Conversations/ConversationsController.cs
+++ b/backend/Features/Conversations/ConversationsController.cs
@@ -130,8 +130,14 @@ public sealed partial class ConversationsController(
     }
 
     [HttpGet("{id:guid}/messages")]
-    public async Task<IActionResult> GetMessagesAsync(Guid id, CancellationToken cancellationToken)
+    public async Task<IActionResult> GetMessagesAsync(
+        Guid id,
+        [FromQuery] DateTimeOffset? before,
+        [FromQuery] int limit,
+        CancellationToken cancellationToken)
     {
+        limit = limit <= 0 ? 50 : Math.Min(limit, 100);
+
         var profile = await GetCurrentProfileAsync(cancellationToken);
         if (profile is null)
         {
@@ -152,8 +158,10 @@ public sealed partial class ConversationsController(
             return Forbid();
         }
 
-        var documents = await cosmosMessages.GetByConversationAsync(
+        var (documents, hasMore) = await cosmosMessages.GetByConversationAsync(
             id.ToString(),
+            before,
+            limit,
             cancellationToken);
 
         var messages = documents.Select(d => new MessageResponse(
@@ -164,7 +172,7 @@ public sealed partial class ConversationsController(
             d.SenderDisplayName,
             IsMine: d.SenderProfileId == profile.Id.ToString()));
 
-        return Ok(messages);
+        return Ok(new MessagesPageResponse(messages, hasMore));
     }
 
     [HttpPost("{id:guid}/messages")]

--- a/backend/Features/Conversations/ConversationsController.cs
+++ b/backend/Features/Conversations/ConversationsController.cs
@@ -139,6 +139,7 @@ public sealed partial class ConversationsController(
         }
 
         var conversation = await db.TaskConversations
+            .AsNoTracking()
             .FirstOrDefaultAsync(c => c.Id == id, cancellationToken);
 
         if (conversation is null)
@@ -150,18 +151,6 @@ public sealed partial class ConversationsController(
         {
             return Forbid();
         }
-
-        var now = DateTimeOffset.UtcNow;
-        if (conversation.SeekerProfileId == profile.Id)
-        {
-            conversation.SeekerLastReadAt = now;
-        }
-        else
-        {
-            conversation.HelperLastReadAt = now;
-        }
-
-        await db.SaveChangesAsync(cancellationToken);
 
         var documents = await cosmosMessages.GetByConversationAsync(
             id.ToString(),

--- a/backend/Features/Conversations/ConversationsController.cs
+++ b/backend/Features/Conversations/ConversationsController.cs
@@ -219,6 +219,16 @@ public sealed partial class ConversationsController(
             ? document.Content[..500]
             : document.Content;
         conversation.LastMessageAt = document.SentAt;
+
+        if (conversation.SeekerProfileId == profile.Id)
+        {
+            conversation.SeekerLastReadAt = document.SentAt;
+        }
+        else
+        {
+            conversation.HelperLastReadAt = document.SentAt;
+        }
+
         db.AddActivityEvent(
             profile.UserId,
             profile.Id,

--- a/backend/Features/Conversations/CosmosMessageService.cs
+++ b/backend/Features/Conversations/CosmosMessageService.cs
@@ -33,31 +33,43 @@ public sealed class CosmosMessageService(CosmosClient client)
         return response.Resource;
     }
 
-    public async Task<IReadOnlyList<MessageDocument>> GetByConversationAsync(
+    public async Task<(IReadOnlyList<MessageDocument> Messages, bool HasMore)> GetByConversationAsync(
         string conversationId,
+        DateTimeOffset? before,
+        int limit,
         CancellationToken cancellationToken)
     {
         var container = client.GetContainer(DatabaseId, ContainerId);
-        var query = new QueryDefinition(
-            "SELECT * FROM c WHERE c.conversationId = @conversationId ORDER BY c.sentAt ASC")
+
+        var queryText = before.HasValue
+            ? "SELECT * FROM c WHERE c.conversationId = @conversationId AND c.sentAt < @before ORDER BY c.sentAt DESC"
+            : "SELECT * FROM c WHERE c.conversationId = @conversationId ORDER BY c.sentAt DESC";
+
+        var query = new QueryDefinition(queryText)
             .WithParameter("@conversationId", conversationId);
+
+        if (before.HasValue)
+        {
+            query = query.WithParameter("@before", before.Value);
+        }
 
         var options = new QueryRequestOptions
         {
             PartitionKey = new PartitionKey(conversationId),
+            MaxItemCount = limit + 1,
         };
 
         var results = new List<MessageDocument>();
-        using var iterator = container.GetItemQueryIterator<MessageDocument>(
-            query,
-            requestOptions: options);
+        using var iterator = container.GetItemQueryIterator<MessageDocument>(query, requestOptions: options);
 
-        while (iterator.HasMoreResults)
+        while (iterator.HasMoreResults && results.Count < limit + 1)
         {
             var page = await iterator.ReadNextAsync(cancellationToken);
             results.AddRange(page);
         }
 
-        return results;
+        var hasMore = results.Count > limit;
+        var messages = results.Take(limit).Reverse().ToList();
+        return (messages, hasMore);
     }
 }

--- a/backend/Infrastructure/Persistence/Configurations/TaskConfigurations.cs
+++ b/backend/Infrastructure/Persistence/Configurations/TaskConfigurations.cs
@@ -198,10 +198,12 @@ internal sealed class TaskConversationConfiguration : IEntityTypeConfiguration<T
 
         builder.Property(conversation => conversation.LastMessageContent).HasMaxLength(500);
         builder.Property(conversation => conversation.LastMessageAt);
+        builder.Property(conversation => conversation.SeekerLastReadAt);
+        builder.Property(conversation => conversation.HelperLastReadAt);
 
         builder.HasOne(conversation => conversation.Task)
-            .WithOne(task => task.Conversation)
-            .HasForeignKey<TaskConversation>(conversation => conversation.TaskId)
+            .WithMany(task => task.Conversations)
+            .HasForeignKey(conversation => conversation.TaskId)
             .OnDelete(DeleteBehavior.Restrict);
 
         builder.HasOne(conversation => conversation.SeekerProfile)

--- a/backend/Infrastructure/Persistence/Migrations/20260516171930_AddConversationReadTracking.Designer.cs
+++ b/backend/Infrastructure/Persistence/Migrations/20260516171930_AddConversationReadTracking.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Backend.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NetTopologySuite.Geometries;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Backend.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260516171930_AddConversationReadTracking")]
+    partial class AddConversationReadTracking
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -1132,6 +1135,10 @@ namespace Backend.Infrastructure.Persistence.Migrations
                     b.HasIndex("SeekerProfileId")
                         .HasDatabaseName("ix_task_conversations_seeker_profile_id");
 
+                    b.HasIndex("TaskId")
+                        .IsUnique()
+                        .HasDatabaseName("ix_task_conversations_task_id");
+
                     b.HasIndex("TaskId", "HelperProfileId")
                         .IsUnique()
                         .HasDatabaseName("ux_task_conversations_task_helper");
@@ -2003,8 +2010,8 @@ namespace Backend.Infrastructure.Persistence.Migrations
                         .HasConstraintName("fk_task_conversations_profiles_seeker_profile_id");
 
                     b.HasOne("Backend.Domain.Entities.CommunityTask", "Task")
-                        .WithMany("Conversations")
-                        .HasForeignKey("TaskId")
+                        .WithOne("Conversation")
+                        .HasForeignKey("Backend.Domain.Entities.TaskConversation", "TaskId")
                         .OnDelete(DeleteBehavior.Restrict)
                         .IsRequired()
                         .HasConstraintName("fk_task_conversations_tasks_task_id");
@@ -2145,7 +2152,7 @@ namespace Backend.Infrastructure.Persistence.Migrations
 
                     b.Navigation("CompletionConfirmations");
 
-                    b.Navigation("Conversations");
+                    b.Navigation("Conversation");
 
                     b.Navigation("PointsLedgerEntries");
 

--- a/backend/Infrastructure/Persistence/Migrations/20260516171930_AddConversationReadTracking.cs
+++ b/backend/Infrastructure/Persistence/Migrations/20260516171930_AddConversationReadTracking.cs
@@ -24,6 +24,15 @@ namespace Backend.Infrastructure.Persistence.Migrations
                 table: "task_conversations",
                 type: "timestamp with time zone",
                 nullable: true);
+
+            // Backfill: treat existing messages as already read so deployment
+            // doesn't flood all users with false unread indicators.
+            migrationBuilder.Sql(@"
+                UPDATE data.task_conversations
+                SET seeker_last_read_at = last_message_at,
+                    helper_last_read_at = last_message_at
+                WHERE last_message_at IS NOT NULL;
+            ");
         }
 
         /// <inheritdoc />

--- a/backend/Infrastructure/Persistence/Migrations/20260516171930_AddConversationReadTracking.cs
+++ b/backend/Infrastructure/Persistence/Migrations/20260516171930_AddConversationReadTracking.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Backend.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddConversationReadTracking : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "helper_last_read_at",
+                schema: "data",
+                table: "task_conversations",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "seeker_last_read_at",
+                schema: "data",
+                table: "task_conversations",
+                type: "timestamp with time zone",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "helper_last_read_at",
+                schema: "data",
+                table: "task_conversations");
+
+            migrationBuilder.DropColumn(
+                name: "seeker_last_read_at",
+                schema: "data",
+                table: "task_conversations");
+        }
+    }
+}

--- a/backend/Infrastructure/Persistence/Migrations/20260516184153_AllowMultipleConversationsPerTask.Designer.cs
+++ b/backend/Infrastructure/Persistence/Migrations/20260516184153_AllowMultipleConversationsPerTask.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Backend.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NetTopologySuite.Geometries;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Backend.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260516184153_AllowMultipleConversationsPerTask")]
+    partial class AllowMultipleConversationsPerTask
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/Infrastructure/Persistence/Migrations/20260516184153_AllowMultipleConversationsPerTask.cs
+++ b/backend/Infrastructure/Persistence/Migrations/20260516184153_AllowMultipleConversationsPerTask.cs
@@ -1,0 +1,30 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Backend.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AllowMultipleConversationsPerTask : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "ix_task_conversations_task_id",
+                schema: "data",
+                table: "task_conversations");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateIndex(
+                name: "ix_task_conversations_task_id",
+                schema: "data",
+                table: "task_conversations",
+                column: "task_id",
+                unique: true);
+        }
+    }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,6 +63,7 @@ services:
     volumes:
       - ./frontend:/app
       - frontend_node_modules:/app/node_modules
+      - frontend_next:/app/.next
     environment:
       API_URL: http://backend:8080
       NEXT_PUBLIC_BACKEND_URL: ${NEXT_PUBLIC_BACKEND_URL:-http://localhost:8080}
@@ -74,3 +75,4 @@ volumes:
   cosmos_data:
   backend_obj:
   frontend_node_modules:
+  frontend_next:

--- a/frontend/app/(main)/layout.tsx
+++ b/frontend/app/(main)/layout.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from "react"
 
 import { AppHeader } from "@/components/layout/app-header"
 import { MobileNav } from "@/components/layout/mobile-nav"
+import { NotificationHubMount } from "@/components/layout/notification-hub-mount"
 
 /**
  * Layout for every authenticated route. Renders the persistent header
@@ -13,6 +14,7 @@ import { MobileNav } from "@/components/layout/mobile-nav"
 export default function MainLayout({ children }: { children: ReactNode }) {
   return (
     <div className="flex min-h-svh flex-col">
+      <NotificationHubMount />
       <AppHeader />
       <main className="flex-1 pb-20 md:pb-10">
         <div className="mx-auto w-full max-w-6xl px-4 py-6 sm:px-6">

--- a/frontend/app/(main)/messages/[chatId]/page.client.tsx
+++ b/frontend/app/(main)/messages/[chatId]/page.client.tsx
@@ -22,8 +22,15 @@ export function ChatPageClient({ chatId }: ChatPageClientProps) {
     isLoading: listLoading,
     isFetching: listFetching,
   } = useConversations()
-  const { data: messages = [], isLoading: messagesLoading } =
-    useConversationMessages(chatId)
+  const {
+    data: messagesData,
+    isLoading: messagesLoading,
+    hasPreviousPage,
+    fetchPreviousPage,
+    isFetchingPreviousPage,
+  } = useConversationMessages(chatId)
+
+  const messages = messagesData?.pages.flatMap((p) => p.messages) ?? []
   const { mutate: markRead } = useMarkConversationRead()
 
   React.useEffect(() => {
@@ -50,7 +57,13 @@ export function ChatPageClient({ chatId }: ChatPageClientProps) {
             <p className="text-sm text-muted-foreground">Loading…</p>
           </div>
         ) : conversation ? (
-          <ChatWindow conversation={conversation} messages={messages} />
+          <ChatWindow
+            conversation={conversation}
+            messages={messages}
+            hasPreviousPage={hasPreviousPage}
+            fetchPreviousPage={fetchPreviousPage}
+            isFetchingPreviousPage={isFetchingPreviousPage}
+          />
         ) : null}
       </Card>
     </div>

--- a/frontend/app/(main)/messages/[chatId]/page.client.tsx
+++ b/frontend/app/(main)/messages/[chatId]/page.client.tsx
@@ -31,13 +31,12 @@ export function ChatPageClient({ chatId }: ChatPageClientProps) {
   } = useConversationMessages(chatId)
 
   const messages = messagesData?.pages.flatMap((p) => p.messages) ?? []
+  const lastMessageId = messages[messages.length - 1]?.id
   const { mutate: markRead } = useMarkConversationRead()
 
   React.useEffect(() => {
-    if (chatId) {
-      markRead(chatId)
-    }
-  }, [chatId, markRead])
+    if (chatId) markRead(chatId)
+  }, [chatId, lastMessageId, markRead])
 
   const conversation = conversations.find((c) => c.id === chatId)
 

--- a/frontend/app/(main)/messages/[chatId]/page.client.tsx
+++ b/frontend/app/(main)/messages/[chatId]/page.client.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import * as React from "react"
 import { notFound } from "next/navigation"
 
 import { Card } from "@/components/ui/card"
@@ -8,6 +9,7 @@ import { ChatWindow } from "@/components/messages/chat-window"
 import {
   useConversations,
   useConversationMessages,
+  useMarkConversationRead,
 } from "@/lib/api/conversations"
 
 interface ChatPageClientProps {
@@ -22,6 +24,13 @@ export function ChatPageClient({ chatId }: ChatPageClientProps) {
   } = useConversations()
   const { data: messages = [], isLoading: messagesLoading } =
     useConversationMessages(chatId)
+  const { mutate: markRead } = useMarkConversationRead()
+
+  React.useEffect(() => {
+    if (chatId) {
+      markRead(chatId)
+    }
+  }, [chatId, markRead])
 
   const conversation = conversations.find((c) => c.id === chatId)
 

--- a/frontend/components/layout/main-nav.tsx
+++ b/frontend/components/layout/main-nav.tsx
@@ -33,6 +33,11 @@ export function MainNav({ className }: MainNavProps) {
             key={item.href}
             href={item.href}
             aria-current={active ? "page" : undefined}
+            aria-label={
+              item.href === "/messages" && unreadCount > 0
+                ? `${item.label}, ${unreadCount} unread`
+                : undefined
+            }
             className={cn(
               "flex items-center gap-2 rounded-md px-3 py-1.5 text-sm font-medium transition-colors",
               active

--- a/frontend/components/layout/main-nav.tsx
+++ b/frontend/components/layout/main-nav.tsx
@@ -5,6 +5,7 @@ import { usePathname } from "next/navigation"
 import { HugeiconsIcon } from "@hugeicons/react"
 
 import { PRIMARY_NAV } from "@/lib/nav"
+import { useUnreadCount } from "@/lib/api/conversations"
 import { cn } from "@/lib/utils"
 
 interface MainNavProps {
@@ -19,6 +20,7 @@ interface MainNavProps {
  */
 export function MainNav({ className }: MainNavProps) {
   const pathname = usePathname()
+  const unreadCount = useUnreadCount()
 
   return (
     <nav className={cn("flex items-center gap-1", className)}>
@@ -38,7 +40,12 @@ export function MainNav({ className }: MainNavProps) {
                 : "text-muted-foreground hover:bg-muted/60 hover:text-foreground"
             )}
           >
-            <HugeiconsIcon icon={item.icon} className="size-4" />
+            <span className="relative">
+              <HugeiconsIcon icon={item.icon} className="size-4" />
+              {item.href === "/messages" && unreadCount > 0 && (
+                <span className="absolute -top-1 -right-1 h-2 w-2 rounded-full bg-destructive" />
+              )}
+            </span>
             {item.label}
           </Link>
         )

--- a/frontend/components/layout/mobile-nav.tsx
+++ b/frontend/components/layout/mobile-nav.tsx
@@ -5,6 +5,7 @@ import { usePathname } from "next/navigation"
 import { HugeiconsIcon } from "@hugeicons/react"
 
 import { PRIMARY_NAV } from "@/lib/nav"
+import { useUnreadCount } from "@/lib/api/conversations"
 import { cn } from "@/lib/utils"
 
 /**
@@ -13,6 +14,7 @@ import { cn } from "@/lib/utils"
  */
 export function MobileNav() {
   const pathname = usePathname()
+  const unreadCount = useUnreadCount()
 
   return (
     <nav
@@ -36,7 +38,12 @@ export function MobileNav() {
                     : "text-muted-foreground hover:text-foreground"
                 )}
               >
-                <HugeiconsIcon icon={item.icon} className="size-5" />
+                <span className="relative">
+                  <HugeiconsIcon icon={item.icon} className="size-5" />
+                  {item.href === "/messages" && unreadCount > 0 && (
+                    <span className="absolute -top-1 -right-1 h-2 w-2 rounded-full bg-destructive" />
+                  )}
+                </span>
                 <span className="truncate">{item.label.split(" ")[0]}</span>
               </Link>
             </li>

--- a/frontend/components/layout/mobile-nav.tsx
+++ b/frontend/components/layout/mobile-nav.tsx
@@ -31,6 +31,11 @@ export function MobileNav() {
               <Link
                 href={item.href}
                 aria-current={active ? "page" : undefined}
+                aria-label={
+                  item.href === "/messages" && unreadCount > 0
+                    ? `${item.label}, ${unreadCount} unread`
+                    : undefined
+                }
                 className={cn(
                   "flex flex-col items-center gap-1 px-2 py-2 text-[0.65rem] font-medium transition-colors",
                   active

--- a/frontend/components/layout/notification-hub-mount.tsx
+++ b/frontend/components/layout/notification-hub-mount.tsx
@@ -1,0 +1,10 @@
+"use client"
+
+import { useAuth } from "@/lib/auth-context"
+import { useNotificationHub } from "@/lib/notification-hub"
+
+export function NotificationHubMount() {
+  const { user } = useAuth()
+  useNotificationHub(user?.profileId)
+  return null
+}

--- a/frontend/components/messages/chat-list.tsx
+++ b/frontend/components/messages/chat-list.tsx
@@ -47,7 +47,13 @@ export function ChatList({ conversations, activeId }: ChatListProps) {
                       {c.otherParticipant.displayName}
                     </span>
                     {c.hasUnread && (
-                      <span className="h-2 w-2 shrink-0 rounded-full bg-primary" />
+                      <>
+                        <span
+                          className="h-2 w-2 shrink-0 rounded-full bg-primary"
+                          aria-hidden="true"
+                        />
+                        <span className="sr-only">Unread</span>
+                      </>
                     )}
                   </div>
                   {c.lastMessageAt ? (

--- a/frontend/components/messages/chat-list.tsx
+++ b/frontend/components/messages/chat-list.tsx
@@ -42,9 +42,14 @@ export function ChatList({ conversations, activeId }: ChatListProps) {
               />
               <div className="flex min-w-0 flex-1 flex-col gap-0.5">
                 <div className="flex items-baseline justify-between gap-2">
-                  <span className="truncate text-sm font-medium">
-                    {c.otherParticipant.displayName}
-                  </span>
+                  <div className="flex min-w-0 items-center gap-1.5">
+                    <span className="truncate text-sm font-medium">
+                      {c.otherParticipant.displayName}
+                    </span>
+                    {c.hasUnread && (
+                      <span className="h-2 w-2 shrink-0 rounded-full bg-primary" />
+                    )}
+                  </div>
                   {c.lastMessageAt ? (
                     <span className="shrink-0 text-xs text-muted-foreground">
                       {formatRelativeTime(c.lastMessageAt)}

--- a/frontend/components/messages/chat-window.tsx
+++ b/frontend/components/messages/chat-window.tsx
@@ -42,9 +42,11 @@ export function ChatWindow({
 
   useConversationHub(conversation.id, user?.profileId)
 
+  const lastMessageId = messages[messages.length - 1]?.id
+
   React.useEffect(() => {
     bottomRef.current?.scrollIntoView({ behavior: "smooth" })
-  }, [messages])
+  }, [lastMessageId])
 
   function handleSend(e: SubmitEvent<HTMLFormElement>) {
     e.preventDefault()

--- a/frontend/components/messages/chat-window.tsx
+++ b/frontend/components/messages/chat-window.tsx
@@ -22,9 +22,18 @@ import { useConversationHub } from "@/lib/chat-hub"
 interface ChatWindowProps {
   conversation: ApiConversationPreview
   messages: ApiMessage[]
+  hasPreviousPage: boolean
+  fetchPreviousPage: () => void
+  isFetchingPreviousPage: boolean
 }
 
-export function ChatWindow({ conversation, messages }: ChatWindowProps) {
+export function ChatWindow({
+  conversation,
+  messages,
+  hasPreviousPage,
+  fetchPreviousPage,
+  isFetchingPreviousPage,
+}: ChatWindowProps) {
   const { user } = useAuth()
   const [draft, setDraft] = React.useState("")
   const bottomRef = React.useRef<HTMLDivElement>(null)
@@ -70,6 +79,18 @@ export function ChatWindow({ conversation, messages }: ChatWindowProps) {
 
       <ScrollArea className="flex-1 px-4">
         <div className="flex flex-col gap-2 py-4">
+          {hasPreviousPage && (
+            <div className="flex justify-center py-1">
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={fetchPreviousPage}
+                disabled={isFetchingPreviousPage}
+              >
+                {isFetchingPreviousPage ? "Loading…" : "Load older messages"}
+              </Button>
+            </div>
+          )}
           {messages.length === 0 ? (
             <p className="text-center text-xs text-muted-foreground">
               No messages yet. Say hello!

--- a/frontend/components/messages/chat-window.tsx
+++ b/frontend/components/messages/chat-window.tsx
@@ -28,6 +28,7 @@ export function ChatWindow({ conversation, messages }: ChatWindowProps) {
   const { user } = useAuth()
   const [draft, setDraft] = React.useState("")
   const bottomRef = React.useRef<HTMLDivElement>(null)
+  const inputRef = React.useRef<HTMLInputElement>(null)
   const { mutate: sendMessage, isPending } = useSendMessage(conversation.id)
 
   useConversationHub(conversation.id, user?.profileId)
@@ -41,6 +42,7 @@ export function ChatWindow({ conversation, messages }: ChatWindowProps) {
     const content = draft.trim()
     if (!content) return
     setDraft("")
+    inputRef.current?.focus()
     sendMessage(content)
   }
 
@@ -85,11 +87,11 @@ export function ChatWindow({ conversation, messages }: ChatWindowProps) {
         className="flex items-center gap-2 border-t border-border px-4 py-3"
       >
         <Input
+          ref={inputRef}
           value={draft}
           onChange={(e) => setDraft(e.target.value)}
           placeholder="Message…"
           aria-label="Message"
-          disabled={isPending}
         />
         <Button
           type="submit"

--- a/frontend/lib/api/conversations.ts
+++ b/frontend/lib/api/conversations.ts
@@ -1,4 +1,10 @@
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import {
+  useInfiniteQuery,
+  useMutation,
+  useQuery,
+  useQueryClient,
+  type InfiniteData,
+} from "@tanstack/react-query"
 
 import { apiClient } from "@/lib/api/client"
 
@@ -37,6 +43,11 @@ export interface ApiMessage {
   isMine: boolean
 }
 
+export interface MessagesPage {
+  messages: ApiMessage[]
+  hasMore: boolean
+}
+
 // ── Query keys ────────────────────────────────────────────────────────────────
 
 export const conversationKeys = {
@@ -55,9 +66,19 @@ export function useConversations() {
 }
 
 export function useConversationMessages(id: string) {
-  return useQuery({
+  return useInfiniteQuery({
     queryKey: conversationKeys.messages(id),
-    queryFn: () => apiClient.get<ApiMessage[]>(`/conversations/${id}/messages`),
+    queryFn: ({ pageParam }: { pageParam: string | undefined }) => {
+      const params = new URLSearchParams({ limit: "50" })
+      if (pageParam) params.set("before", pageParam)
+      return apiClient.get<MessagesPage>(
+        `/conversations/${id}/messages?${params.toString()}`
+      )
+    },
+    initialPageParam: undefined as string | undefined,
+    getNextPageParam: () => undefined,
+    getPreviousPageParam: (firstPage) =>
+      firstPage.hasMore ? firstPage.messages[0]?.sentAt : undefined,
     enabled: Boolean(id),
   })
 }
@@ -101,12 +122,24 @@ export function useSendMessage(conversationId: string) {
         content,
       }),
     onSuccess: (message) => {
-      qc.setQueryData<ApiMessage[]>(
+      qc.setQueryData<InfiniteData<MessagesPage>>(
         conversationKeys.messages(conversationId),
         (prev) => {
-          if (!prev) return [message]
-          if (prev.some((m) => m.id === message.id)) return prev
-          return [...prev, message]
+          if (!prev) {
+            return {
+              pages: [{ messages: [message], hasMore: false }],
+              pageParams: [undefined],
+            }
+          }
+          const lastPage = prev.pages[prev.pages.length - 1]
+          if (lastPage.messages.some((m) => m.id === message.id)) return prev
+          return {
+            ...prev,
+            pages: [
+              ...prev.pages.slice(0, -1),
+              { ...lastPage, messages: [...lastPage.messages, message] },
+            ],
+          }
         }
       )
       void qc.invalidateQueries({ queryKey: conversationKeys.list })

--- a/frontend/lib/api/conversations.ts
+++ b/frontend/lib/api/conversations.ts
@@ -25,6 +25,7 @@ export interface ApiConversationPreview {
   otherParticipant: ApiParticipant
   lastMessageContent: string | null
   lastMessageAt: string | null
+  hasUnread: boolean
 }
 
 export interface ApiMessage {
@@ -71,6 +72,26 @@ export function useStartConversation() {
   })
 }
 
+export function useMarkConversationRead() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (conversationId: string) =>
+      apiClient.put<void>(`/conversations/${conversationId}/read`, {}),
+    onSuccess: (_data, conversationId) => {
+      qc.setQueryData<ApiConversationPreview[]>(conversationKeys.list, (prev) =>
+        prev?.map((c) =>
+          c.id === conversationId ? { ...c, hasUnread: false } : c
+        )
+      )
+    },
+  })
+}
+
+export function useUnreadCount(): number {
+  const { data: conversations = [] } = useConversations()
+  return conversations.filter((c) => c.hasUnread).length
+}
+
 export function useSendMessage(conversationId: string) {
   const qc = useQueryClient()
   return useMutation({
@@ -81,7 +102,11 @@ export function useSendMessage(conversationId: string) {
     onSuccess: (message) => {
       qc.setQueryData<ApiMessage[]>(
         conversationKeys.messages(conversationId),
-        (prev) => (prev ? [...prev, message] : [message])
+        (prev) => {
+          if (!prev) return [message]
+          if (prev.some((m) => m.id === message.id)) return prev
+          return [...prev, message]
+        }
       )
       void qc.invalidateQueries({ queryKey: conversationKeys.list })
     },

--- a/frontend/lib/api/conversations.ts
+++ b/frontend/lib/api/conversations.ts
@@ -50,6 +50,7 @@ export function useConversations() {
   return useQuery({
     queryKey: conversationKeys.list,
     queryFn: () => apiClient.get<ApiConversationPreview[]>("/conversations"),
+    staleTime: 60_000,
   })
 }
 

--- a/frontend/lib/chat-hub.ts
+++ b/frontend/lib/chat-hub.ts
@@ -2,10 +2,10 @@
 
 import * as React from "react"
 import * as signalR from "@microsoft/signalr"
-import { useQueryClient } from "@tanstack/react-query"
+import { useQueryClient, type InfiniteData } from "@tanstack/react-query"
 
 import { conversationKeys } from "@/lib/api/conversations"
-import type { ApiMessage } from "@/lib/api/conversations"
+import type { ApiMessage, MessagesPage } from "@/lib/api/conversations"
 import { fetchSignalRToken } from "@/lib/signalr-token"
 
 export function useConversationHub(
@@ -29,12 +29,24 @@ export function useConversationHub(
         ...msg,
         isMine: msg.senderProfileId === currentProfileId,
       }
-      qc.setQueryData<ApiMessage[]>(
+      qc.setQueryData<InfiniteData<MessagesPage>>(
         conversationKeys.messages(conversationId),
         (prev) => {
-          if (!prev) return [message]
-          if (prev.some((m) => m.id === message.id)) return prev
-          return [...prev, message]
+          if (!prev) {
+            return {
+              pages: [{ messages: [message], hasMore: false }],
+              pageParams: [undefined],
+            }
+          }
+          const lastPage = prev.pages[prev.pages.length - 1]
+          if (lastPage.messages.some((m) => m.id === message.id)) return prev
+          return {
+            ...prev,
+            pages: [
+              ...prev.pages.slice(0, -1),
+              { ...lastPage, messages: [...lastPage.messages, message] },
+            ],
+          }
         }
       )
       void qc.invalidateQueries({ queryKey: conversationKeys.list })

--- a/frontend/lib/chat-hub.ts
+++ b/frontend/lib/chat-hub.ts
@@ -6,20 +6,7 @@ import { useQueryClient } from "@tanstack/react-query"
 
 import { conversationKeys } from "@/lib/api/conversations"
 import type { ApiMessage } from "@/lib/api/conversations"
-import { refreshAccessToken } from "@/lib/auth/token-bridge"
-
-async function fetchToken(): Promise<string> {
-  let res = await fetch("/api/auth/token")
-  if (res.status === 401) {
-    const refreshed = await refreshAccessToken()
-    if (refreshed) {
-      res = await fetch("/api/auth/token")
-    }
-  }
-  if (!res.ok) return ""
-  const data = (await res.json()) as { token: string }
-  return data.token
-}
+import { fetchSignalRToken } from "@/lib/signalr-token"
 
 export function useConversationHub(
   conversationId: string,
@@ -32,7 +19,7 @@ export function useConversationHub(
 
     const connection = new signalR.HubConnectionBuilder()
       .withUrl("/hubs/chat", {
-        accessTokenFactory: fetchToken,
+        accessTokenFactory: fetchSignalRToken,
       })
       .withAutomaticReconnect()
       .build()

--- a/frontend/lib/notification-hub.ts
+++ b/frontend/lib/notification-hub.ts
@@ -5,20 +5,7 @@ import * as signalR from "@microsoft/signalr"
 import { useQueryClient } from "@tanstack/react-query"
 
 import { conversationKeys } from "@/lib/api/conversations"
-import { refreshAccessToken } from "@/lib/auth/token-bridge"
-
-async function fetchToken(): Promise<string> {
-  let res = await fetch("/api/auth/token")
-  if (res.status === 401) {
-    const refreshed = await refreshAccessToken()
-    if (refreshed) {
-      res = await fetch("/api/auth/token")
-    }
-  }
-  if (!res.ok) return ""
-  const data = (await res.json()) as { token: string }
-  return data.token
-}
+import { fetchSignalRToken } from "@/lib/signalr-token"
 
 export function useNotificationHub(profileId: string | undefined) {
   const qc = useQueryClient()
@@ -27,7 +14,7 @@ export function useNotificationHub(profileId: string | undefined) {
     if (!profileId) return
 
     const connection = new signalR.HubConnectionBuilder()
-      .withUrl("/hubs/chat", { accessTokenFactory: fetchToken })
+      .withUrl("/hubs/chat", { accessTokenFactory: fetchSignalRToken })
       .withAutomaticReconnect()
       .build()
 

--- a/frontend/lib/notification-hub.ts
+++ b/frontend/lib/notification-hub.ts
@@ -1,0 +1,54 @@
+"use client"
+
+import * as React from "react"
+import * as signalR from "@microsoft/signalr"
+import { useQueryClient } from "@tanstack/react-query"
+
+import { conversationKeys } from "@/lib/api/conversations"
+import { refreshAccessToken } from "@/lib/auth/token-bridge"
+
+async function fetchToken(): Promise<string> {
+  let res = await fetch("/api/auth/token")
+  if (res.status === 401) {
+    const refreshed = await refreshAccessToken()
+    if (refreshed) {
+      res = await fetch("/api/auth/token")
+    }
+  }
+  if (!res.ok) return ""
+  const data = (await res.json()) as { token: string }
+  return data.token
+}
+
+export function useNotificationHub(profileId: string | undefined) {
+  const qc = useQueryClient()
+
+  React.useEffect(() => {
+    if (!profileId) return
+
+    const connection = new signalR.HubConnectionBuilder()
+      .withUrl("/hubs/chat", { accessTokenFactory: fetchToken })
+      .withAutomaticReconnect()
+      .build()
+
+    connection.on("NewMessageNotification", () => {
+      void qc.invalidateQueries({ queryKey: conversationKeys.list })
+    })
+
+    connection.onreconnected(() => {
+      void connection.invoke("JoinUserGroupAsync")
+      void qc.invalidateQueries({ queryKey: conversationKeys.list })
+    })
+
+    void connection
+      .start()
+      .then(() => connection.invoke("JoinUserGroupAsync"))
+      .catch((err: unknown) => {
+        console.warn("Notification hub connection failed", err)
+      })
+
+    return () => {
+      void connection.stop()
+    }
+  }, [profileId, qc])
+}

--- a/frontend/lib/signalr-token.ts
+++ b/frontend/lib/signalr-token.ts
@@ -1,0 +1,14 @@
+import { refreshAccessToken } from "@/lib/auth/token-bridge"
+
+export async function fetchSignalRToken(): Promise<string> {
+  let res = await fetch("/api/auth/token")
+  if (res.status === 401) {
+    const refreshed = await refreshAccessToken()
+    if (refreshed) {
+      res = await fetch("/api/auth/token")
+    }
+  }
+  if (!res.ok) return ""
+  const data = (await res.json()) as { token: string }
+  return data.token
+}


### PR DESCRIPTION
## Summary
- Adds per-user read/unread indicators on the chat list and nav badge
- Fixes duplicate message flash for the sender (dedup guard in `useSendMessage.onSuccess`)
- Fixes "Could not open chat" for a second helper messaging the same task poster (removes implicit unique constraint on `task_id`)
- Keeps input focused after sending a message
- `GET /api/conversations/{id}/messages` is now read-only; read tracking moved to `PUT /api/conversations/{id}/read`
- Backend controller tests for HasUnread logic, MarkReadAsync column targeting, and non-participant Forbid

## Closes
Closes #56
Closes #57
Closes #46
Closes #47
Closes #48