### PR TITLE
feat(tasks): implement task applications flow

### DIFF
--- a/backend.Tests/AdminAnalyticsControllerTests.cs
+++ b/backend.Tests/AdminAnalyticsControllerTests.cs
@@ -214,6 +214,57 @@ public sealed class AdminAnalyticsControllerTests
         Assert.Equal(1, paidEntry.Count);
     }
 
+    [Fact]
+    public async Task GetTaskApplicationStatusChart_ReturnsGroupedByStatus()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await using var db = CreateDbContext();
+        var (catId, seekerProfileId) = await SeedMinimalRequiredEntities(db, cancellationToken);
+
+        var helperProfileId = Guid.NewGuid();
+        db.Profiles.Add(new UserProfile
+        {
+            Id = helperProfileId,
+            UserId = Guid.NewGuid(),
+            DisplayName = "Helper",
+            IsProfileCompleted = true,
+            CreatedAt = DateTimeOffset.UtcNow,
+            UpdatedAt = DateTimeOffset.UtcNow,
+        });
+
+        var task = MakeTask(catId, seekerProfileId, DomainTaskStatus.Open, CompensationType.Voluntary);
+        db.Tasks.Add(task);
+        db.TaskApplications.Add(new TaskApplication
+        {
+            Id = Guid.NewGuid(),
+            TaskId = task.Id,
+            HelperProfileId = helperProfileId,
+            Status = TaskApplicationStatus.Pending,
+            CreatedAt = DateTimeOffset.UtcNow,
+            UpdatedAt = DateTimeOffset.UtcNow,
+        });
+        db.TaskApplications.Add(new TaskApplication
+        {
+            Id = Guid.NewGuid(),
+            TaskId = task.Id,
+            HelperProfileId = Guid.NewGuid(),
+            Status = TaskApplicationStatus.Rejected,
+            CreatedAt = DateTimeOffset.UtcNow,
+            UpdatedAt = DateTimeOffset.UtcNow,
+        });
+        await db.SaveChangesAsync(cancellationToken);
+
+        var controller = CreateController(db);
+        var result = await controller.GetTaskApplicationStatusChartAsync(cancellationToken);
+
+        var ok = Assert.IsType<OkObjectResult>(result);
+        var response = Assert.IsType<ChartDataResponse>(ok.Value);
+
+        Assert.Equal(2, response.Entries.Count);
+        Assert.Contains(response.Entries, e => e.Label == "Pending" && e.Count == 1);
+        Assert.Contains(response.Entries, e => e.Label == "Rejected" && e.Count == 1);
+    }
+
     private static async Task<(Guid CatId, Guid ProfileId)> SeedMinimalRequiredEntities(
         AppDbContext db,
         CancellationToken cancellationToken)

--- a/backend.Tests/TaskApplicationsControllerTests.cs
+++ b/backend.Tests/TaskApplicationsControllerTests.cs
@@ -1,0 +1,217 @@
+using System.Security.Claims;
+using Backend.Domain.Entities;
+using Backend.Domain.Enums;
+using Backend.Features.Tasks.Applications;
+using Backend.Infrastructure.Persistence;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+using DomainTaskStatus = Backend.Domain.Enums.TaskStatus;
+
+namespace backend.Tests;
+
+public sealed class TaskApplicationsControllerTests
+{
+    [Fact]
+    public async Task ApplyAsync_LogsApplicationActivityAndAuditEvent()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await using var db = CreateDbContext();
+        var scenario = await SeedScenarioAsync(db, cancellationToken);
+        var controller = CreateController(db, scenario.HelperUserId);
+
+        var result = await controller.ApplyAsync(
+            scenario.TaskId,
+            new ApplyToTaskRequest("I can help after work."),
+            cancellationToken);
+
+        Assert.IsType<CreatedResult>(result);
+
+        var activity = Assert.Single(db.ActivityEvents);
+        Assert.Equal(ActivityEventType.TaskApplicationSubmitted, activity.EventType);
+        Assert.Equal(nameof(TaskApplication), activity.EntityType);
+        Assert.Equal(scenario.HelperUserId, activity.UserId);
+
+        var audit = Assert.Single(db.AuditEvents);
+        Assert.Equal("task_application.submitted", audit.EventType);
+        Assert.Equal(nameof(TaskApplication), audit.EntityType);
+        Assert.Equal(scenario.HelperUserId, audit.ActorUserId);
+        Assert.Contains(scenario.TaskId.ToString(), audit.Payload);
+    }
+
+    [Fact]
+    public async Task ListMineAsync_ReturnsApplicationsForCurrentHelper()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await using var db = CreateDbContext();
+        var scenario = await SeedScenarioAsync(db, cancellationToken);
+        db.TaskApplications.Add(new TaskApplication
+        {
+            Id = Guid.NewGuid(),
+            TaskId = scenario.TaskId,
+            HelperProfileId = scenario.HelperProfileId,
+            Message = "Available tomorrow.",
+            Status = TaskApplicationStatus.Pending,
+            CreatedAt = DateTimeOffset.UtcNow,
+            UpdatedAt = DateTimeOffset.UtcNow
+        });
+        await db.SaveChangesAsync(cancellationToken);
+        var controller = CreateController(db, scenario.HelperUserId);
+
+        var result = await controller.ListMineAsync(cancellationToken);
+
+        var ok = Assert.IsType<OkObjectResult>(result);
+        var applications = Assert.IsAssignableFrom<IEnumerable<MyTaskApplicationResponse>>(ok.Value).ToList();
+        var application = Assert.Single(applications);
+        Assert.Equal(scenario.TaskId, application.TaskId);
+        Assert.Equal("Carry boxes", application.Task.Title);
+    }
+
+    [Fact]
+    public async Task PatchAsync_Reject_LogsApplicationActivityAndAuditEvent()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await using var db = CreateDbContext();
+        var scenario = await SeedScenarioAsync(db, cancellationToken);
+        var application = await SeedApplicationAsync(db, scenario, cancellationToken);
+        var controller = CreateController(db, scenario.SeekerUserId);
+
+        var result = await controller.PatchAsync(
+            scenario.TaskId,
+            application.Id,
+            new PatchApplicationRequest("reject"),
+            cancellationToken);
+
+        Assert.IsType<OkObjectResult>(result);
+        Assert.Contains(db.ActivityEvents, e => e.EventType == ActivityEventType.TaskApplicationRejected);
+        Assert.Contains(db.AuditEvents, e => e.EventType == "task_application.rejected");
+    }
+
+    [Fact]
+    public async Task WithdrawAsync_LogsApplicationActivityAndAuditEvent()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await using var db = CreateDbContext();
+        var scenario = await SeedScenarioAsync(db, cancellationToken);
+        var application = await SeedApplicationAsync(db, scenario, cancellationToken);
+        var controller = CreateController(db, scenario.HelperUserId);
+
+        var result = await controller.WithdrawAsync(
+            scenario.TaskId,
+            application.Id,
+            cancellationToken);
+
+        Assert.IsType<NoContentResult>(result);
+        Assert.Contains(db.ActivityEvents, e => e.EventType == ActivityEventType.TaskApplicationWithdrawn);
+        Assert.Contains(db.AuditEvents, e => e.EventType == "task_application.withdrawn");
+    }
+
+    private static async Task<TestScenario> SeedScenarioAsync(
+        AppDbContext db,
+        CancellationToken cancellationToken)
+    {
+        var categoryId = Guid.NewGuid();
+        db.Categories.Add(new Category
+        {
+            Id = categoryId,
+            Code = "moving",
+            Name = "Moving",
+            Icon = Category.DefaultIcon,
+            IsActive = true,
+            CreatedAt = DateTimeOffset.UtcNow,
+            UpdatedAt = DateTimeOffset.UtcNow
+        });
+
+        var seekerUserId = Guid.NewGuid();
+        var seekerProfileId = Guid.NewGuid();
+        db.Profiles.Add(new UserProfile
+        {
+            Id = seekerProfileId,
+            UserId = seekerUserId,
+            DisplayName = "Seeker",
+            CreatedAt = DateTimeOffset.UtcNow,
+            UpdatedAt = DateTimeOffset.UtcNow
+        });
+
+        var helperUserId = Guid.NewGuid();
+        var helperProfileId = Guid.NewGuid();
+        db.Profiles.Add(new UserProfile
+        {
+            Id = helperProfileId,
+            UserId = helperUserId,
+            DisplayName = "Helper",
+            CreatedAt = DateTimeOffset.UtcNow,
+            UpdatedAt = DateTimeOffset.UtcNow
+        });
+
+        var taskId = Guid.NewGuid();
+        db.Tasks.Add(new CommunityTask
+        {
+            Id = taskId,
+            PublicCode = "TASK-TEST-000001",
+            SeekerProfileId = seekerProfileId,
+            CategoryId = categoryId,
+            Title = "Carry boxes",
+            Description = "Need help carrying boxes.",
+            CompensationType = CompensationType.Voluntary,
+            Status = DomainTaskStatus.Open,
+            CreatedAt = DateTimeOffset.UtcNow,
+            UpdatedAt = DateTimeOffset.UtcNow
+        });
+
+        await db.SaveChangesAsync(cancellationToken);
+        return new TestScenario(taskId, seekerUserId, helperUserId, helperProfileId);
+    }
+
+    private static async Task<TaskApplication> SeedApplicationAsync(
+        AppDbContext db,
+        TestScenario scenario,
+        CancellationToken cancellationToken)
+    {
+        var application = new TaskApplication
+        {
+            Id = Guid.NewGuid(),
+            TaskId = scenario.TaskId,
+            HelperProfileId = scenario.HelperProfileId,
+            Status = TaskApplicationStatus.Pending,
+            CreatedAt = DateTimeOffset.UtcNow,
+            UpdatedAt = DateTimeOffset.UtcNow
+        };
+        db.TaskApplications.Add(application);
+        await db.SaveChangesAsync(cancellationToken);
+        return application;
+    }
+
+    private static AppDbContext CreateDbContext()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString(), options => options.EnableNullChecks(false))
+            .Options;
+
+        return new AppDbContext(options);
+    }
+
+    private static TaskApplicationsController CreateController(AppDbContext db, Guid userId)
+    {
+        return new TaskApplicationsController(db)
+        {
+            ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext
+                {
+                    User = new ClaimsPrincipal(new ClaimsIdentity(
+                    [
+                        new Claim(ClaimTypes.NameIdentifier, userId.ToString())
+                    ], "TestAuth"))
+                }
+            }
+        };
+    }
+
+    private sealed record TestScenario(
+        Guid TaskId,
+        Guid SeekerUserId,
+        Guid HelperUserId,
+        Guid HelperProfileId);
+}

