### PR TITLE
feat(frontend): finish feed and post task flows

### DIFF
--- a/backend.Tests/TasksControllerTests.cs
+++ b/backend.Tests/TasksControllerTests.cs
@@ -79,7 +79,7 @@ public sealed class TasksControllerTests
             latitude: 47.4979,
             longitude: null,
             radiusMeters: 1000,
-            cancellationToken);
+            cancellationToken: cancellationToken);
 
         var badRequest = Assert.IsType<ObjectResult>(result);
         var problem = Assert.IsType<ValidationProblemDetails>(badRequest.Value);

--- a/backend.Tests/TasksControllerTests.cs
+++ b/backend.Tests/TasksControllerTests.cs
@@ -88,6 +88,117 @@ public sealed class TasksControllerTests
     }
 
     [Fact]
+    public async Task ListAsync_PaginatesOrderedTasks_WhenPageIsProvided()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await using var db = CreateInMemoryDbContext();
+        var categoryId = Guid.NewGuid();
+        var profileId = Guid.NewGuid();
+        var now = DateTimeOffset.UtcNow;
+
+        db.Profiles.Add(new UserProfile
+        {
+            Id = profileId,
+            UserId = Guid.NewGuid(),
+            DisplayName = "Task seeker",
+            CreatedAt = now,
+            UpdatedAt = now
+        });
+        db.Categories.Add(new Category
+        {
+            Id = categoryId,
+            Code = "help",
+            Name = "Help",
+            Icon = Category.DefaultIcon,
+            IsActive = true,
+            CreatedAt = now,
+            UpdatedAt = now
+        });
+
+        for (var i = 0; i < 5; i++)
+        {
+            db.Tasks.Add(new CommunityTask
+            {
+                Id = Guid.NewGuid(),
+                SeekerProfileId = profileId,
+                CategoryId = categoryId,
+                Title = $"Task {i}",
+                Description = "Need help with a task.",
+                CompensationType = CompensationType.Voluntary,
+                Status = Backend.Domain.Enums.TaskStatus.Open,
+                CreatedAt = now.AddMinutes(i),
+                UpdatedAt = now.AddMinutes(i)
+            });
+        }
+
+        await db.SaveChangesAsync(cancellationToken);
+
+        var controller = new TasksController(db);
+
+        var result = await controller.ListAsync(
+            status: "Open",
+            categoryId: null,
+            latitude: null,
+            longitude: null,
+            radiusMeters: null,
+            cancellationToken: cancellationToken,
+            page: 2,
+            pageSize: 2);
+
+        var ok = Assert.IsType<OkObjectResult>(result);
+        var tasks = Assert.IsAssignableFrom<IEnumerable<TaskResponse>>(ok.Value).ToArray();
+
+        Assert.Equal(["Task 2", "Task 1"], tasks.Select(task => task.Title));
+    }
+
+    [Fact]
+    public async Task ListAsync_RejectsInvalidPagination()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await using var db = CreateInMemoryDbContext();
+        var controller = new TasksController(db);
+
+        var result = await controller.ListAsync(
+            status: null,
+            categoryId: null,
+            latitude: null,
+            longitude: null,
+            radiusMeters: null,
+            cancellationToken: cancellationToken,
+            page: 0,
+            pageSize: 101);
+
+        var badRequest = Assert.IsType<ObjectResult>(result);
+        var problem = Assert.IsType<ValidationProblemDetails>(badRequest.Value);
+
+        Assert.Contains("page", problem.Errors.Keys);
+        Assert.Contains("pageSize", problem.Errors.Keys);
+    }
+
+    [Fact]
+    public async Task ListAsync_RejectsPaginationOffsetOverflow()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await using var db = CreateInMemoryDbContext();
+        var controller = new TasksController(db);
+
+        var result = await controller.ListAsync(
+            status: null,
+            categoryId: null,
+            latitude: null,
+            longitude: null,
+            radiusMeters: null,
+            cancellationToken: cancellationToken,
+            page: int.MaxValue,
+            pageSize: 100);
+
+        var badRequest = Assert.IsType<ObjectResult>(result);
+        var problem = Assert.IsType<ValidationProblemDetails>(badRequest.Value);
+
+        Assert.Contains("page", problem.Errors.Keys);
+    }
+
+    [Fact]
     public void ProximityQuery_TranslatesToPostgisDWithinAndDistanceOrdering()
     {
         using var db = CreateNpgsqlDbContext();

--- a/backend/Features/Tasks/TasksController.cs
+++ b/backend/Features/Tasks/TasksController.cs
@@ -26,9 +26,9 @@ public sealed partial class TasksController(AppDbContext db) : ControllerBase
         [FromQuery] double? latitude,
         [FromQuery] double? longitude,
         [FromQuery] double? radiusMeters,
-        CancellationToken cancellationToken,
         [FromQuery] int? page = null,
-        [FromQuery] int? pageSize = null)
+        [FromQuery] int? pageSize = null,
+        CancellationToken cancellationToken = default)
     {
         Point? proximityOrigin = null;
         var shouldPage = page.HasValue || pageSize.HasValue;
@@ -93,40 +93,30 @@ public sealed partial class TasksController(AppDbContext db) : ControllerBase
             query = query.Where(task => task.CategoryId == categoryId.Value);
         }
 