--- a/backend.Tests/TaskApplicationsControllerTests.cs
+++ b/backend.Tests/TaskApplicationsControllerTests.cs
@@ -23,7 +23,7 @@ public sealed class TaskApplicationsControllerTests
 
         var result = await controller.ApplyAsync(
             scenario.TaskId,
-            new ApplyToTaskRequest("I can help after work."),
+            new ApplyToTaskRequest(null),
             cancellationToken);
 
         Assert.IsType<CreatedResult>(result);
@@ -194,7 +194,7 @@ public sealed class TaskApplicationsControllerTests
 
     private static TaskApplicationsController CreateController(AppDbContext db, Guid userId)
     {
-        return new TaskApplicationsController(db)
+        return new TaskApplicationsController(db, null!, null!)
         {
             ControllerContext = new ControllerContext
             {

--- a/backend/Domain/Enums/ActivityEventType.cs
+++ b/backend/Domain/Enums/ActivityEventType.cs
@@ -6,7 +6,11 @@ public enum ActivityEventType
     UserLoggedIn,
     ProfileUpdated,
     TaskPosted,
+    TaskApplicationSubmitted,
+    TaskApplicationRejected,
+    TaskApplicationWithdrawn,
     TaskAccepted,
+    TaskCancelled,
     TaskCompleted,
     ReviewSubmitted,
     MessageSent

--- a/backend/Features/Admin/Analytics/AdminAnalyticsController.cs
+++ b/backend/Features/Admin/Analytics/AdminAnalyticsController.cs
@@ -88,4 +88,24 @@ public sealed class AdminAnalyticsController(AppDbContext db) : ControllerBase
 
         return Ok(new ChartDataResponse(entries));
     }
+
+    [HttpGet("charts/task-application-status")]
+    public async Task<IActionResult> GetTaskApplicationStatusChartAsync(CancellationToken cancellationToken)
+    {
+        var groups = await db.TaskApplications.AsNoTracking()
+            .GroupBy(a => a.Status)
+            .Select(g => new { Status = g.Key, Count = g.Count() })
+            .ToListAsync(cancellationToken);
+
+        var total = groups.Sum(g => g.Count);
+        var entries = groups
+            .OrderByDescending(g => g.Count)
+            .Select(g => new ChartEntry(
+                g.Status.ToString(),
+                g.Count,
+                total > 0 ? Math.Round(g.Count * 100.0 / total, 1) : 0))
+            .ToList();
+
+        return Ok(new ChartDataResponse(entries));
+    }
 }

--- a/backend/Features/Conversations/ConversationDtos.cs
+++ b/backend/Features/Conversations/ConversationDtos.cs
@@ -31,7 +31,9 @@ public sealed record ConversationPreviewResponse(
     ParticipantInfo OtherParticipant,
     string? LastMessageContent,
     DateTimeOffset? LastMessageAt,
-    bool HasUnread);
+    bool HasUnread,
+    string TaskStatus,
+    Guid? PendingApplicationId);
 
 // Sent over SignalR to the recipient's personal user group when they receive a new message.
 [PublicAPI]

--- a/backend/Features/Conversations/ConversationsController.cs
+++ b/backend/Features/Conversations/ConversationsController.cs
@@ -68,8 +68,21 @@ public sealed partial class ConversationsController(
             CosmosConversationId = Guid.NewGuid().ToString(),
         };
 
-        db.TaskConversations.Add(conversation);
-        await db.SaveChangesAsync(cancellationToken);
+        try
+        {
+            db.TaskConversations.Add(conversation);
+            await db.SaveChangesAsync(cancellationToken);
+        }
+        catch (DbUpdateException ex) when (PostgresExceptionHelpers.IsDuplicateTaskConversation(ex))
+        {
+            var raced = await db.TaskConversations
+                .Include(c => c.SeekerProfile)
+                .Include(c => c.HelperProfile)
+                .FirstAsync(
+                    c => c.TaskId == request.TaskId && c.HelperProfileId == profile.Id,
+                    cancellationToken);
+            return Ok(ToConversationResponse(raced, task.Title, profile.Id));
+        }
 
         conversation.SeekerProfile = task.SeekerProfile;
         conversation.HelperProfile = profile;
@@ -93,6 +106,7 @@ public sealed partial class ConversationsController(
                 c.Id,
                 c.TaskId,
                 TaskTitle = c.Task.Title,
+                TaskStatus = c.Task.Status,
                 c.SeekerProfileId,
                 SeekerDisplayName = c.SeekerProfile.DisplayName,
                 SeekerPhotoUrl = c.SeekerProfile.PhotoUrl,
@@ -104,6 +118,10 @@ public sealed partial class ConversationsController(
                 c.SeekerLastReadAt,
                 c.HelperLastReadAt,
                 c.CreatedAt,
+                PendingApplicationId = c.Task.Applications
+                    .Where(a => a.HelperProfileId == c.HelperProfileId && a.Status == TaskApplicationStatus.Pending)
+                    .Select(a => (Guid?)a.Id)
+                    .FirstOrDefault(),
             })
             .OrderByDescending(x => x.LastMessageAt.HasValue ? x.LastMessageAt.Value : x.CreatedAt)
             .ToListAsync(cancellationToken);
@@ -126,7 +144,9 @@ public sealed partial class ConversationsController(
                 other,
                 r.LastMessageContent,
                 r.LastMessageAt,
-                hasUnread);
+                hasUnread,
+                r.TaskStatus.ToString(),
+                isSeeker ? r.PendingApplicationId : null);
         });
 
         return Ok(result);

--- a/backend/Features/Tasks/Applications/TaskApplicationDtos.cs
+++ b/backend/Features/Tasks/Applications/TaskApplicationDtos.cs
@@ -39,3 +39,30 @@ public sealed record TaskApplicationResponse(
             application.UpdatedAt);
     }
 }
+
+[PublicAPI]
+public sealed record MyTaskApplicationResponse(
+    Guid Id,
+    Guid TaskId,
+    Guid HelperProfileId,
+    string HelperDisplayName,
+    string? Message,
+    string Status,
+    DateTimeOffset CreatedAt,
+    DateTimeOffset UpdatedAt,
+    TaskResponse Task)
+{
+    public static MyTaskApplicationResponse FromApplication(TaskApplication application)
+    {
+        return new MyTaskApplicationResponse(
+            application.Id,
+            application.TaskId,
+            application.HelperProfileId,
+            application.HelperProfile.DisplayName,
+            application.Message,
+            application.Status.ToString(),
+            application.CreatedAt,
+            application.UpdatedAt,
+            TaskResponse.FromTask(application.Task));
+    }
+}