-        List<CommunityTask> tasks;
+        IQueryable<CommunityTask> orderedQuery;
         if (proximityOrigin is not null)
         {
             var radius = radiusMeters.GetValueOrDefault();
 
-            IQueryable<CommunityTask> orderedQuery = query
+            orderedQuery = query
                 .Where(task => task.Location != null && task.Location.IsWithinDistance(proximityOrigin, radius))
                 .OrderBy(task => task.Location!.Distance(proximityOrigin))
                 .ThenByDescending(task => task.CreatedAt);
-
-            if (shouldPage)
-            {
-                orderedQuery = orderedQuery
-                    .Skip(skip)
-                    .Take(effectivePageSize);
-            }
-
-            tasks = await orderedQuery
-                .ToListAsync(cancellationToken);
         }
         else
         {
-            IQueryable<CommunityTask> orderedQuery = query.OrderByDescending(task => task.CreatedAt);
-
-            if (shouldPage)
-            {
-                orderedQuery = orderedQuery
-                    .Skip(skip)
-                    .Take(effectivePageSize);
-            }
-
-            tasks = await orderedQuery
-                .ToListAsync(cancellationToken);
+            orderedQuery = query.OrderByDescending(task => task.CreatedAt);
         }
+
+        if (shouldPage)
+        {
+            orderedQuery = orderedQuery
+                .Skip(skip)
+                .Take(effectivePageSize);
+        }
+
+        var tasks = await orderedQuery
+            .ToListAsync(cancellationToken);
 
         return Ok(tasks.Select(TaskResponse.FromTask));
     }

--- a/backend/Features/Tasks/TasksController.cs
+++ b/backend/Features/Tasks/TasksController.cs
@@ -16,6 +16,9 @@ namespace Backend.Features.Tasks;
 [Authorize]
 public sealed partial class TasksController(AppDbContext db) : ControllerBase
 {
+    private const int DefaultPageSize = 20;
+    private const int MaxPageSize = 100;
+
     [HttpGet]
     public async Task<IActionResult> ListAsync(
         [FromQuery] string? status,
@@ -23,9 +26,41 @@ public sealed partial class TasksController(AppDbContext db) : ControllerBase
         [FromQuery] double? latitude,
         [FromQuery] double? longitude,
         [FromQuery] double? radiusMeters,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        [FromQuery] int? page = null,
+        [FromQuery] int? pageSize = null)
     {
         Point? proximityOrigin = null;
+        var shouldPage = page.HasValue || pageSize.HasValue;
+        var effectivePage = page.GetValueOrDefault(1);
+        var effectivePageSize = pageSize.GetValueOrDefault(DefaultPageSize);
+        var skip = 0;
+
+        if (shouldPage)
+        {
+            if (effectivePage < 1)
+            {
+                ModelState.AddModelError(nameof(page), "Page must be greater than or equal to 1.");
+            }
+
+            if (effectivePageSize is < 1 or > MaxPageSize)
+            {
+                ModelState.AddModelError(nameof(pageSize), $"PageSize must be between 1 and {MaxPageSize}.");
+            }
+
+            var offset = ((long)effectivePage - 1) * effectivePageSize;
+            if (offset > int.MaxValue)
+            {
+                ModelState.AddModelError(nameof(page), "Page is too large for the requested page size.");
+            }
+
+            if (!ModelState.IsValid)
+            {
+                return ValidationProblem(ModelState);
+            }
+
+            skip = (int)offset;
+        }
 
         if (latitude.HasValue || longitude.HasValue || radiusMeters.HasValue)
         {
@@ -63,16 +98,33 @@ public sealed partial class TasksController(AppDbContext db) : ControllerBase
         {
             var radius = radiusMeters.GetValueOrDefault();
 
-            tasks = await query
+            IQueryable<CommunityTask> orderedQuery = query
                 .Where(task => task.Location != null && task.Location.IsWithinDistance(proximityOrigin, radius))
                 .OrderBy(task => task.Location!.Distance(proximityOrigin))
-                .ThenByDescending(task => task.CreatedAt)
+                .ThenByDescending(task => task.CreatedAt);
+
+            if (shouldPage)
+            {
+                orderedQuery = orderedQuery
+                    .Skip(skip)
+                    .Take(effectivePageSize);
+            }
+
+            tasks = await orderedQuery
                 .ToListAsync(cancellationToken);
         }
         else
         {
-            tasks = await query
-                .OrderByDescending(task => task.CreatedAt)
+            IQueryable<CommunityTask> orderedQuery = query.OrderByDescending(task => task.CreatedAt);
+
+            if (shouldPage)
+            {
+                orderedQuery = orderedQuery
+                    .Skip(skip)
+                    .Take(effectivePageSize);
+            }
+
+            tasks = await orderedQuery
                 .ToListAsync(cancellationToken);
         }
 

--- a/frontend/app/(main)/feed/page.client.tsx
+++ b/frontend/app/(main)/feed/page.client.tsx
@@ -1,18 +1,42 @@
 "use client"
 
+import * as React from "react"
 import Link from "next/link"
 
 import { Button } from "@/components/ui/button"
 import { PageHeader } from "@/components/shared/page-header"
 import { TaskList } from "@/components/tasks/task-list"
-import { useTaskList } from "@/lib/api/tasks"
+import { useInfiniteTaskList } from "@/lib/api/tasks"
 
 export function FeedPageClient() {
+  const sentinelRef = React.useRef<HTMLDivElement | null>(null)
   const {
-    data: tasks = [],
+    data,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
     isLoading,
     isError,
-  } = useTaskList({ status: "Open" })
+  } = useInfiniteTaskList({ status: "Open" })
+
+  const tasks = React.useMemo(() => data?.pages.flat() ?? [], [data])
+
+  React.useEffect(() => {
+    const sentinel = sentinelRef.current
+    if (!sentinel || !hasNextPage) return
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry?.isIntersecting && !isFetchingNextPage) {
+          void fetchNextPage()
+        }
+      },
+      { rootMargin: "400px 0px" }
+    )
+
+    observer.observe(sentinel)
+    return () => observer.disconnect()
+  }, [fetchNextPage, hasNextPage, isFetchingNextPage])
 
   return (
     <div className="flex flex-col gap-6">
@@ -32,12 +56,35 @@ export function FeedPageClient() {
           Could not load tasks. Please try again.
         </p>
       ) : (
-        <TaskList
-          tasks={tasks}
-          emptyTitle="No open requests right now"
-          emptyDescription="Be the first to post one - your neighbours might be ready to help."
-          hideStatus
-        />
+        <>
+          <TaskList
+            tasks={tasks}
+            emptyTitle="No open requests right now"
+            emptyDescription="Be the first to post one - your neighbours might be ready to help."
+            hideStatus
+          />
+          {tasks.length > 0 ? (
+            <div ref={sentinelRef} className="flex justify-center py-2">
+              {isFetchingNextPage ? (
+                <p className="text-sm text-muted-foreground">
+                  Loading more tasks…
+                </p>
+              ) : hasNextPage ? (
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() => void fetchNextPage()}
+                >
+                  Load more
+                </Button>
+              ) : (
+                <p className="text-sm text-muted-foreground">
+                  You are all caught up.
+                </p>
+              )}
+            </div>
+          ) : null}
+        </>
       )}
     </div>
   )