--- a/backend/Features/Tasks/Applications/TaskApplicationDtos.cs
+++ b/backend/Features/Tasks/Applications/TaskApplicationDtos.cs
@@ -19,6 +19,7 @@ public sealed record PatchApplicationRequest(
 public sealed record TaskApplicationResponse(
     Guid Id,
     Guid TaskId,
+    Guid? ConversationId,
     Guid HelperProfileId,
     string HelperDisplayName,
     string? Message,
@@ -26,11 +27,15 @@ public sealed record TaskApplicationResponse(
     DateTimeOffset CreatedAt,
     DateTimeOffset UpdatedAt)
 {
-    public static TaskApplicationResponse FromApplication(TaskApplication application, string helperDisplayName)
+    public static TaskApplicationResponse FromApplication(
+        TaskApplication application,
+        string helperDisplayName,
+        Guid? conversationId = null)
     {
         return new TaskApplicationResponse(
             application.Id,
             application.TaskId,
+            conversationId,
             application.HelperProfileId,
             helperDisplayName,
             application.Message,
@@ -44,6 +49,7 @@ public sealed record TaskApplicationResponse(
 public sealed record MyTaskApplicationResponse(
     Guid Id,
     Guid TaskId,
+    Guid? ConversationId,
     Guid HelperProfileId,
     string HelperDisplayName,
     string? Message,
@@ -52,11 +58,15 @@ public sealed record MyTaskApplicationResponse(
     DateTimeOffset UpdatedAt,
     TaskResponse Task)
 {
-    public static MyTaskApplicationResponse FromApplication(TaskApplication application, string helperDisplayName)
+    public static MyTaskApplicationResponse FromApplication(
+        TaskApplication application,
+        string helperDisplayName,
+        Guid? conversationId = null)
     {
         return new MyTaskApplicationResponse(
             application.Id,
             application.TaskId,
+            conversationId,
             application.HelperProfileId,
             helperDisplayName,
             application.Message,

--- a/backend/Features/Tasks/Applications/TaskApplicationDtos.cs
+++ b/backend/Features/Tasks/Applications/TaskApplicationDtos.cs
@@ -52,13 +52,13 @@ public sealed record MyTaskApplicationResponse(
     DateTimeOffset UpdatedAt,
     TaskResponse Task)
 {
-    public static MyTaskApplicationResponse FromApplication(TaskApplication application)
+    public static MyTaskApplicationResponse FromApplication(TaskApplication application, string helperDisplayName)
     {
         return new MyTaskApplicationResponse(
             application.Id,
             application.TaskId,
             application.HelperProfileId,
-            application.HelperProfile.DisplayName,
+            helperDisplayName,
             application.Message,
             application.Status.ToString(),
             application.CreatedAt,

--- a/backend/Features/Tasks/Applications/TaskApplicationsController.cs
+++ b/backend/Features/Tasks/Applications/TaskApplicationsController.cs
@@ -1,9 +1,11 @@
 using Backend.Common;
 using Backend.Domain.Entities;
 using Backend.Domain.Enums;
+using Backend.Features.Conversations;
 using Backend.Infrastructure.Persistence;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.SignalR;
 using Microsoft.EntityFrameworkCore;
 using DomainTaskStatus = Backend.Domain.Enums.TaskStatus;
 
@@ -12,7 +14,10 @@ namespace Backend.Features.Tasks.Applications;
 [ApiController]
 [Route("api/tasks/{taskId:guid}/applications")]
 [Authorize]
-public sealed partial class TaskApplicationsController(AppDbContext db) : ControllerBase
+public sealed partial class TaskApplicationsController(
+    AppDbContext db,
+    CosmosMessageService cosmosMessages,
+    IHubContext<ChatHub> chatHub) : ControllerBase
 {
     [HttpPost]
     public async Task<IActionResult> ApplyAsync(
@@ -91,9 +96,66 @@ public sealed partial class TaskApplicationsController(AppDbContext db) : Contro
                 statusCode: StatusCodes.Status409Conflict);
         }
 
+        // Create the conversation thread immediately on apply.
+        var conversation = new TaskConversation
+        {
+            Id = Guid.NewGuid(),
+            TaskId = taskId,
+            SeekerProfileId = task.SeekerProfileId,
+            HelperProfileId = profile.Id,
+            CosmosConversationId = Guid.NewGuid().ToString()
+        };
+        db.TaskConversations.Add(conversation);
+
+        try
+        {
+            await db.SaveChangesAsync(cancellationToken);
+        }
+        catch (DbUpdateException ex) when (PostgresExceptionHelpers.IsDuplicateTaskConversation(ex))
+        {
+            // A conversation already exists (e.g. from a prior StartConversation call).
+            db.Entry(conversation).State = EntityState.Detached;
+            conversation = await db.TaskConversations
+                .FirstAsync(c => c.TaskId == taskId && c.HelperProfileId == profile.Id, cancellationToken);
+        }
+
+        // Send the application message as the first real message in the thread.
+        if (!string.IsNullOrWhiteSpace(application.Message))
+        {
+            var document = new MessageDocument
+            {
+                Id = Guid.NewGuid().ToString(),
+                ConversationId = conversation.Id.ToString(),
+                SenderProfileId = profile.Id.ToString(),
+                SenderDisplayName = profile.DisplayName,
+                Content = application.Message,
+                SentAt = DateTimeOffset.UtcNow,
+            };
+
+            await cosmosMessages.AddAsync(document, cancellationToken);
+
+            conversation.LastMessageContent = document.Content.Length > 500
+                ? document.Content[..500]
+                : document.Content;
+            conversation.LastMessageAt = document.SentAt;
+            conversation.HelperLastReadAt = document.SentAt;
+
+            await db.SaveChangesAsync(cancellationToken);
+
+            await chatHub.Clients
+                .Group($"user-{task.SeekerProfileId}")
+                .SendAsync(
+                    "NewMessageNotification",
+                    new NewMessageNotification(
+                        conversation.Id,
+                        profile.DisplayName,
+                        document.Content.Length > 100 ? document.Content[..100] : document.Content),
+                    cancellationToken);
+        }
+
         return Created(
             $"/api/tasks/{taskId}/applications/{application.Id}",
-            TaskApplicationResponse.FromApplication(application, profile.DisplayName));
+            TaskApplicationResponse.FromApplication(application, profile.DisplayName, conversation.Id));
     }
 
     [HttpGet("~/api/task-applications/me")]
@@ -118,7 +180,18 @@ public sealed partial class TaskApplicationsController(AppDbContext db) : Contro
             .ThenByDescending(a => a.CreatedAt)
             .ToListAsync(cancellationToken);
 
-        return Ok(applications.Select(a => MyTaskApplicationResponse.FromApplication(a, profile.DisplayName)));
+        var taskIds = applications.Select(a => a.TaskId).ToHashSet();
+        var convIdByTask = await db.TaskConversations
+            .AsNoTracking()
+            .Where(c => taskIds.Contains(c.TaskId) && c.HelperProfileId == profile.Id)
+            .Select(c => new { c.TaskId, c.Id })
+            .ToDictionaryAsync(c => c.TaskId, c => (Guid?)c.Id, cancellationToken);
+
+        return Ok(applications.Select(a =>
+            MyTaskApplicationResponse.FromApplication(
+                a,
+                profile.DisplayName,
+                convIdByTask.GetValueOrDefault(a.TaskId))));
     }
 
     [HttpGet]
@@ -153,7 +226,18 @@ public sealed partial class TaskApplicationsController(AppDbContext db) : Contro
             .OrderBy(a => a.CreatedAt)
             .ToListAsync(cancellationToken);
 
-        return Ok(applications.Select(a => TaskApplicationResponse.FromApplication(a, a.HelperProfile.DisplayName)));
+        var helperIds = applications.Select(a => a.HelperProfileId).ToHashSet();
+        var convIdByHelper = await db.TaskConversations
+            .AsNoTracking()
+            .Where(c => c.TaskId == taskId && helperIds.Contains(c.HelperProfileId))
+            .Select(c => new { c.HelperProfileId, c.Id })
+            .ToDictionaryAsync(c => c.HelperProfileId, c => (Guid?)c.Id, cancellationToken);
+
+        return Ok(applications.Select(a =>
+            TaskApplicationResponse.FromApplication(
+                a,
+                a.HelperProfile.DisplayName,
+                convIdByHelper.GetValueOrDefault(a.HelperProfileId))));
     }
 
     [HttpPatch("{appId:guid}")]
@@ -196,6 +280,12 @@ public sealed partial class TaskApplicationsController(AppDbContext db) : Contro
         {
             return NotFound();
         }
+
+        var helperName = await db.Profiles
+            .AsNoTracking()
+            .Where(p => p.Id == application.HelperProfileId)
+            .Select(p => p.DisplayName)
+            .FirstAsync(cancellationToken);
 
         if (isAccept)
         {
@@ -261,14 +351,6 @@ public sealed partial class TaskApplicationsController(AppDbContext db) : Contro
                         .SetProperty(a => a.UpdatedAt, now),
                     cancellationToken);
 
-            db.TaskConversations.Add(new TaskConversation
-            {
-                TaskId = taskId,
-                SeekerProfileId = task.SeekerProfileId,
-                HelperProfileId = application.HelperProfileId,
-                CosmosConversationId = Guid.NewGuid().ToString()
-            });
-
             db.TaskStatusHistory.Add(new TaskStatusHistoryEntry
             {
                 TaskId = taskId,
@@ -317,13 +399,6 @@ public sealed partial class TaskApplicationsController(AppDbContext db) : Contro
                 await db.SaveChangesAsync(cancellationToken);
                 await transaction.CommitAsync(cancellationToken);
             }
-            catch (DbUpdateException ex) when (PostgresExceptionHelpers.IsDuplicateTaskConversation(ex))
-            {
-                return Problem(
-                    title: "Task is not open",
-                    detail: "The task was already accepted or is no longer open.",
-                    statusCode: StatusCodes.Status409Conflict);
-            }
             catch (DbUpdateConcurrencyException)
             {
                 return Problem(
@@ -334,6 +409,42 @@ public sealed partial class TaskApplicationsController(AppDbContext db) : Contro
 
             application.Status = TaskApplicationStatus.Accepted;
             application.UpdatedAt = now;
+
+            // Conversation was already created when the helper applied.
+            var conversation = await db.TaskConversations
+                .FirstOrDefaultAsync(
+                    c => c.TaskId == taskId && c.HelperProfileId == application.HelperProfileId,
+                    cancellationToken);
+
+            if (conversation is null)
+            {
+                // Backward compat: application pre-dates the apply→conversation flow.
+                var newConversation = new TaskConversation
+                {
+                    Id = Guid.NewGuid(),
+                    TaskId = taskId,
+                    SeekerProfileId = task.SeekerProfileId,
+                    HelperProfileId = application.HelperProfileId,
+                    CosmosConversationId = Guid.NewGuid().ToString()
+                };
+                db.TaskConversations.Add(newConversation);
+
+                try
+                {
+                    await db.SaveChangesAsync(cancellationToken);
+                    conversation = newConversation;
+                }
+                catch (DbUpdateException ex) when (PostgresExceptionHelpers.IsDuplicateTaskConversation(ex))
+                {
+                    db.Entry(newConversation).State = EntityState.Detached;
+                    conversation = await db.TaskConversations
+                        .FirstAsync(
+                            c => c.TaskId == taskId && c.HelperProfileId == application.HelperProfileId,
+                            cancellationToken);
+                }
+            }
+
+            return Ok(TaskApplicationResponse.FromApplication(application, helperName, conversation.Id));
         }
         else
         {
@@ -364,12 +475,6 @@ public sealed partial class TaskApplicationsController(AppDbContext db) : Contro
 
             await db.SaveChangesAsync(cancellationToken);
         }
-
-        var helperName = await db.Profiles
-            .AsNoTracking()
-            .Where(p => p.Id == application.HelperProfileId)
-            .Select(p => p.DisplayName)
-            .FirstAsync(cancellationToken);
 
         return Ok(TaskApplicationResponse.FromApplication(application, helperName));
     }

--- a/backend/Features/Tasks/Applications/TaskApplicationsController.cs
+++ b/backend/Features/Tasks/Applications/TaskApplicationsController.cs
@@ -108,7 +108,6 @@ public sealed partial class TaskApplicationsController(AppDbContext db) : Contro
         var applications = await db.TaskApplications
             .AsNoTracking()
             .Where(a => a.HelperProfileId == profile.Id)
-            .Include(a => a.HelperProfile)
             .Include(a => a.Task)
                 .ThenInclude(t => t.SeekerProfile)
             .Include(a => a.Task)
@@ -119,7 +118,7 @@ public sealed partial class TaskApplicationsController(AppDbContext db) : Contro
             .ThenByDescending(a => a.CreatedAt)
             .ToListAsync(cancellationToken);
 
-        return Ok(applications.Select(MyTaskApplicationResponse.FromApplication));
+        return Ok(applications.Select(a => MyTaskApplicationResponse.FromApplication(a, profile.DisplayName)));
     }
 
     [HttpGet]

--- a/backend/Features/Tasks/Applications/TaskApplicationsController.cs
+++ b/backend/Features/Tasks/Applications/TaskApplicationsController.cs
@@ -53,12 +53,31 @@ public sealed partial class TaskApplicationsController(AppDbContext db) : Contro
 
         var application = new TaskApplication
         {
+            Id = Guid.NewGuid(),
             TaskId = taskId,
             HelperProfileId = profile.Id,
             Message = StringUtilities.Normalize(request.Message)
         };
 
         db.TaskApplications.Add(application);
+        db.AddActivityEvent(
+            profile.UserId,
+            profile.Id,
+            ActivityEventType.TaskApplicationSubmitted,
+            nameof(TaskApplication),
+            application.Id,
+            new { application.TaskId, MessageLength = application.Message?.Length ?? 0 });
+        db.AddAuditEvent(
+            profile.UserId,
+            "task_application.submitted",
+            nameof(TaskApplication),
+            application.Id,
+            new
+            {
+                application.TaskId,
+                application.HelperProfileId,
+                MessageLength = application.Message?.Length ?? 0
+            });
 
         try
         {
@@ -75,6 +94,32 @@ public sealed partial class TaskApplicationsController(AppDbContext db) : Contro
         return Created(
             $"/api/tasks/{taskId}/applications/{application.Id}",
             TaskApplicationResponse.FromApplication(application, profile.DisplayName));
+    }
+
+    [HttpGet("~/api/task-applications/me")]
+    public async Task<IActionResult> ListMineAsync(CancellationToken cancellationToken)
+    {
+        var profile = await GetCurrentProfileAsync(cancellationToken);
+        if (profile is null)
+        {
+            return Unauthorized();
+        }
+
+        var applications = await db.TaskApplications
+            .AsNoTracking()
+            .Where(a => a.HelperProfileId == profile.Id)
+            .Include(a => a.HelperProfile)
+            .Include(a => a.Task)
+                .ThenInclude(t => t.SeekerProfile)
+            .Include(a => a.Task)
+                .ThenInclude(t => t.AcceptedHelperProfile)
+            .Include(a => a.Task)
+                .ThenInclude(t => t.Category)
+            .OrderByDescending(a => a.UpdatedAt)
+            .ThenByDescending(a => a.CreatedAt)
+            .ToListAsync(cancellationToken);
+
+        return Ok(applications.Select(MyTaskApplicationResponse.FromApplication));
     }
 
     [HttpGet]
@@ -209,7 +254,7 @@ public sealed partial class TaskApplicationsController(AppDbContext db) : Contro
                     statusCode: StatusCodes.Status409Conflict);
             }
 
-            await db.TaskApplications
+            var rejectedCount = await db.TaskApplications
                 .Where(a => a.TaskId == taskId && a.Id != appId && a.Status == TaskApplicationStatus.Pending)
                 .ExecuteUpdateAsync(
                     s => s
@@ -240,6 +285,33 @@ public sealed partial class TaskApplicationsController(AppDbContext db) : Contro
                 nameof(CommunityTask),
                 taskId,
                 new { application.HelperProfileId, ApplicationId = application.Id });
+            db.AddAuditEvent(
+                profile.UserId,
+                "task_application.accepted",
+                nameof(TaskApplication),
+                application.Id,
+                new
+                {
+                    application.TaskId,
+                    application.HelperProfileId,
+                    task.SeekerProfileId,
+                    RejectedPendingApplicationCount = rejectedCount
+                });
+
+            if (rejectedCount > 0)
+            {
+                db.AddAuditEvent(
+                    profile.UserId,
+                    "task_application.auto_rejected",
+                    nameof(CommunityTask),
+                    taskId,
+                    new
+                    {
+                        AcceptedApplicationId = application.Id,
+                        application.HelperProfileId,
+                        RejectedPendingApplicationCount = rejectedCount
+                    });
+            }
 
             try
             {
@@ -276,6 +348,20 @@ public sealed partial class TaskApplicationsController(AppDbContext db) : Contro
 
             application.Status = TaskApplicationStatus.Rejected;
             application.UpdatedAt = DateTimeOffset.UtcNow;
+
+            db.AddActivityEvent(
+                profile.UserId,
+                profile.Id,
+                ActivityEventType.TaskApplicationRejected,
+                nameof(TaskApplication),
+                application.Id,
+                new { application.TaskId, application.HelperProfileId });
+            db.AddAuditEvent(
+                profile.UserId,
+                "task_application.rejected",
+                nameof(TaskApplication),
+                application.Id,
+                new { application.TaskId, application.HelperProfileId });
 
             await db.SaveChangesAsync(cancellationToken);
         }
@@ -333,6 +419,20 @@ public sealed partial class TaskApplicationsController(AppDbContext db) : Contro
 
         application.Status = TaskApplicationStatus.Withdrawn;
         application.UpdatedAt = DateTimeOffset.UtcNow;
+
+        db.AddActivityEvent(
+            profile.UserId,
+            profile.Id,
+            ActivityEventType.TaskApplicationWithdrawn,
+            nameof(TaskApplication),
+            application.Id,
+            new { application.TaskId, application.HelperProfileId });
+        db.AddAuditEvent(
+            profile.UserId,
+            "task_application.withdrawn",
+            nameof(TaskApplication),
+            application.Id,
+            new { application.TaskId, application.HelperProfileId });
 
         await db.SaveChangesAsync(cancellationToken);
 

--- a/backend/Features/Tasks/TasksController.cs
+++ b/backend/Features/Tasks/TasksController.cs
@@ -312,9 +312,40 @@ public sealed partial class TasksController(AppDbContext db) : ControllerBase
                 return ValidationProblem(ModelState);
             }
 
+            var oldStatus = task.Status;
+            var cancelledAt = DateTimeOffset.UtcNow;
+            var cancellationReason = StringUtilities.Normalize(request.CancellationReason);
+
             task.Status = DomainTaskStatus.Cancelled;
-            task.CancelledAt = DateTimeOffset.UtcNow;
-            task.CancellationReason = StringUtilities.Normalize(request.CancellationReason);
+            task.CancelledAt = cancelledAt;
+            task.CancellationReason = cancellationReason;
+            db.TaskStatusHistory.Add(new TaskStatusHistoryEntry
+            {
+                TaskId = task.Id,
+                OldStatus = oldStatus,
+                NewStatus = DomainTaskStatus.Cancelled,
+                ChangedByProfileId = profile.Id,
+                Reason = cancellationReason
+            });
+            db.AddActivityEvent(
+                profile.UserId,
+                profile.Id,
+                ActivityEventType.TaskCancelled,
+                nameof(CommunityTask),
+                task.Id,
+                new { OldStatus = oldStatus.ToString(), Reason = cancellationReason });
+            db.AddAuditEvent(
+                profile.UserId,
+                "task.cancelled",
+                nameof(CommunityTask),
+                task.Id,
+                new
+                {
+                    OldStatus = oldStatus.ToString(),
+                    Reason = cancellationReason,
+                    task.AcceptedHelperProfileId,
+                    CancelledAt = cancelledAt
+                });
             anyChange = true;
         }
 

--- a/backend/Infrastructure/Persistence/AuditEventExtensions.cs
+++ b/backend/Infrastructure/Persistence/AuditEventExtensions.cs
@@ -1,0 +1,26 @@
+using System.Text.Json;
+using Backend.Domain.Entities;
+
+namespace Backend.Infrastructure.Persistence;
+
+internal static class AuditEventExtensions
+{
+    public static void AddAuditEvent(
+        this AppDbContext db,
+        Guid? actorUserId,
+        string eventType,
+        string? entityType,
+        Guid? entityId,
+        object? payload)
+    {
+        db.AuditEvents.Add(new AuditEvent
+        {
+            ActorUserId = actorUserId,
+            EventType = eventType,
+            EntityType = entityType,
+            EntityId = entityId,
+            Payload = payload is null ? null : JsonSerializer.Serialize(payload),
+            CreatedAt = DateTimeOffset.UtcNow
+        });
+    }
+}

--- a/backend/Infrastructure/Persistence/PostgresExceptionHelpers.cs
+++ b/backend/Infrastructure/Persistence/PostgresExceptionHelpers.cs
@@ -75,6 +75,6 @@ public static class PostgresExceptionHelpers
     /// <returns>True if the exception is a duplicate task conversation violation, false otherwise.</returns>
     public static bool IsDuplicateTaskConversation(DbUpdateException exception)
     {
-        return IsUniqueConstraintViolation(exception, "ux_task_conversations_task_id");
+        return IsUniqueConstraintViolation(exception, "ux_task_conversations_task_helper");
     }
 }

--- a/frontend/app/(main)/tasks/[id]/page.client.tsx
+++ b/frontend/app/(main)/tasks/[id]/page.client.tsx
@@ -237,6 +237,7 @@ function ApplicationControls({
   application?: ApiTaskApplication
   isLoadingApplication?: boolean
 }) {
+  const router = useRouter()
   const [open, setOpen] = React.useState(false)
   const [message, setMessage] = React.useState("")
   const { mutate: applyToTask, isPending: isApplying } = useApplyToTask(taskId)
@@ -249,10 +250,14 @@ function ApplicationControls({
     applyToTask(
       { message: message.trim() || undefined },
       {
-        onSuccess: () => {
-          toast.success("Application sent.")
+        onSuccess: (app) => {
           setMessage("")
           setOpen(false)
+          if (app.conversationId) {
+            router.push(`/messages/${app.conversationId}`)
+          } else {
+            toast.success("Application sent.")
+          }
         },
         onError: () => toast.error("Could not apply to this task."),
       }
@@ -278,6 +283,13 @@ function ApplicationControls({
         <Button variant="outline" disabled>
           Application pending
         </Button>
+        {application.conversationId ? (
+          <Button variant="outline" asChild>
+            <Link href={`/messages/${application.conversationId}`}>
+              View conversation
+            </Link>
+          </Button>
+        ) : null}
         <Button
           variant="ghost"
           disabled={isWithdrawing}
@@ -291,9 +303,18 @@ function ApplicationControls({
 
   if (application) {
     return (
-      <Badge variant="outline" className="h-9 rounded-md px-3">
-        Application {application.status.toLowerCase()}
-      </Badge>
+      <div className="flex flex-wrap items-center gap-2">
+        <Badge variant="outline" className="h-9 rounded-md px-3">
+          Application {application.status.toLowerCase()}
+        </Badge>
+        {application.conversationId ? (
+          <Button variant="outline" size="sm" asChild>
+            <Link href={`/messages/${application.conversationId}`}>
+              View conversation
+            </Link>
+          </Button>
+        ) : null}
+      </div>
     )
   }
 
@@ -397,25 +418,34 @@ function TaskApplicationsPanel({
                   {application.message}
                 </p>
               ) : null}
-              {application.status === "Pending" ? (
-                <div className="flex flex-wrap gap-2">
-                  <Button
-                    size="sm"
-                    disabled={isPending}
-                    onClick={() => handleAction(application.id, "accept")}
-                  >
-                    Accept
+              <div className="flex flex-wrap gap-2">
+                {application.conversationId ? (
+                  <Button size="sm" variant="outline" asChild>
+                    <Link href={`/messages/${application.conversationId}`}>
+                      View chat
+                    </Link>
                   </Button>
-                  <Button
-                    size="sm"
-                    variant="ghost"
-                    disabled={isPending}
-                    onClick={() => handleAction(application.id, "reject")}
-                  >
-                    Reject
-                  </Button>
-                </div>
-              ) : null}
+                ) : null}
+                {application.status === "Pending" ? (
+                  <>
+                    <Button
+                      size="sm"
+                      disabled={isPending}
+                      onClick={() => handleAction(application.id, "accept")}
+                    >
+                      Accept
+                    </Button>
+                    <Button
+                      size="sm"
+                      variant="ghost"
+                      disabled={isPending}
+                      onClick={() => handleAction(application.id, "reject")}
+                    >
+                      Reject
+                    </Button>
+                  </>
+                ) : null}
+              </div>
             </div>
           ))}
         </div>

--- a/frontend/app/(main)/tasks/[id]/page.client.tsx
+++ b/frontend/app/(main)/tasks/[id]/page.client.tsx
@@ -111,7 +111,8 @@ function TaskActions({ task }: { task: ApiTask }) {
   const { user } = useAuth()
   const router = useRouter()
   const { mutate: updateTask, isPending: isCancelling } = useUpdateTask(task.id)
-  const { data: myApplications = [] } = useMyTaskApplications()
+  const { data: myApplications = [], isLoading: isLoadingMyApplications } =
+    useMyTaskApplications()
   const { data: applications = [], isLoading: isLoadingApplications } =
     useTaskApplications(task.id, task.seekerProfileId === user?.profileId)
   const { mutate: startConversation, isPending: isStarting } =
@@ -121,7 +122,8 @@ function TaskActions({ task }: { task: ApiTask }) {
   const canOpenInProgressChat =
     status === "in_progress" &&
     (isSeeker || task.acceptedHelperProfileId === user?.profileId)
-  const { data: conversations = [] } = useConversations(canOpenInProgressChat)
+  const { data: conversations = [], isLoading: isLoadingConversations } =
+    useConversations(canOpenInProgressChat)
   const currentApplication = myApplications.find((a) => a.taskId === task.id)
 
   function handleCancel() {
@@ -163,6 +165,7 @@ function TaskActions({ task }: { task: ApiTask }) {
             <ApplicationControls
               taskId={task.id}
               application={currentApplication}
+              isLoadingApplication={isLoadingMyApplications}
             />
           ) : (
             <>
@@ -194,7 +197,10 @@ function TaskActions({ task }: { task: ApiTask }) {
     return (
       <div className="flex flex-wrap gap-2">
         {canOpenInProgressChat ? (
-          <Button disabled={isStarting} onClick={handleMessage}>
+          <Button
+            disabled={isStarting || isLoadingConversations}
+            onClick={handleMessage}
+          >
             {isStarting ? "Opening…" : "Open chat"}
           </Button>
         ) : null}
@@ -225,9 +231,11 @@ function TaskActions({ task }: { task: ApiTask }) {
 function ApplicationControls({
   taskId,
   application,
+  isLoadingApplication = false,
 }: {
   taskId: string
   application?: ApiTaskApplication
+  isLoadingApplication?: boolean
 }) {
   const [open, setOpen] = React.useState(false)
   const [message, setMessage] = React.useState("")
@@ -258,6 +266,10 @@ function ApplicationControls({
       onSuccess: () => toast.success("Application withdrawn."),
       onError: () => toast.error("Could not withdraw the application."),
     })
+  }
+
+  if (!application && isLoadingApplication) {
+    return <Button disabled>Apply to help</Button>
   }
 
   if (application?.status === "Pending") {

--- a/frontend/app/(main)/tasks/[id]/page.client.tsx
+++ b/frontend/app/(main)/tasks/[id]/page.client.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import * as React from "react"
 import Link from "next/link"
 import { useRouter } from "next/navigation"
 import { notFound } from "next/navigation"
@@ -8,8 +9,19 @@ import { Calendar03Icon, Location01Icon } from "@hugeicons/core-free-icons"
 import { toast } from "sonner"
 
 import { Button } from "@/components/ui/button"
+import { Badge } from "@/components/ui/badge"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog"
 import { Separator } from "@/components/ui/separator"
+import { Textarea } from "@/components/ui/textarea"
 import { CategoryBadge } from "@/components/tasks/category-badge"
 import { CompensationBadge } from "@/components/tasks/compensation-badge"
 import { TaskStatusBadge } from "@/components/tasks/task-status-badge"
@@ -17,9 +29,17 @@ import { UserAvatar } from "@/components/shared/user-avatar"
 import { RichTextContent } from "@/components/shared/rich-text-content"
 import { formatRelativeTime } from "@/lib/format"
 import { useAuth } from "@/lib/auth-context"
-import { useTask, useUpdateTask } from "@/lib/api/tasks"
-import type { ApiTask } from "@/lib/api/tasks"
-import { useStartConversation } from "@/lib/api/conversations"
+import {
+  useApplyToTask,
+  useMyTaskApplications,
+  usePatchTaskApplication,
+  useTask,
+  useTaskApplications,
+  useUpdateTask,
+  useWithdrawTaskApplication,
+} from "@/lib/api/tasks"
+import type { ApiTask, ApiTaskApplication } from "@/lib/api/tasks"
+import { useConversations, useStartConversation } from "@/lib/api/conversations"
 
 interface TaskDetailPageClientProps {
   id: string
@@ -91,10 +111,18 @@ function TaskActions({ task }: { task: ApiTask }) {
   const { user } = useAuth()
   const router = useRouter()
   const { mutate: updateTask, isPending: isCancelling } = useUpdateTask(task.id)
+  const { data: myApplications = [] } = useMyTaskApplications()
+  const { data: applications = [], isLoading: isLoadingApplications } =
+    useTaskApplications(task.id, task.seekerProfileId === user?.profileId)
   const { mutate: startConversation, isPending: isStarting } =
     useStartConversation()
   const isSeeker = task.seekerProfileId === user?.profileId
   const status = task.status.toLowerCase().replace(/([a-z])([A-Z])/g, "$1_$2")
+  const canOpenInProgressChat =
+    status === "in_progress" &&
+    (isSeeker || task.acceptedHelperProfileId === user?.profileId)
+  const { data: conversations = [] } = useConversations(canOpenInProgressChat)
+  const currentApplication = myApplications.find((a) => a.taskId === task.id)
 
   function handleCancel() {
     updateTask(
@@ -110,6 +138,17 @@ function TaskActions({ task }: { task: ApiTask }) {
   }
 
   function handleMessage() {
+    const existing = conversations.find((c) => c.taskId === task.id)
+    if (existing) {
+      router.push(`/messages/${existing.id}`)
+      return
+    }
+
+    if (isSeeker) {
+      router.push("/messages")
+      return
+    }
+
     startConversation(task.id, {
       onSuccess: (c) => router.push(`/messages/${c.id}`),
       onError: () => toast.error("Could not open chat."),
@@ -118,29 +157,34 @@ function TaskActions({ task }: { task: ApiTask }) {
 
   if (status === "open") {
     return (
-      <div className="flex flex-wrap gap-2">
-        {!isSeeker ? (
-          <Button
-            variant="outline"
-            disabled={isStarting}
-            onClick={handleMessage}
-          >
-            {isStarting ? "Opening…" : "Message seeker"}
-          </Button>
-        ) : null}
+      <div className="flex flex-col gap-4">
+        <div className="flex flex-wrap gap-2">
+          {!isSeeker ? (
+            <ApplicationControls
+              taskId={task.id}
+              application={currentApplication}
+            />
+          ) : (
+            <>
+              <Button variant="outline" asChild>
+                <Link href={`/tasks/${task.id}/edit`}>Edit task</Link>
+              </Button>
+              <Button
+                variant="ghost"
+                disabled={isCancelling}
+                onClick={handleCancel}
+              >
+                {isCancelling ? "Cancelling…" : "Cancel task"}
+              </Button>
+            </>
+          )}
+        </div>
         {isSeeker ? (
-          <>
-            <Button variant="outline" asChild>
-              <Link href={`/tasks/${task.id}/edit`}>Edit task</Link>
-            </Button>
-            <Button
-              variant="ghost"
-              disabled={isCancelling}
-              onClick={handleCancel}
-            >
-              {isCancelling ? "Cancelling…" : "Cancel task"}
-            </Button>
-          </>
+          <TaskApplicationsPanel
+            applications={applications}
+            isLoading={isLoadingApplications}
+            taskId={task.id}
+          />
         ) : null}
       </div>
     )
@@ -149,9 +193,11 @@ function TaskActions({ task }: { task: ApiTask }) {
   if (status === "in_progress") {
     return (
       <div className="flex flex-wrap gap-2">
-        <Button disabled={isStarting} onClick={handleMessage}>
-          {isStarting ? "Opening…" : "Open chat"}
-        </Button>
+        {canOpenInProgressChat ? (
+          <Button disabled={isStarting} onClick={handleMessage}>
+            {isStarting ? "Opening…" : "Open chat"}
+          </Button>
+        ) : null}
         {isSeeker ? (
           <Button
             variant="ghost"
@@ -174,4 +220,194 @@ function TaskActions({ task }: { task: ApiTask }) {
   }
 
   return null
+}
+
+function ApplicationControls({
+  taskId,
+  application,
+}: {
+  taskId: string
+  application?: ApiTaskApplication
+}) {
+  const [open, setOpen] = React.useState(false)
+  const [message, setMessage] = React.useState("")
+  const { mutate: applyToTask, isPending: isApplying } = useApplyToTask(taskId)
+  const { mutate: withdraw, isPending: isWithdrawing } =
+    useWithdrawTaskApplication(taskId)
+
+  function handleApply(event: React.SyntheticEvent<HTMLFormElement>) {
+    event.preventDefault()
+
+    applyToTask(
+      { message: message.trim() || undefined },
+      {
+        onSuccess: () => {
+          toast.success("Application sent.")
+          setMessage("")
+          setOpen(false)
+        },
+        onError: () => toast.error("Could not apply to this task."),
+      }
+    )
+  }
+
+  function handleWithdraw() {
+    if (!application) return
+
+    withdraw(application.id, {
+      onSuccess: () => toast.success("Application withdrawn."),
+      onError: () => toast.error("Could not withdraw the application."),
+    })
+  }
+
+  if (application?.status === "Pending") {
+    return (
+      <>
+        <Button variant="outline" disabled>
+          Application pending
+        </Button>
+        <Button
+          variant="ghost"
+          disabled={isWithdrawing}
+          onClick={handleWithdraw}
+        >
+          {isWithdrawing ? "Withdrawing…" : "Withdraw"}
+        </Button>
+      </>
+    )
+  }
+
+  if (application) {
+    return (
+      <Badge variant="outline" className="h-9 rounded-md px-3">
+        Application {application.status.toLowerCase()}
+      </Badge>
+    )
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button>Apply to help</Button>
+      </DialogTrigger>
+      <DialogContent className="max-w-md">
+        <form onSubmit={handleApply}>
+          <DialogHeader>
+            <DialogTitle>Apply to help</DialogTitle>
+            <DialogDescription>
+              Send a short note to the seeker with your availability or relevant
+              experience.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="py-4">
+            <Textarea
+              value={message}
+              onChange={(event) => setMessage(event.target.value)}
+              maxLength={1000}
+              placeholder="I can help this afternoon and have a small hand cart."
+              rows={5}
+            />
+          </div>
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => setOpen(false)}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" disabled={isApplying}>
+              {isApplying ? "Sending…" : "Send application"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function TaskApplicationsPanel({
+  applications,
+  isLoading,
+  taskId,
+}: {
+  applications: ApiTaskApplication[]
+  isLoading: boolean
+  taskId: string
+}) {
+  const { mutate: patchApplication, isPending } =
+    usePatchTaskApplication(taskId)
+
+  function handleAction(applicationId: string, action: "accept" | "reject") {
+    patchApplication(
+      { applicationId, action },
+      {
+        onSuccess: () =>
+          toast.success(
+            action === "accept"
+              ? "Application accepted."
+              : "Application rejected."
+          ),
+        onError: () => toast.error("Could not update the application."),
+      }
+    )
+  }
+
+  return (
+    <section className="rounded-lg border bg-card p-4">
+      <div className="mb-3 flex items-center justify-between gap-3">
+        <h2 className="text-sm font-medium">Applications</h2>
+        <Badge variant="muted">{isLoading ? "…" : applications.length}</Badge>
+      </div>
+      {isLoading ? (
+        <p className="text-sm text-muted-foreground">Loading applications…</p>
+      ) : applications.length === 0 ? (
+        <p className="text-sm text-muted-foreground">No applications yet.</p>
+      ) : (
+        <div className="divide-y">
+          {applications.map((application) => (
+            <div
+              key={application.id}
+              className="flex flex-col gap-3 py-3 first:pt-0 last:pb-0"
+            >
+              <div className="flex flex-wrap items-center gap-2">
+                <UserAvatar size="sm" name={application.helperDisplayName} />
+                <span className="text-sm font-medium">
+                  {application.helperDisplayName}
+                </span>
+                <Badge variant="outline">{application.status}</Badge>
+                <span className="ml-auto text-xs text-muted-foreground">
+                  {formatRelativeTime(application.createdAt)}
+                </span>
+              </div>
+              {application.message ? (
+                <p className="text-sm text-muted-foreground">
+                  {application.message}
+                </p>
+              ) : null}
+              {application.status === "Pending" ? (
+                <div className="flex flex-wrap gap-2">
+                  <Button
+                    size="sm"
+                    disabled={isPending}
+                    onClick={() => handleAction(application.id, "accept")}
+                  >
+                    Accept
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    disabled={isPending}
+                    onClick={() => handleAction(application.id, "reject")}
+                  >
+                    Reject
+                  </Button>
+                </div>
+              ) : null}
+            </div>
+          ))}
+        </div>
+      )}
+    </section>
+  )
 }

--- a/frontend/app/(main)/tasks/page.client.tsx
+++ b/frontend/app/(main)/tasks/page.client.tsx
@@ -1,11 +1,14 @@
 "use client"
 
 import Link from "next/link"
+import { InboxIcon } from "@hugeicons/core-free-icons"
 
 import { Button } from "@/components/ui/button"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { PageHeader } from "@/components/shared/page-header"
+import { TaskCard } from "@/components/tasks/task-card"
 import { TaskList } from "@/components/tasks/task-list"
+import { EmptyState } from "@/components/shared/empty-state"
 import { useAuth } from "@/lib/auth-context"
 import { useMyTaskApplications, useTaskList } from "@/lib/api/tasks"
 
@@ -22,14 +25,6 @@ export function TasksPageClient() {
   const accepted = tasks.filter(
     (t) => t.acceptedHelperProfileId === user?.profileId
   )
-  const appliedSeen = new Set<string>()
-  const applied = applications
-    .map((a) => a.task)
-    .filter((t) => {
-      if (appliedSeen.has(t.id)) return false
-      appliedSeen.add(t.id)
-      return true
-    })
 
   return (
     <div className="flex flex-col gap-6">
@@ -52,7 +47,7 @@ export function TasksPageClient() {
             Accepted ({isLoading ? "…" : accepted.length})
           </TabsTrigger>
           <TabsTrigger value="applied">
-            Applied ({isLoadingApplications ? "…" : applied.length})
+            Applied ({isLoadingApplications ? "…" : applications.length})
           </TabsTrigger>
         </TabsList>
 
@@ -87,12 +82,23 @@ export function TasksPageClient() {
             <TabsContent value="applied">
               {isLoadingApplications ? (
                 <p className="mt-4 text-sm text-muted-foreground">Loading…</p>
-              ) : (
-                <TaskList
-                  tasks={applied}
-                  emptyTitle="No applications yet"
-                  emptyDescription="Apply to open tasks from the helper feed to track them here."
+              ) : applications.length === 0 ? (
+                <EmptyState
+                  icon={InboxIcon}
+                  title="No applications yet"
+                  description="Apply to open tasks from the helper feed to track them here."
                 />
+              ) : (
+                <ul className="flex flex-col gap-3">
+                  {applications.map((application) => (
+                    <li key={application.id}>
+                      <TaskCard
+                        task={application.task}
+                        applicationStatus={application.status}
+                      />
+                    </li>
+                  ))}
+                </ul>
               )}
             </TabsContent>
           </>

--- a/frontend/app/(main)/tasks/page.client.tsx
+++ b/frontend/app/(main)/tasks/page.client.tsx
@@ -7,16 +7,22 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { PageHeader } from "@/components/shared/page-header"
 import { TaskList } from "@/components/tasks/task-list"
 import { useAuth } from "@/lib/auth-context"
-import { useTaskList } from "@/lib/api/tasks"
+import { useMyTaskApplications, useTaskList } from "@/lib/api/tasks"
 
 export function TasksPageClient() {
   const { user } = useAuth()
   const { data: tasks = [], isLoading, isError } = useTaskList()
+  const {
+    data: applications = [],
+    isLoading: isLoadingApplications,
+    isError: isApplicationsError,
+  } = useMyTaskApplications()
 
   const posted = tasks.filter((t) => t.seekerProfileId === user?.profileId)
   const accepted = tasks.filter(
     (t) => t.acceptedHelperProfileId === user?.profileId
   )
+  const applied = applications.map((a) => a.task)
 
   return (
     <div className="flex flex-col gap-6">
@@ -38,9 +44,12 @@ export function TasksPageClient() {
           <TabsTrigger value="accepted">
             Accepted ({isLoading ? "…" : accepted.length})
           </TabsTrigger>
+          <TabsTrigger value="applied">
+            Applied ({isLoadingApplications ? "…" : applied.length})
+          </TabsTrigger>
         </TabsList>
 
-        {isError ? (
+        {isError || isApplicationsError ? (
           <p className="mt-4 text-sm text-destructive">
             Could not load tasks. Please try again.
           </p>
@@ -65,6 +74,17 @@ export function TasksPageClient() {
                   tasks={accepted}
                   emptyTitle="No accepted tasks"
                   emptyDescription="Browse the feed and accept a task to see it here."
+                />
+              )}
+            </TabsContent>
+            <TabsContent value="applied">
+              {isLoadingApplications ? (
+                <p className="mt-4 text-sm text-muted-foreground">Loading…</p>
+              ) : (
+                <TaskList
+                  tasks={applied}
+                  emptyTitle="No applications yet"
+                  emptyDescription="Apply to open tasks from the helper feed to track them here."
                 />
               )}
             </TabsContent>

--- a/frontend/app/(main)/tasks/page.client.tsx
+++ b/frontend/app/(main)/tasks/page.client.tsx
@@ -22,7 +22,14 @@ export function TasksPageClient() {
   const accepted = tasks.filter(
     (t) => t.acceptedHelperProfileId === user?.profileId
   )
-  const applied = applications.map((a) => a.task)
+  const appliedSeen = new Set<string>()
+  const applied = applications
+    .map((a) => a.task)
+    .filter((t) => {
+      if (appliedSeen.has(t.id)) return false
+      appliedSeen.add(t.id)
+      return true
+    })
 
   return (
     <div className="flex flex-col gap-6">

--- a/frontend/components/messages/chat-window.tsx
+++ b/frontend/components/messages/chat-window.tsx
@@ -6,6 +6,8 @@ import { HugeiconsIcon } from "@hugeicons/react"
 import { Sent02Icon } from "@hugeicons/core-free-icons"
 import type { SubmitEvent } from "react"
 
+import { toast } from "sonner"
+
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { ScrollArea } from "@/components/ui/scroll-area"
@@ -17,6 +19,7 @@ import type {
   ApiConversationPreview,
   ApiMessage,
 } from "@/lib/api/conversations"
+import { usePatchTaskApplication } from "@/lib/api/tasks"
 import { useConversationHub } from "@/lib/chat-hub"
 
 interface ChatWindowProps {
@@ -39,8 +42,32 @@ export function ChatWindow({
   const bottomRef = React.useRef<HTMLDivElement>(null)
   const inputRef = React.useRef<HTMLInputElement>(null)
   const { mutate: sendMessage, isPending } = useSendMessage(conversation.id)
+  const { mutate: patchApplication, isPending: isPatchingApplication } =
+    usePatchTaskApplication(conversation.taskId)
 
   useConversationHub(conversation.id, user?.profileId)
+
+  function handleAccept() {
+    if (!conversation.pendingApplicationId) return
+    patchApplication(
+      { applicationId: conversation.pendingApplicationId, action: "accept" },
+      {
+        onSuccess: () => toast.success("Application accepted."),
+        onError: () => toast.error("Could not accept the application."),
+      }
+    )
+  }
+
+  function handleReject() {
+    if (!conversation.pendingApplicationId) return
+    patchApplication(
+      { applicationId: conversation.pendingApplicationId, action: "reject" },
+      {
+        onSuccess: () => toast.success("Application rejected."),
+        onError: () => toast.error("Could not reject the application."),
+      }
+    )
+  }
 
   const lastMessageId = messages[messages.length - 1]?.id
 
@@ -78,6 +105,30 @@ export function ChatWindow({
           </Link>
         </div>
       </header>
+
+      {conversation.pendingApplicationId ? (
+        <div className="flex items-center gap-3 border-b border-border bg-muted/40 px-4 py-2.5">
+          <p className="flex-1 text-sm text-muted-foreground">
+            {conversation.otherParticipant.displayName} applied to help with
+            this task.
+          </p>
+          <Button
+            size="sm"
+            disabled={isPatchingApplication}
+            onClick={handleAccept}
+          >
+            Accept
+          </Button>
+          <Button
+            size="sm"
+            variant="ghost"
+            disabled={isPatchingApplication}
+            onClick={handleReject}
+          >
+            Decline
+          </Button>
+        </div>
+      ) : null}
 
       <ScrollArea className="flex-1 px-4">
         <div className="flex flex-col gap-2 py-4">

--- a/frontend/components/tasks/task-card.tsx
+++ b/frontend/components/tasks/task-card.tsx
@@ -3,6 +3,7 @@ import { HugeiconsIcon } from "@hugeicons/react"
 import { Location01Icon } from "@hugeicons/core-free-icons"
 
 import { Card, CardContent, CardFooter, CardHeader } from "@/components/ui/card"
+import { Badge } from "@/components/ui/badge"
 import { CategoryBadge } from "@/components/tasks/category-badge"
 import { CompensationBadge } from "@/components/tasks/compensation-badge"
 import { TaskStatusBadge } from "@/components/tasks/task-status-badge"
@@ -14,10 +15,16 @@ import { cn } from "@/lib/utils"
 interface TaskCardProps {
   task: ApiTask
   hideStatus?: boolean
+  applicationStatus?: string
   className?: string
 }
 
-export function TaskCard({ task, hideStatus, className }: TaskCardProps) {
+export function TaskCard({
+  task,
+  hideStatus,
+  applicationStatus,
+  className,
+}: TaskCardProps) {
   return (
     <Card className={cn("transition-colors hover:border-ring/40", className)}>
       <Link
@@ -32,6 +39,15 @@ export function TaskCard({ task, hideStatus, className }: TaskCardProps) {
               compensationAmount={task.compensationAmount}
             />
             {!hideStatus ? <TaskStatusBadge status={task.status} /> : null}
+            {applicationStatus ? (
+              <Badge
+                variant={
+                  applicationStatus === "Rejected" ? "destructive" : "outline"
+                }
+              >
+                Application {applicationStatus.toLowerCase()}
+              </Badge>
+            ) : null}
             <span className="ml-auto text-xs text-muted-foreground">
               {formatRelativeTime(task.createdAt)}
             </span>

--- a/frontend/lib/api/admin/analytics.ts
+++ b/frontend/lib/api/admin/analytics.ts
@@ -37,6 +37,8 @@ export const adminAnalyticsKeys = {
       [...adminAnalyticsKeys.charts.all(), "category-demand"] as const,
     compensationMix: () =>
       [...adminAnalyticsKeys.charts.all(), "compensation-mix"] as const,
+    taskApplicationStatus: () =>
+      [...adminAnalyticsKeys.charts.all(), "task-application-status"] as const,
   },
 }
 
@@ -74,6 +76,17 @@ export function useCompensationMixChart() {
     queryFn: () =>
       apiClient.get<ChartDataResponse>(
         "/admin/analytics/charts/compensation-mix"
+      ),
+    staleTime: 5 * 60 * 1000,
+  })
+}
+
+export function useTaskApplicationStatusChart() {
+  return useQuery({
+    queryKey: adminAnalyticsKeys.charts.taskApplicationStatus(),
+    queryFn: () =>
+      apiClient.get<ChartDataResponse>(
+        "/admin/analytics/charts/task-application-status"
       ),
     staleTime: 5 * 60 * 1000,
   })

--- a/frontend/lib/api/conversations.ts
+++ b/frontend/lib/api/conversations.ts
@@ -32,6 +32,8 @@ export interface ApiConversationPreview {
   lastMessageContent: string | null
   lastMessageAt: string | null
   hasUnread: boolean
+  taskStatus: string
+  pendingApplicationId: string | null
 }
 
 export interface ApiMessage {

--- a/frontend/lib/api/conversations.ts
+++ b/frontend/lib/api/conversations.ts
@@ -57,10 +57,11 @@ export const conversationKeys = {
 
 // ── Hooks ─────────────────────────────────────────────────────────────────────
 
-export function useConversations() {
+export function useConversations(enabled = true) {
   return useQuery({
     queryKey: conversationKeys.list,
     queryFn: () => apiClient.get<ApiConversationPreview[]>("/conversations"),
+    enabled,
     staleTime: 60_000,
   })
 }

--- a/frontend/lib/api/tasks.ts
+++ b/frontend/lib/api/tasks.ts
@@ -21,7 +21,7 @@ export interface ApiTask {
   longitude: number | null
   compensationType: string
   compensationAmount: number | null
-  status: string
+  status: "Open" | "InProgress" | "Completed" | "Cancelled"
   createdAt: string
   updatedAt: string
 }
@@ -32,7 +32,7 @@ export interface ApiTaskApplication {
   helperProfileId: string
   helperDisplayName: string
   message: string | null
-  status: string
+  status: "Pending" | "Accepted" | "Rejected" | "Withdrawn"
   createdAt: string
   updatedAt: string
 }
@@ -133,6 +133,7 @@ export function useTaskApplications(taskId: string, enabled = true) {
     queryFn: () =>
       apiClient.get<ApiTaskApplication[]>(`/tasks/${taskId}/applications`),
     enabled: Boolean(taskId) && enabled,
+    staleTime: 5 * 60 * 1000,
   })
 }
 
@@ -141,6 +142,7 @@ export function useMyTaskApplications() {
     queryKey: taskKeys.myApplications(),
     queryFn: () =>
       apiClient.get<ApiMyTaskApplication[]>("/task-applications/me"),
+    staleTime: 5 * 60 * 1000,
   })
 }
 

--- a/frontend/lib/api/tasks.ts
+++ b/frontend/lib/api/tasks.ts
@@ -26,6 +26,21 @@ export interface ApiTask {
   updatedAt: string
 }
 
+export interface ApiTaskApplication {
+  id: string
+  taskId: string
+  helperProfileId: string
+  helperDisplayName: string
+  message: string | null
+  status: string
+  createdAt: string
+  updatedAt: string
+}
+
+export interface ApiMyTaskApplication extends ApiTaskApplication {
+  task: ApiTask
+}
+
 export interface CreateTaskInput {
   title: string
   description: string
@@ -48,6 +63,10 @@ export interface UpdateTaskInput {
   cancellationReason?: string
 }
 
+export interface ApplyToTaskInput {
+  message?: string
+}
+
 // ── Query keys ────────────────────────────────────────────────────────────────
 
 export const taskKeys = {
@@ -56,6 +75,9 @@ export const taskKeys = {
   list: (filters: Record<string, string | undefined>) =>
     [...taskKeys.lists(), filters] as const,
   detail: (id: string) => [...taskKeys.all, "detail", id] as const,
+  applications: (id: string) =>
+    [...taskKeys.detail(id), "applications"] as const,
+  myApplications: () => [...taskKeys.all, "my-applications"] as const,
 }
 
 // ── Hooks ─────────────────────────────────────────────────────────────────────
@@ -101,6 +123,71 @@ export function useUpdateTask(id: string) {
     onSuccess: (updated) => {
       qc.setQueryData(taskKeys.detail(id), updated)
       void qc.invalidateQueries({ queryKey: taskKeys.lists() })
+    },
+  })
+}
+
+export function useTaskApplications(taskId: string, enabled = true) {
+  return useQuery({
+    queryKey: taskKeys.applications(taskId),
+    queryFn: () =>
+      apiClient.get<ApiTaskApplication[]>(`/tasks/${taskId}/applications`),
+    enabled: Boolean(taskId) && enabled,
+  })
+}
+
+export function useMyTaskApplications() {
+  return useQuery({
+    queryKey: taskKeys.myApplications(),
+    queryFn: () =>
+      apiClient.get<ApiMyTaskApplication[]>("/task-applications/me"),
+  })
+}
+
+export function useApplyToTask(taskId: string) {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (data: ApplyToTaskInput) =>
+      apiClient.post<ApiTaskApplication>(`/tasks/${taskId}/applications`, data),
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: taskKeys.myApplications() })
+      void qc.invalidateQueries({ queryKey: taskKeys.applications(taskId) })
+      void qc.invalidateQueries({ queryKey: taskKeys.detail(taskId) })
+    },
+  })
+}
+
+export function usePatchTaskApplication(taskId: string) {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: ({
+      applicationId,
+      action,
+    }: {
+      applicationId: string
+      action: "accept" | "reject"
+    }) =>
+      apiClient.patch<ApiTaskApplication>(
+        `/tasks/${taskId}/applications/${applicationId}`,
+        { action }
+      ),
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: taskKeys.applications(taskId) })
+      void qc.invalidateQueries({ queryKey: taskKeys.myApplications() })
+      void qc.invalidateQueries({ queryKey: taskKeys.detail(taskId) })
+      void qc.invalidateQueries({ queryKey: taskKeys.lists() })
+    },
+  })
+}
+
+export function useWithdrawTaskApplication(taskId: string) {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (applicationId: string) =>
+      apiClient.delete<void>(`/tasks/${taskId}/applications/${applicationId}`),
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: taskKeys.myApplications() })
+      void qc.invalidateQueries({ queryKey: taskKeys.applications(taskId) })
     },
   })
 }

--- a/frontend/lib/api/tasks.ts
+++ b/frontend/lib/api/tasks.ts
@@ -6,6 +6,7 @@ import {
 } from "@tanstack/react-query"
 
 import { apiClient } from "@/lib/api/client"
+import { conversationKeys } from "@/lib/api/conversations"
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -34,6 +35,7 @@ export interface ApiTask {
 export interface ApiTaskApplication {
   id: string
   taskId: string
+  conversationId: string | null
   helperProfileId: string
   helperDisplayName: string
   message: string | null
@@ -183,6 +185,7 @@ export function useApplyToTask(taskId: string) {
       void qc.invalidateQueries({ queryKey: taskKeys.myApplications() })
       void qc.invalidateQueries({ queryKey: taskKeys.applications(taskId) })
       void qc.invalidateQueries({ queryKey: taskKeys.detail(taskId) })
+      void qc.invalidateQueries({ queryKey: conversationKeys.list })
     },
   })
 }
@@ -206,6 +209,7 @@ export function usePatchTaskApplication(taskId: string) {
       void qc.invalidateQueries({ queryKey: taskKeys.myApplications() })
       void qc.invalidateQueries({ queryKey: taskKeys.detail(taskId) })
       void qc.invalidateQueries({ queryKey: taskKeys.lists() })
+      void qc.invalidateQueries({ queryKey: ["conversations"] })
     },
   })
 }


### PR DESCRIPTION
## Summary
- wire task detail so helpers can apply, withdraw pending applications, and seekers can review/accept/reject applicants
- add a current-user task applications endpoint and Applied tab in My tasks
- add task application/cancellation audit + activity logging and an admin application-status analytics chart endpoint

## Related issues
Closes #40
Closes #50
Closes #55
Closes #60

## Verification
- dotnet test --configuration Release
- dotnet format --verify-no-changes
- npm --prefix frontend run lint
- npm --prefix frontend run typecheck
- npm --prefix frontend run build