--- a/frontend/components/tasks/post-task-form.tsx
+++ b/frontend/components/tasks/post-task-form.tsx
@@ -104,6 +104,12 @@ export function PostTaskForm() {
   function handleSubmit(e: SubmitEvent<HTMLFormElement>) {
     e.preventDefault()
 
+    const title = form.title.trim()
+    if (title.length < 3) {
+      toast.error("Title must be at least 3 characters.")
+      return
+    }
+
     const plainText = form.description.replace(/<[^>]*>/g, "").trim()
     if (plainText.length < 10) {
       toast.error("Description must be at least 10 characters.")
@@ -114,14 +120,27 @@ export function PostTaskForm() {
       return
     }
 
+    if (!form.categoryId) {
+      toast.error("Pick a category.")
+      return
+    }
+
     const amount =
       form.compensationType === "paid" && form.compensationAmount
         ? Number(form.compensationAmount)
         : undefined
 
+    if (
+      form.compensationType === "paid" &&
+      (amount === undefined || !Number.isFinite(amount) || amount < 0)
+    ) {
+      toast.error("Enter a valid paid amount.")
+      return
+    }
+
     createTask(
       {
-        title: form.title,
+        title,
         description: form.description,
         categoryId: form.categoryId,
         compensationType: form.compensationType,
@@ -151,6 +170,7 @@ export function PostTaskForm() {
         <Input
           id="title"
           required
+          minLength={3}
           maxLength={160}
           placeholder="e.g. Help carrying boxes to my new apartment"
           value={form.title}
@@ -235,6 +255,8 @@ export function PostTaskForm() {
               id="amount"
               type="number"
               min={0}
+              max={9_999_999_999.99}
+              step="0.01"
               required
               placeholder="e.g. 5000"
               value={form.compensationAmount}

--- a/frontend/lib/api/tasks.ts
+++ b/frontend/lib/api/tasks.ts
@@ -1,4 +1,9 @@
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import {
+  useInfiniteQuery,
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query"
 
 import { apiClient } from "@/lib/api/client"
 
@@ -48,6 +53,11 @@ export interface UpdateTaskInput {
   cancellationReason?: string
 }
 
+export interface TaskListFilters {
+  status?: string
+  categoryId?: string
+}
+
 // ── Query keys ────────────────────────────────────────────────────────────────
 
 export const taskKeys = {
@@ -55,22 +65,38 @@ export const taskKeys = {
   lists: () => [...taskKeys.all, "list"] as const,
   list: (filters: Record<string, string | undefined>) =>
     [...taskKeys.lists(), filters] as const,
+  infiniteList: (
+    filters: Record<string, string | undefined>,
+    pageSize: number
+  ) => [...taskKeys.list(filters), "infinite", pageSize] as const,
   detail: (id: string) => [...taskKeys.all, "detail", id] as const,
 }
 
 // ── Hooks ─────────────────────────────────────────────────────────────────────
 
-export function useTaskList(
-  filters: { status?: string; categoryId?: string } = {}
-) {
-  const params = new URLSearchParams()
-  if (filters.status) params.set("status", filters.status)
-  if (filters.categoryId) params.set("categoryId", filters.categoryId)
-  const qs = params.size > 0 ? `?${params.toString()}` : ""
-
+export function useTaskList(filters: TaskListFilters = {}) {
   return useQuery({
     queryKey: taskKeys.list(filters as Record<string, string | undefined>),
-    queryFn: () => apiClient.get<ApiTask[]>(`/tasks${qs}`),
+    queryFn: () => apiClient.get<ApiTask[]>(buildTaskListPath(filters)),
+  })
+}
+
+export function useInfiniteTaskList(
+  filters: TaskListFilters = {},
+  pageSize = 20
+) {
+  return useInfiniteQuery({
+    queryKey: taskKeys.infiniteList(
+      filters as Record<string, string | undefined>,
+      pageSize
+    ),
+    initialPageParam: 1,
+    queryFn: ({ pageParam }) =>
+      apiClient.get<ApiTask[]>(
+        buildTaskListPath(filters, { page: pageParam, pageSize })
+      ),
+    getNextPageParam: (lastPage, _pages, lastPageParam) =>
+      lastPage.length < pageSize ? undefined : lastPageParam + 1,
   })
 }
 
@@ -103,4 +129,20 @@ export function useUpdateTask(id: string) {
       void qc.invalidateQueries({ queryKey: taskKeys.lists() })
     },
   })
+}
+
+function buildTaskListPath(
+  filters: TaskListFilters,
+  pagination?: { page: number; pageSize: number }
+) {
+  const params = new URLSearchParams()
+  if (filters.status) params.set("status", filters.status)
+  if (filters.categoryId) params.set("categoryId", filters.categoryId)
+  if (pagination) {
+    params.set("page", String(pagination.page))
+    params.set("pageSize", String(pagination.pageSize))
+  }
+
+  const qs = params.size > 0 ? `?${params.toString()}` : ""
+  return `/tasks${qs}`
 }

--- a/frontend/lib/api/tasks.ts
+++ b/frontend/lib/api/tasks.ts
@@ -95,6 +95,8 @@ export function useInfiniteTaskList(
       apiClient.get<ApiTask[]>(
         buildTaskListPath(filters, { page: pageParam, pageSize })
       ),
+    // The API returns a plain array, so a full final page intentionally causes
+    // one extra empty-page fetch before pagination stops.
     getNextPageParam: (lastPage, _pages, lastPageParam) =>
       lastPage.length < pageSize ? undefined : lastPageParam + 1,
   })


### PR DESCRIPTION
## Summary
- add optional task list pagination for feed-sized pages
- switch the seeker feed to infinite loading with an intersection sentinel and manual fallback button
- tighten post-task form validation before create and redirect

## Validation
- dotnet test --configuration Release --no-restore
- dotnet format --verify-no-changes --no-restore
- npm --prefix frontend run lint
- npm --prefix frontend run typecheck
- npm --prefix frontend run build

Closes #37
Closes #38