### PR TITLE
feat: add reputation scoring system and profile reputation trend

### DIFF
--- a/backend.Tests/ProfilesControllerTests.cs
+++ b/backend.Tests/ProfilesControllerTests.cs
@@ -263,6 +263,157 @@ public sealed class ProfilesControllerTests
         Assert.IsType<NotFoundResult>(result);
     }
 
+    [Fact]
+    public async Task GetProfileReputationTrendAsync_ReturnsDailySnapshotsFromCompletedTasksAndReviews()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await using var db = CreateDbContext();
+        var profile = CreateProfile("Profile");
+        var helper = CreateProfile("Helper");
+        var seeker = CreateProfile("Seeker");
+        var reviewer = CreateProfile("Reviewer");
+        var category = CreateCategory("repairs", "Repairs", "Wrench01Icon");
+        var firstDay = new DateTimeOffset(2026, 1, 2, 9, 0, 0, TimeSpan.Zero);
+        var secondDay = firstDay.AddDays(1);
+        var thirdDay = firstDay.AddDays(2);
+        var fourthDay = firstDay.AddDays(3);
+        var seekerTask = CreateTask(
+            "Seeker completion",
+            profile,
+            helper,
+            category,
+            DomainTaskStatus.Completed,
+            firstDay.AddDays(-1),
+            firstDay);
+        var helperTask = CreateTask(
+            "Helper completion",
+            seeker,
+            profile,
+            category,
+            DomainTaskStatus.Completed,
+            thirdDay.AddDays(-1),
+            thirdDay);
+
+        db.Profiles.AddRange(profile, helper, seeker, reviewer);
+        db.Categories.Add(category);
+        db.Tasks.AddRange(seekerTask, helperTask);
+        db.Reviews.AddRange(
+            new Review
+            {
+                Id = Guid.NewGuid(),
+                TaskId = seekerTask.Id,
+                ReviewerProfileId = reviewer.Id,
+                ReviewerProfile = reviewer,
+                RevieweeProfileId = profile.Id,
+                RevieweeProfile = profile,
+                Rating = 5,
+                Comment = "Great help",
+                CreatedAt = secondDay,
+                UpdatedAt = secondDay
+            },
+            new Review
+            {
+                Id = Guid.NewGuid(),
+                TaskId = helperTask.Id,
+                ReviewerProfileId = reviewer.Id,
+                ReviewerProfile = reviewer,
+                RevieweeProfileId = profile.Id,
+                RevieweeProfile = profile,
+                Rating = 3,
+                Comment = "Solid help",
+                CreatedAt = fourthDay,
+                UpdatedAt = fourthDay
+            });
+        await db.SaveChangesAsync(cancellationToken);
+
+        var controller = new ProfilesController(db, new NullBlobStorageService(), NullLogger<ProfilesController>.Instance);
+        var result = await controller.GetProfileReputationTrendAsync(profile.Id, cancellationToken);
+
+        var ok = Assert.IsType<OkObjectResult>(result);
+        var trend = Assert.IsAssignableFrom<IEnumerable<ProfileReputationTrendPointResponse>>(ok.Value).ToList();
+
+        Assert.Equal(
+            [10, 20, 30, 36],
+            trend.Select(point => point.Score));
+        Assert.Equal(
+            new[] { firstDay, secondDay, thirdDay, fourthDay }
+                .Select(day => DateOnly.FromDateTime(day.UtcDateTime)),
+            trend.Select(point => point.Date));
+        Assert.Equal([0m, 5m, 5m, 4m], trend.Select(point => point.AverageRating));
+        Assert.Equal([0, 1, 1, 2], trend.Select(point => point.ReviewCount));
+        Assert.Equal([1, 1, 2, 2], trend.Select(point => point.CompletedTaskCount));
+    }
+
+    [Fact]
+    public async Task GetPublicProfileAsync_PopulatesReputationScore_FromCalculator()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await using var db = CreateDbContext();
+        var profile = CreateProfile("Helper");
+        profile.AverageRating = 4.8m;
+        profile.ReviewCount = 12;
+        profile.CompletedTaskCount = 9;
+        profile.PrivacySettings = new ProfilePrivacySettings
+        {
+            Id = Guid.NewGuid(),
+            ProfileId = profile.Id,
+            ShowWorkplace = true,
+            ShowPosition = true,
+            ShowLocation = true,
+            ShowAvailability = true,
+            CreatedAt = DateTimeOffset.UtcNow,
+            UpdatedAt = DateTimeOffset.UtcNow
+        };
+        db.Profiles.Add(profile);
+        await db.SaveChangesAsync(cancellationToken);
+
+        var controller = new ProfilesController(db, new NullBlobStorageService(), NullLogger<ProfilesController>.Instance);
+        var result = await controller.GetPublicProfileAsync(profile.Id, cancellationToken);
+
+        var ok = Assert.IsType<OkObjectResult>(result);
+        var response = Assert.IsType<PublicProfileResponse>(ok.Value);
+        // 9 x 10 + 4.8 x 12 x 2 = 205
+        Assert.Equal(205, response.ReputationScore);
+        Assert.Equal(profile.AverageRating, response.AverageRating);
+        Assert.Equal(profile.ReviewCount, response.ReviewCount);
+        Assert.Equal(profile.CompletedTaskCount, response.CompletedTaskCount);
+    }
+
+    [Fact]
+    public async Task GetOwnProfileAsync_PopulatesReputationScore_FromCalculator()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await using var db = CreateDbContext();
+        var (userId, profileId) = await SeedProfileAsync(db, cancellationToken);
+        var profile = await db.Profiles.FindAsync([profileId], cancellationToken);
+        Assert.NotNull(profile);
+        profile.AverageRating = 5m;
+        profile.ReviewCount = 4;
+        profile.CompletedTaskCount = 3;
+        var privacySettings = new ProfilePrivacySettings
+        {
+            Id = Guid.NewGuid(),
+            ProfileId = profile.Id,
+            ShowWorkplace = true,
+            ShowPosition = true,
+            ShowLocation = true,
+            ShowAvailability = true,
+            CreatedAt = DateTimeOffset.UtcNow,
+            UpdatedAt = DateTimeOffset.UtcNow
+        };
+        profile.PrivacySettings = privacySettings;
+        db.ProfilePrivacySettings.Add(privacySettings);
+        await db.SaveChangesAsync(cancellationToken);
+
+        var controller = CreateProfilesController(db, userId);
+        var result = await controller.GetOwnProfileAsync(cancellationToken);
+
+        var ok = Assert.IsType<OkObjectResult>(result);
+        var response = Assert.IsType<OwnProfileResponse>(ok.Value);
+        // 3 x 10 + 5 x 4 x 2 = 70
+        Assert.Equal(70, response.ReputationScore);
+    }
+
     private static async Task<(Guid userId, Guid profileId)> SeedProfileAsync(
         AppDbContext db, CancellationToken cancellationToken)
     {
@@ -313,7 +464,8 @@ public sealed class ProfilesControllerTests
         UserProfile? acceptedHelper,
         Category category,
         DomainTaskStatus status,
-        DateTimeOffset createdAt)
+        DateTimeOffset createdAt,
+        DateTimeOffset? completedAt = null)
     {
         return new CommunityTask
         {
@@ -330,7 +482,8 @@ public sealed class ProfilesControllerTests
             CompensationType = CompensationType.Voluntary,
             Status = status,
             CreatedAt = createdAt,
-            UpdatedAt = createdAt
+            UpdatedAt = completedAt ?? createdAt,
+            CompletedAt = completedAt
         };
     }
 

--- a/backend.Tests/ReputationScoreCalculatorTests.cs
+++ b/backend.Tests/ReputationScoreCalculatorTests.cs
@@ -31,7 +31,7 @@ public sealed class ReputationScoreCalculatorTests
     [Fact]
     public void Compute_CombinesCompletedAndReviewComponents()
     {
-        // 9 × 10 + 4.8 × 12 × 2 = 90 + 115.2 → 205 (banker's-away rounding)
+        // 9 × 10 + 4.8 × 12 × 2 = 90 + 115.2 → 205 (rounded to the nearest integer)
         var score = ReputationScoreCalculator.Compute(4.8m, 12, 9);
         Assert.Equal(205, score);
     }

--- a/backend.Tests/ReputationScoreCalculatorTests.cs
+++ b/backend.Tests/ReputationScoreCalculatorTests.cs
@@ -1,0 +1,93 @@
+using Backend.Domain.Reputation;
+using Xunit;
+
+namespace backend.Tests;
+
+public sealed class ReputationScoreCalculatorTests
+{
+    [Fact]
+    public void Compute_ReturnsZero_ForBrandNewProfile()
+    {
+        var score = ReputationScoreCalculator.Compute(0m, 0, 0);
+        Assert.Equal(0, score);
+    }
+
+    [Fact]
+    public void Compute_AddsCompletedTaskWeight_WhenNoReviews()
+    {
+        // 9 completed × 10 + 0 × 0 × 2 = 90
+        var score = ReputationScoreCalculator.Compute(0m, 0, 9);
+        Assert.Equal(90, score);
+    }
+
+    [Fact]
+    public void Compute_RewardsReviewQuality()
+    {
+        // 0 completed × 10 + 4.5 × 4 × 2 = 36
+        var score = ReputationScoreCalculator.Compute(4.5m, 4, 0);
+        Assert.Equal(36, score);
+    }
+
+    [Fact]
+    public void Compute_CombinesCompletedAndReviewComponents()
+    {
+        // 9 × 10 + 4.8 × 12 × 2 = 90 + 115.2 → 205 (banker's-away rounding)
+        var score = ReputationScoreCalculator.Compute(4.8m, 12, 9);
+        Assert.Equal(205, score);
+    }
+
+    [Theory]
+    [InlineData(-1, 0, 0)] // negative rating clamped
+    [InlineData(6.5, 4, 2)] // rating above 5 clamped
+    public void Compute_ClampsRatingToZeroFive(decimal rating, int reviewCount, int completed)
+    {
+        var score = ReputationScoreCalculator.Compute(rating, reviewCount, completed);
+        // Clamping must keep score non-negative and finite
+        Assert.True(score >= 0);
+    }
+
+    [Fact]
+    public void Compute_TreatsRatingAboveFive_AsFive()
+    {
+        // Above-range rating should be clamped to 5
+        var clamped = ReputationScoreCalculator.Compute(5m, 10, 0);
+        var raw = ReputationScoreCalculator.Compute(7m, 10, 0);
+        Assert.Equal(clamped, raw);
+    }
+
+    [Fact]
+    public void Compute_TreatsNegativeRating_AsZero()
+    {
+        var withZero = ReputationScoreCalculator.Compute(0m, 10, 3);
+        var withNegative = ReputationScoreCalculator.Compute(-2m, 10, 3);
+        Assert.Equal(withZero, withNegative);
+    }
+
+    [Fact]
+    public void Compute_TreatsNegativeCounts_AsZero()
+    {
+        var fromZero = ReputationScoreCalculator.Compute(4m, 0, 0);
+        var fromNegative = ReputationScoreCalculator.Compute(4m, -5, -3);
+        Assert.Equal(fromZero, fromNegative);
+        Assert.Equal(0, fromNegative);
+    }
+
+    [Fact]
+    public void Compute_RoundsHalfAwayFromZero()
+    {
+        // 4.5 × 1 × 2 = 9.0 (no rounding); use a case that lands on .5
+        // 0.5 × 1 × 2 = 1.0 → still integer; force .5 via 0.25 × 2 × 2 = 1.0 — also integer
+        // The current formula always lands on integer or 0.5 multiples; pick one:
+        // 4.75 × 1 × 2 = 9.5 → 10 with AwayFromZero
+        var score = ReputationScoreCalculator.Compute(4.75m, 1, 0);
+        Assert.Equal(10, score);
+    }
+
+    [Fact]
+    public void Compute_HandlesLargeCounts_WithoutOverflow()
+    {
+        var score = ReputationScoreCalculator.Compute(5m, 100_000, 50_000);
+        // 50000 × 10 + 5 × 100000 × 2 = 500000 + 1000000 = 1_500_000
+        Assert.Equal(1_500_000, score);
+    }
+}

--- a/backend/Domain/Reputation/ReputationScoreCalculator.cs
+++ b/backend/Domain/Reputation/ReputationScoreCalculator.cs
@@ -1,0 +1,36 @@
+namespace Backend.Domain.Reputation;
+
+/// <summary>
+/// Computes the aggregate reputation score surfaced by the profile widget.
+///
+/// The formula is intentionally simple and stable so the same value can be
+/// reproduced on the client when the score is missing from the API response:
+///
+///     score = round(completedTasks * 10 + averageRating * reviewCount * 2)
+///
+/// Inputs are clamped (rating to [0, 5], counts to non-negative) so malformed
+/// data cannot produce negative or NaN scores.
+/// </summary>
+public static class ReputationScoreCalculator
+{
+    public const int CompletedTaskWeight = 10;
+    public const int ReviewQualityWeight = 2;
+
+    public static int Compute(decimal averageRating, int reviewCount, int completedTaskCount)
+    {
+        var clampedRating = averageRating switch
+        {
+            < 0m => 0m,
+            > 5m => 5m,
+            _ => averageRating,
+        };
+
+        var safeReviewCount = Math.Max(0, reviewCount);
+        var safeCompletedCount = Math.Max(0, completedTaskCount);
+
+        var score = (safeCompletedCount * (decimal)CompletedTaskWeight)
+                    + (clampedRating * safeReviewCount * ReviewQualityWeight);
+
+        return (int)Math.Round(score, MidpointRounding.AwayFromZero);
+    }
+}

--- a/backend/Features/Profiles/OwnProfileResponse.cs
+++ b/backend/Features/Profiles/OwnProfileResponse.cs
@@ -25,6 +25,10 @@ public sealed record OwnProfileResponse
     public required decimal AverageRating { get; init; }
     public required int ReviewCount { get; init; }
     public required int CompletedTaskCount { get; init; }
+
+    /// <summary>Gets the aggregate reputation score surfaced in the profile widget.</summary>
+    public required int ReputationScore { get; init; }
+
     public required DateTimeOffset CreatedAt { get; init; }
     public required DateTimeOffset UpdatedAt { get; init; }
     public ICollection<Guid> SkillIds { get; init; } = [];

--- a/backend/Features/Profiles/ProfileReputationTrendPointResponse.cs
+++ b/backend/Features/Profiles/ProfileReputationTrendPointResponse.cs
@@ -1,0 +1,8 @@
+namespace Backend.Features.Profiles;
+
+public sealed record ProfileReputationTrendPointResponse(
+    DateOnly Date,
+    int Score,
+    decimal AverageRating,
+    int ReviewCount,
+    int CompletedTaskCount);

--- a/backend/Features/Profiles/ProfilesController.Reputation.cs
+++ b/backend/Features/Profiles/ProfilesController.Reputation.cs
@@ -50,9 +50,9 @@ public sealed partial class ProfilesController
                 && (task.SeekerProfileId == profileId || task.AcceptedHelperProfileId == profileId))
             .Select(task => new
             {
-                Year = (task.CompletedAt ?? task.UpdatedAt).Year,
-                Month = (task.CompletedAt ?? task.UpdatedAt).Month,
-                Day = (task.CompletedAt ?? task.UpdatedAt).Day
+                (task.CompletedAt ?? task.UpdatedAt).Year,
+                (task.CompletedAt ?? task.UpdatedAt).Month,
+                (task.CompletedAt ?? task.UpdatedAt).Day
             });
 
         var trendDaysDescending = await reviewEventDaysQuery
@@ -134,9 +134,9 @@ public sealed partial class ProfilesController
                 && (task.CompletedAt ?? task.UpdatedAt) >= earliestTrendStartUtc)
             .GroupBy(task => new
             {
-                Year = (task.CompletedAt ?? task.UpdatedAt).Year,
-                Month = (task.CompletedAt ?? task.UpdatedAt).Month,
-                Day = (task.CompletedAt ?? task.UpdatedAt).Day
+                (task.CompletedAt ?? task.UpdatedAt).Year,
+                (task.CompletedAt ?? task.UpdatedAt).Month,
+                (task.CompletedAt ?? task.UpdatedAt).Day
             })
             .Select(group => new
             {

--- a/backend/Features/Profiles/ProfilesController.Reputation.cs
+++ b/backend/Features/Profiles/ProfilesController.Reputation.cs
@@ -1,0 +1,108 @@
+using Backend.Domain.Reputation;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using DomainTaskStatus = Backend.Domain.Enums.TaskStatus;
+
+namespace Backend.Features.Profiles;
+
+public sealed partial class ProfilesController
+{
+    private const int ReputationTrendPointLimit = 12;
+
+    /// <summary>
+    /// Get cumulative reputation snapshots for a profile.
+    /// </summary>
+    /// <param name="id">The profile ID whose reputation trend should be returned.</param>
+    /// <param name="cancellationToken">The cancellation token for the request.</param>
+    /// <returns>
+    /// 200 OK with daily reputation snapshots ordered oldest to newest.
+    /// 404 Not Found if the profile does not exist.
+    /// </returns>
+    [HttpGet("{id:guid}/reputation-trend")]
+    public async Task<IActionResult> GetProfileReputationTrendAsync(Guid id, CancellationToken cancellationToken)
+    {
+        if (!await ProfileExistsAsync(id, cancellationToken))
+        {
+            return NotFound();
+        }
+
+        return Ok(await BuildReputationTrendAsync(id, cancellationToken));
+    }
+
+    private async Task<IReadOnlyList<ProfileReputationTrendPointResponse>> BuildReputationTrendAsync(
+        Guid profileId,
+        CancellationToken cancellationToken)
+    {
+        var reviewEvents = await db.Reviews
+            .AsNoTracking()
+            .Where(review => review.RevieweeProfileId == profileId)
+            .Select(review => new
+            {
+                OccurredAt = review.CreatedAt,
+                Rating = (int?)review.Rating,
+                CountsCompletedTask = false
+            })
+            .ToListAsync(cancellationToken);
+
+        var completedTaskEvents = await db.Tasks
+            .AsNoTracking()
+            .Where(task =>
+                task.Status == DomainTaskStatus.Completed
+                && (task.SeekerProfileId == profileId || task.AcceptedHelperProfileId == profileId))
+            .Select(task => new
+            {
+                OccurredAt = task.CompletedAt ?? task.UpdatedAt,
+                Rating = (int?)null,
+                CountsCompletedTask = true
+            })
+            .ToListAsync(cancellationToken);
+
+        var events = reviewEvents
+            .Concat(completedTaskEvents)
+            .OrderBy(reputationEvent => reputationEvent.OccurredAt)
+            .ThenBy(reputationEvent => reputationEvent.CountsCompletedTask)
+            .ToList();
+
+        var dailySnapshots = new List<ProfileReputationTrendPointResponse>();
+        decimal ratingSum = 0;
+        var reviewCount = 0;
+        var completedTaskCount = 0;
+
+        foreach (var reputationEvent in events)
+        {
+            if (reputationEvent.CountsCompletedTask)
+            {
+                completedTaskCount++;
+            }
+
+            if (reputationEvent.Rating is { } rating)
+            {
+                ratingSum += rating;
+                reviewCount++;
+            }
+
+            var averageRating = reviewCount > 0
+                ? decimal.Round(ratingSum / reviewCount, 2, MidpointRounding.AwayFromZero)
+                : 0m;
+            var snapshot = new ProfileReputationTrendPointResponse(
+                DateOnly.FromDateTime(reputationEvent.OccurredAt.UtcDateTime),
+                ReputationScoreCalculator.Compute(averageRating, reviewCount, completedTaskCount),
+                averageRating,
+                reviewCount,
+                completedTaskCount);
+
+            if (dailySnapshots.Count > 0 && dailySnapshots[^1].Date == snapshot.Date)
+            {
+                dailySnapshots[^1] = snapshot;
+            }
+            else
+            {
+                dailySnapshots.Add(snapshot);
+            }
+        }
+
+        return dailySnapshots
+            .TakeLast(ReputationTrendPointLimit)
+            .ToList();
+    }
+}

--- a/backend/Features/Profiles/ProfilesController.Reputation.cs
+++ b/backend/Features/Profiles/ProfilesController.Reputation.cs
@@ -33,76 +33,158 @@ public sealed partial class ProfilesController
         Guid profileId,
         CancellationToken cancellationToken)
     {
-        var reviewEvents = await db.Reviews
+        var reviewEventDaysQuery = db.Reviews
             .AsNoTracking()
             .Where(review => review.RevieweeProfileId == profileId)
             .Select(review => new
             {
-                OccurredAt = review.CreatedAt,
-                Rating = (int?)review.Rating,
-                CountsCompletedTask = false
-            })
-            .ToListAsync(cancellationToken);
+                review.CreatedAt.Year,
+                review.CreatedAt.Month,
+                review.CreatedAt.Day
+            });
 
-        var completedTaskEvents = await db.Tasks
+        var completedTaskEventDaysQuery = db.Tasks
             .AsNoTracking()
             .Where(task =>
                 task.Status == DomainTaskStatus.Completed
                 && (task.SeekerProfileId == profileId || task.AcceptedHelperProfileId == profileId))
             .Select(task => new
             {
-                OccurredAt = task.CompletedAt ?? task.UpdatedAt,
-                Rating = (int?)null,
-                CountsCompletedTask = true
+                Year = (task.CompletedAt ?? task.UpdatedAt).Year,
+                Month = (task.CompletedAt ?? task.UpdatedAt).Month,
+                Day = (task.CompletedAt ?? task.UpdatedAt).Day
+            });
+
+        var trendDaysDescending = await reviewEventDaysQuery
+            .Concat(completedTaskEventDaysQuery)
+            .Distinct()
+            .OrderByDescending(day => day.Year)
+            .ThenByDescending(day => day.Month)
+            .ThenByDescending(day => day.Day)
+            .Take(ReputationTrendPointLimit)
+            .ToListAsync(cancellationToken);
+
+        if (trendDaysDescending.Count == 0)
+        {
+            return Array.Empty<ProfileReputationTrendPointResponse>();
+        }
+
+        var trendDays = trendDaysDescending
+            .Select(day => new DateOnly(day.Year, day.Month, day.Day))
+            .OrderBy(day => day)
+            .ToList();
+
+        var earliestTrendDay = trendDays[0];
+        var earliestTrendStartUtc = new DateTimeOffset(
+            earliestTrendDay.Year,
+            earliestTrendDay.Month,
+            earliestTrendDay.Day,
+            0,
+            0,
+            0,
+            TimeSpan.Zero);
+
+        var reviewBaseline = await db.Reviews
+            .AsNoTracking()
+            .Where(review =>
+                review.RevieweeProfileId == profileId
+                && review.CreatedAt < earliestTrendStartUtc)
+            .GroupBy(_ => 1)
+            .Select(group => new
+            {
+                RatingSum = group.Sum(review => (decimal?)review.Rating) ?? 0m,
+                ReviewCount = group.Count()
+            })
+            .FirstOrDefaultAsync(cancellationToken);
+
+        var completedTaskBaseline = await db.Tasks
+            .AsNoTracking()
+            .Where(task =>
+                task.Status == DomainTaskStatus.Completed
+                && (task.SeekerProfileId == profileId || task.AcceptedHelperProfileId == profileId)
+                && (task.CompletedAt ?? task.UpdatedAt) < earliestTrendStartUtc)
+            .CountAsync(cancellationToken);
+
+        var reviewDailyAggregates = await db.Reviews
+            .AsNoTracking()
+            .Where(review =>
+                review.RevieweeProfileId == profileId
+                && review.CreatedAt >= earliestTrendStartUtc)
+            .GroupBy(review => new
+            {
+                review.CreatedAt.Year,
+                review.CreatedAt.Month,
+                review.CreatedAt.Day
+            })
+            .Select(group => new
+            {
+                group.Key.Year,
+                group.Key.Month,
+                group.Key.Day,
+                RatingSum = group.Sum(review => (decimal)review.Rating),
+                ReviewCount = group.Count()
             })
             .ToListAsync(cancellationToken);
 
-        var events = reviewEvents
-            .Concat(completedTaskEvents)
-            .OrderBy(reputationEvent => reputationEvent.OccurredAt)
-            .ThenBy(reputationEvent => reputationEvent.CountsCompletedTask)
-            .ToList();
-
-        var dailySnapshots = new List<ProfileReputationTrendPointResponse>();
-        decimal ratingSum = 0;
-        var reviewCount = 0;
-        var completedTaskCount = 0;
-
-        foreach (var reputationEvent in events)
-        {
-            if (reputationEvent.CountsCompletedTask)
+        var completedTaskDailyAggregates = await db.Tasks
+            .AsNoTracking()
+            .Where(task =>
+                task.Status == DomainTaskStatus.Completed
+                && (task.SeekerProfileId == profileId || task.AcceptedHelperProfileId == profileId)
+                && (task.CompletedAt ?? task.UpdatedAt) >= earliestTrendStartUtc)
+            .GroupBy(task => new
             {
-                completedTaskCount++;
+                Year = (task.CompletedAt ?? task.UpdatedAt).Year,
+                Month = (task.CompletedAt ?? task.UpdatedAt).Month,
+                Day = (task.CompletedAt ?? task.UpdatedAt).Day
+            })
+            .Select(group => new
+            {
+                group.Key.Year,
+                group.Key.Month,
+                group.Key.Day,
+                CompletedTaskCount = group.Count()
+            })
+            .ToListAsync(cancellationToken);
+
+        var reviewDailyAggregateMap = reviewDailyAggregates.ToDictionary(
+            aggregate => new DateOnly(aggregate.Year, aggregate.Month, aggregate.Day),
+            aggregate => new { aggregate.RatingSum, aggregate.ReviewCount });
+
+        var completedTaskDailyAggregateMap = completedTaskDailyAggregates.ToDictionary(
+            aggregate => new DateOnly(aggregate.Year, aggregate.Month, aggregate.Day),
+            aggregate => aggregate.CompletedTaskCount);
+
+        var dailySnapshots = new List<ProfileReputationTrendPointResponse>(trendDays.Count);
+        decimal ratingSum = reviewBaseline?.RatingSum ?? 0m;
+        var reviewCount = reviewBaseline?.ReviewCount ?? 0;
+        var completedTaskCount = completedTaskBaseline;
+
+        foreach (var trendDay in trendDays)
+        {
+            if (reviewDailyAggregateMap.TryGetValue(trendDay, out var reviewAggregate))
+            {
+                ratingSum += reviewAggregate.RatingSum;
+                reviewCount += reviewAggregate.ReviewCount;
             }
 
-            if (reputationEvent.Rating is { } rating)
+            if (completedTaskDailyAggregateMap.TryGetValue(trendDay, out var completedTasksOnDay))
             {
-                ratingSum += rating;
-                reviewCount++;
+                completedTaskCount += completedTasksOnDay;
             }
 
             var averageRating = reviewCount > 0
                 ? decimal.Round(ratingSum / reviewCount, 2, MidpointRounding.AwayFromZero)
                 : 0m;
-            var snapshot = new ProfileReputationTrendPointResponse(
-                DateOnly.FromDateTime(reputationEvent.OccurredAt.UtcDateTime),
+
+            dailySnapshots.Add(new ProfileReputationTrendPointResponse(
+                trendDay,
                 ReputationScoreCalculator.Compute(averageRating, reviewCount, completedTaskCount),
                 averageRating,
                 reviewCount,
-                completedTaskCount);
-
-            if (dailySnapshots.Count > 0 && dailySnapshots[^1].Date == snapshot.Date)
-            {
-                dailySnapshots[^1] = snapshot;
-            }
-            else
-            {
-                dailySnapshots.Add(snapshot);
-            }
+                completedTaskCount));
         }
 
-        return dailySnapshots
-            .TakeLast(ReputationTrendPointLimit)
-            .ToList();
+        return dailySnapshots;
     }
 }

--- a/backend/Features/Profiles/ProfilesController.cs
+++ b/backend/Features/Profiles/ProfilesController.cs
@@ -1,6 +1,7 @@
 using System.Security.Claims;
 using Backend.Domain.Entities;
 using Backend.Domain.Enums;
+using Backend.Domain.Reputation;
 using Backend.Infrastructure.Persistence;
 using Backend.Infrastructure.Security;
 using Backend.Infrastructure.Storage;
@@ -51,7 +52,9 @@ public sealed partial class ProfilesController(AppDbContext db, IBlobStorageServ
             LocationText = privacy?.ShowLocation == true ? profile.LocationText : null,
             AverageRating = profile.AverageRating,
             ReviewCount = profile.ReviewCount,
-            CompletedTaskCount = profile.CompletedTaskCount
+            CompletedTaskCount = profile.CompletedTaskCount,
+            ReputationScore = ReputationScoreCalculator.Compute(
+                profile.AverageRating, profile.ReviewCount, profile.CompletedTaskCount)
         };
 
         return Ok(response);
@@ -227,6 +230,8 @@ public sealed partial class ProfilesController(AppDbContext db, IBlobStorageServ
             AverageRating = profile.AverageRating,
             ReviewCount = profile.ReviewCount,
             CompletedTaskCount = profile.CompletedTaskCount,
+            ReputationScore = ReputationScoreCalculator.Compute(
+                profile.AverageRating, profile.ReviewCount, profile.CompletedTaskCount),
             CreatedAt = profile.CreatedAt,
             UpdatedAt = profile.UpdatedAt,
             SkillIds = profile.ProfileSkills.Select(ps => ps.SkillId).ToList(),
@@ -339,6 +344,8 @@ public sealed partial class ProfilesController(AppDbContext db, IBlobStorageServ
             AverageRating = profile.AverageRating,
             ReviewCount = profile.ReviewCount,
             CompletedTaskCount = profile.CompletedTaskCount,
+            ReputationScore = ReputationScoreCalculator.Compute(
+                profile.AverageRating, profile.ReviewCount, profile.CompletedTaskCount),
             CreatedAt = profile.CreatedAt,
             UpdatedAt = profile.UpdatedAt,
             SkillIds = profile.ProfileSkills.Select(ps => ps.SkillId).ToList(),

--- a/backend/Features/Profiles/PublicProfileResponse.cs
+++ b/backend/Features/Profiles/PublicProfileResponse.cs
@@ -27,4 +27,7 @@ public sealed record PublicProfileResponse
     public required decimal AverageRating { get; init; }
     public required int ReviewCount { get; init; }
     public required int CompletedTaskCount { get; init; }
+
+    /// <summary>Gets the aggregate reputation score surfaced in the profile widget.</summary>
+    public required int ReputationScore { get; init; }
 }

--- a/backend/Infrastructure/Persistence/Analytics/ProfileReputation.cs
+++ b/backend/Infrastructure/Persistence/Analytics/ProfileReputation.cs
@@ -1,3 +1,5 @@
+using Backend.Domain.Reputation;
+
 namespace Backend.Infrastructure.Persistence.Analytics;
 
 public sealed class ProfileReputation
@@ -6,4 +8,14 @@ public sealed class ProfileReputation
     public decimal AverageRating { get; set; }
     public long ReviewCount { get; set; }
     public long CompletedTaskCount { get; set; }
+
+    /// <summary>
+    /// Gets the aggregate reputation score derived from the other three fields via
+    /// <see cref="ReputationScoreCalculator"/>. Computed on demand so it
+    /// stays in sync with whatever the persisted aggregates are.
+    /// </summary>
+    public int Score => ReputationScoreCalculator.Compute(
+        AverageRating,
+        checked((int)Math.Min(ReviewCount, int.MaxValue)),
+        checked((int)Math.Min(CompletedTaskCount, int.MaxValue)));
 }

--- a/frontend/app/component-gallery/page.tsx
+++ b/frontend/app/component-gallery/page.tsx
@@ -15,6 +15,8 @@ import {
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Textarea } from "@/components/ui/textarea"
+import { ReputationCard } from "@/components/profile/reputation-card"
+import { ReputationSummary } from "@/components/shared/reputation-summary"
 import {
   colorTokenGroups,
   fontTokens,
@@ -55,6 +57,61 @@ const badgeVariants = [
   "muted",
   "ghost",
   "link",
+] as const
+
+const singleReviewTrend = [
+  {
+    date: "2026-01-04",
+    score: 10,
+    averageRating: 0,
+    reviewCount: 0,
+    completedTaskCount: 1,
+  },
+  {
+    date: "2026-01-08",
+    score: 20,
+    averageRating: 5,
+    reviewCount: 1,
+    completedTaskCount: 1,
+  },
+  {
+    date: "2026-01-12",
+    score: 50,
+    averageRating: 5,
+    reviewCount: 1,
+    completedTaskCount: 4,
+  },
+] as const
+
+const highVolumeTrend = [
+  {
+    date: "2026-02-01",
+    score: 98,
+    averageRating: 4.75,
+    reviewCount: 4,
+    completedTaskCount: 6,
+  },
+  {
+    date: "2026-02-12",
+    score: 235,
+    averageRating: 4.8,
+    reviewCount: 12,
+    completedTaskCount: 12,
+  },
+  {
+    date: "2026-03-02",
+    score: 397,
+    averageRating: 4.7,
+    reviewCount: 21,
+    completedTaskCount: 20,
+  },
+  {
+    date: "2026-03-19",
+    score: 584,
+    averageRating: 4.9,
+    reviewCount: 31,
+    completedTaskCount: 28,
+  },
 ] as const
 
 export default function ComponentGalleryPage() {
@@ -214,6 +271,80 @@ export default function ComponentGalleryPage() {
                 </Button>
               </CardFooter>
             </Card>
+          </div>
+        </GallerySection>
+
+        <GallerySection
+          title="Reputation"
+          description="Profile reputation widget and the inline summary primitive that other surfaces compose."
+        >
+          <div className="grid gap-6 lg:grid-cols-2">
+            <ComponentPanel title="Inline summary (sm)">
+              <div className="flex flex-col gap-3">
+                <ReputationSummary
+                  score={0}
+                  averageRating={0}
+                  reviewCount={0}
+                  completedTaskCount={0}
+                />
+                <ReputationSummary
+                  score={40}
+                  averageRating={5}
+                  reviewCount={1}
+                  completedTaskCount={3}
+                />
+                <ReputationSummary
+                  score={584}
+                  averageRating={4.9}
+                  reviewCount={31}
+                  completedTaskCount={28}
+                />
+                <ReputationSummary
+                  score={584}
+                  averageRating={4.9}
+                  reviewCount={31}
+                  completedTaskCount={28}
+                  size="md"
+                />
+                <ReputationSummary
+                  score={584}
+                  averageRating={4.9}
+                  reviewCount={31}
+                  completedTaskCount={28}
+                  showScore={false}
+                />
+              </div>
+            </ComponentPanel>
+
+            <ComponentPanel title="Dashboard widget - new user">
+              <ReputationCard
+                score={0}
+                averageRating={0}
+                reviewCount={0}
+                completedTaskCount={0}
+                showOwnerCtas
+              />
+            </ComponentPanel>
+
+            <ComponentPanel title="Dashboard widget - single review">
+              <ReputationCard
+                score={50}
+                averageRating={5}
+                reviewCount={1}
+                completedTaskCount={4}
+                trend={singleReviewTrend}
+              />
+            </ComponentPanel>
+
+            <ComponentPanel title="Dashboard widget - high volume helper">
+              <ReputationCard
+                score={584}
+                averageRating={4.9}
+                reviewCount={31}
+                completedTaskCount={28}
+                trend={highVolumeTrend}
+              />
+            </ComponentPanel>
           </div>
         </GallerySection>
       </div>

--- a/frontend/components/profile/profile-page-content.tsx
+++ b/frontend/components/profile/profile-page-content.tsx
@@ -18,6 +18,7 @@ import {
   profileKeys,
   toProfileUser,
   useOwnProfile,
+  useProfileReputationTrend,
   useProfileReviews,
   useProfileTaskHistory,
   usePublicProfile,
@@ -62,6 +63,7 @@ export function ProfilePageContent({
       canEdit={isOwnRoute || isOwner}
       editHref={editHref}
       showMessage={!isOwnRoute && !isOwner}
+      showOwnerCtas={isOwnRoute || isOwner}
     />
   )
 }
@@ -71,11 +73,13 @@ function ProfileLoaded({
   canEdit,
   editHref,
   showMessage,
+  showOwnerCtas,
 }: {
   profile: OwnProfileResponse | PublicProfileResponse
   canEdit: boolean
   editHref: string
   showMessage: boolean
+  showOwnerCtas: boolean
 }) {
   const skillIds = "skillIds" in profile ? profile.skillIds : []
   const skillQueries = useQueries({
@@ -91,6 +95,7 @@ function ProfileLoaded({
   const profileUser = toProfileUser(profile, skillNames)
   const reviewsQuery = useProfileReviews(profile.id)
   const taskHistoryQuery = useProfileTaskHistory(profile.id)
+  const reputationTrendQuery = useProfileReputationTrend(profile.id)
   const reviews = reviewsQuery.data ?? []
   const taskHistory = taskHistoryQuery.data ?? []
   const reviewsCount = reviewsQuery.data?.length ?? profile.reviewCount
@@ -114,9 +119,12 @@ function ProfileLoaded({
         }
       />
       <ReputationCard
+        score={profileUser.reputation.points}
         averageRating={profileUser.reputation.averageRating}
         reviewCount={profileUser.reputation.reviewCount}
         completedTaskCount={profileUser.reputation.completedTasks}
+        trend={reputationTrendQuery.data ?? []}
+        showOwnerCtas={showOwnerCtas}
       />
 
       <Tabs defaultValue="reviews">

--- a/frontend/components/profile/reputation-card.tsx
+++ b/frontend/components/profile/reputation-card.tsx
@@ -321,7 +321,7 @@ function TrendPanel({ trend }: { trend: readonly ReputationTrendPoint[] }) {
 
   const first = points[0]
   const last = points[points.length - 1]
-  const comparisonScore = points.length > 1 ? first.score : 0
+  const comparisonScore = points.length > 1 ? first.score : first.score
   const delta = last.score - comparisonScore
   const deltaLabel =
     delta > 0

--- a/frontend/components/profile/reputation-card.tsx
+++ b/frontend/components/profile/reputation-card.tsx
@@ -1,49 +1,497 @@
+"use client"
+
+import Link from "next/link"
 import type { ReactNode } from "react"
+import { HugeiconsIcon } from "@hugeicons/react"
+import type { IconSvgElement } from "@hugeicons/react"
+import {
+  Award01Icon,
+  ChartLineData01Icon,
+  InformationCircleIcon,
+  StarIcon,
+  TaskDone01Icon,
+} from "@hugeicons/core-free-icons"
 
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip"
 import { RatingStars } from "@/components/shared/rating-stars"
+import {
+  COMPLETED_TASK_WEIGHT,
+  REVIEW_QUALITY_WEIGHT,
+  nextTierForScore,
+  reputationScoreBreakdown,
+  tierForScore,
+} from "@/lib/reputation"
+import { cn } from "@/lib/utils"
 
-interface ReputationCardProps {
+interface ReputationTrendPoint {
+  date: string
+  score: number
   averageRating: number
   reviewCount: number
   completedTaskCount: number
 }
 
+interface ReputationCardProps {
+  /** Aggregate reputation score (server-computed, with a client fallback). */
+  score: number
+  averageRating: number
+  reviewCount: number
+  completedTaskCount: number
+  /** Backend-computed cumulative reputation snapshots for the sparkline. */
+  trend?: readonly ReputationTrendPoint[]
+  /**
+   * When `true`, the empty-state shows CTAs aimed at the profile owner
+   * (post a task / browse helper requests). For public profiles we hide them.
+   */
+  showOwnerCtas?: boolean
+  className?: string
+}
+
+/**
+ * Reputation dashboard widget rendered on the profile.
+ *
+ * Composes {@link ReputationSummary}-style metrics (score, rating, completed)
+ * with a tier badge, a tooltip explaining how the score is computed, a
+ * progress bar toward the next tier, and a guided empty state for new users.
+ */
 export function ReputationCard({
+  score,
   averageRating,
   reviewCount,
   completedTaskCount,
+  trend = [],
+  showOwnerCtas = false,
+  className,
 }: ReputationCardProps) {
+  const breakdown = reputationScoreBreakdown({
+    score,
+    averageRating,
+    reviewCount,
+    completedTaskCount,
+  })
+  const tier = tierForScore(breakdown.total)
+  const nextTier = nextTierForScore(breakdown.total)
+  const isEmpty =
+    breakdown.total === 0 &&
+    breakdown.reviewCount === 0 &&
+    breakdown.completedTaskCount === 0
+
   return (
-    <Card>
-      <CardHeader>
+    <Card className={className}>
+      <CardHeader className="flex flex-row items-center justify-between">
         <CardTitle className="text-sm tracking-wide text-muted-foreground uppercase">
           Reputation
         </CardTitle>
+        <Badge variant={isEmpty ? "muted" : "warning"} className="gap-1">
+          <HugeiconsIcon icon={Award01Icon} />
+          {tier.label}
+        </Badge>
       </CardHeader>
-      <CardContent className="grid grid-cols-2 gap-4 sm:grid-cols-3">
-        <Stat
-          label="Rating"
-          value={
-            <RatingStars
-              size="md"
-              value={averageRating}
-              reviewCount={reviewCount}
-            />
-          }
-        />
-        <Stat label="Reviews" value={reviewCount.toString()} />
-        <Stat label="Completed" value={completedTaskCount.toString()} />
+      <CardContent className="flex flex-col gap-5">
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+          <Stat
+            icon={Award01Icon}
+            label="Score"
+            value={
+              <span className="font-heading text-2xl font-semibold tracking-tight tabular-nums">
+                {breakdown.total.toLocaleString()}
+              </span>
+            }
+            hint={
+              <ScoreBreakdownTooltip
+                completedComponent={breakdown.completedComponent}
+                reviewComponent={breakdown.reviewComponent}
+                completedTaskCount={breakdown.completedTaskCount}
+                averageRating={breakdown.averageRating}
+                reviewCount={breakdown.reviewCount}
+                total={breakdown.total}
+              />
+            }
+            accent
+          />
+          <Stat
+            icon={StarIcon}
+            label="Average rating"
+            value={
+              <RatingStars
+                size="md"
+                value={breakdown.averageRating}
+                reviewCount={breakdown.reviewCount}
+              />
+            }
+            hint={
+              breakdown.reviewCount > 0
+                ? `${breakdown.averageRating.toFixed(1)} from ${formatCount(
+                    breakdown.reviewCount,
+                    "review",
+                    "reviews"
+                  )}`
+                : "No reviews yet"
+            }
+          />
+          <Stat
+            icon={TaskDone01Icon}
+            label="Completed tasks"
+            value={
+              <span className="font-heading text-2xl font-semibold tracking-tight tabular-nums">
+                {breakdown.completedTaskCount.toLocaleString()}
+              </span>
+            }
+            hint={
+              breakdown.completedTaskCount === 1
+                ? "task completed"
+                : "tasks completed"
+            }
+          />
+        </div>
+
+        <TrendPanel trend={trend} />
+
+        {nextTier ? (
+          <NextTierProgress
+            currentScore={breakdown.total}
+            nextTierLabel={nextTier.label}
+            nextTierMin={nextTier.minScore}
+          />
+        ) : null}
+
+        {isEmpty ? <EmptyState showOwnerCtas={showOwnerCtas} /> : null}
       </CardContent>
     </Card>
   )
 }
 
-function Stat({ label, value }: { label: string; value: ReactNode }) {
+interface StatProps {
+  icon: IconSvgElement
+  label: string
+  value: ReactNode
+  hint?: ReactNode
+  accent?: boolean
+}
+
+function Stat({ icon, label, value, hint, accent = false }: StatProps) {
   return (
-    <div className="flex flex-col gap-1">
-      <span className="text-xs text-muted-foreground">{label}</span>
-      <span className="text-base leading-none font-semibold">{value}</span>
+    <div className="flex items-start gap-3">
+      <div
+        className={cn(
+          "flex size-9 shrink-0 items-center justify-center rounded-lg ring-1 ring-foreground/10",
+          accent
+            ? "bg-reputation/15 text-reputation"
+            : "bg-muted text-muted-foreground"
+        )}
+        aria-hidden
+      >
+        <HugeiconsIcon icon={icon} className="size-4" strokeWidth={1.5} />
+      </div>
+      <div className="flex min-w-0 flex-col gap-1">
+        <span className="text-xs text-muted-foreground">{label}</span>
+        <span className="text-base leading-none font-semibold">{value}</span>
+        {hint ? (
+          <span className="text-xs text-muted-foreground">{hint}</span>
+        ) : null}
+      </div>
     </div>
   )
+}
+
+interface ScoreBreakdownTooltipProps {
+  completedComponent: number
+  reviewComponent: number
+  completedTaskCount: number
+  averageRating: number
+  reviewCount: number
+  total: number
+}
+
+function ScoreBreakdownTooltip({
+  completedComponent,
+  reviewComponent,
+  completedTaskCount,
+  averageRating,
+  reviewCount,
+  total,
+}: ScoreBreakdownTooltipProps) {
+  return (
+    <TooltipProvider delayDuration={150}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            type="button"
+            className="inline-flex items-center gap-1 rounded-sm text-xs text-muted-foreground underline-offset-2 hover:underline focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none"
+            aria-label="How is the reputation score calculated?"
+          >
+            <HugeiconsIcon
+              icon={InformationCircleIcon}
+              className="size-3.5"
+              strokeWidth={1.5}
+            />
+            How is this calculated?
+          </button>
+        </TooltipTrigger>
+        <TooltipContent
+          side="bottom"
+          align="start"
+          className="max-w-xs px-3 py-2 text-left"
+        >
+          <p className="font-semibold">Reputation score</p>
+          <p className="mt-1 text-muted-foreground">
+            Each completed task is worth {COMPLETED_TASK_WEIGHT} points; each
+            review multiplies your average rating by {REVIEW_QUALITY_WEIGHT}.
+          </p>
+          <dl className="mt-2 grid grid-cols-[1fr_auto] gap-x-3 gap-y-0.5 tabular-nums">
+            <dt>
+              {completedTaskCount} x {COMPLETED_TASK_WEIGHT}
+            </dt>
+            <dd className="text-right">{completedComponent}</dd>
+            <dt>
+              {averageRating.toFixed(1)} x {reviewCount} x{" "}
+              {REVIEW_QUALITY_WEIGHT}
+            </dt>
+            <dd className="text-right">{reviewComponent}</dd>
+            <dt className="border-t border-border/50 pt-1 font-semibold">
+              Total
+            </dt>
+            <dd className="border-t border-border/50 pt-1 text-right font-semibold">
+              {total}
+            </dd>
+          </dl>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  )
+}
+
+interface NextTierProgressProps {
+  currentScore: number
+  nextTierLabel: string
+  nextTierMin: number
+}
+
+function NextTierProgress({
+  currentScore,
+  nextTierLabel,
+  nextTierMin,
+}: NextTierProgressProps) {
+  const ratio =
+    nextTierMin > 0 ? Math.min(1, Math.max(0, currentScore / nextTierMin)) : 1
+  const pct = Math.round(ratio * 100)
+  const remaining = Math.max(0, nextTierMin - currentScore)
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex items-center justify-between text-xs text-muted-foreground">
+        <span>
+          {remaining > 0
+            ? `${remaining.toLocaleString()} points to ${nextTierLabel}`
+            : `Ready for ${nextTierLabel}`}
+        </span>
+        <span className="tabular-nums">{pct}%</span>
+      </div>
+      <div
+        className="h-1.5 w-full overflow-hidden rounded-full bg-muted"
+        role="progressbar"
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-valuenow={pct}
+        aria-label={`Progress to ${nextTierLabel} tier`}
+      >
+        <div
+          className="h-full rounded-full bg-reputation transition-[width]"
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+    </div>
+  )
+}
+
+function TrendPanel({ trend }: { trend: readonly ReputationTrendPoint[] }) {
+  const points = normalizeTrend(trend)
+
+  if (points.length === 0) {
+    return null
+  }
+
+  const first = points[0]
+  const last = points[points.length - 1]
+  const comparisonScore = points.length > 1 ? first.score : 0
+  const delta = last.score - comparisonScore
+  const deltaLabel =
+    delta > 0
+      ? `+${delta.toLocaleString()}`
+      : delta < 0
+        ? `-${Math.abs(delta).toLocaleString()}`
+        : "No change"
+
+  return (
+    <div className="grid gap-3 rounded-lg border border-border bg-muted/20 p-3 sm:grid-cols-[minmax(0,1fr)_11rem] sm:items-center">
+      <div className="flex items-start gap-3">
+        <div
+          className="flex size-9 shrink-0 items-center justify-center rounded-lg bg-reputation/15 text-reputation ring-1 ring-foreground/10"
+          aria-hidden
+        >
+          <HugeiconsIcon
+            icon={ChartLineData01Icon}
+            className="size-4"
+            strokeWidth={1.5}
+          />
+        </div>
+        <div className="min-w-0">
+          <p className="text-xs text-muted-foreground">Trend</p>
+          <p className="font-heading text-lg font-semibold tracking-tight tabular-nums">
+            {deltaLabel}
+          </p>
+          <p className="text-xs text-muted-foreground">
+            {formatTrendSpan(first.date, last.date)}
+          </p>
+        </div>
+      </div>
+      <Sparkline points={points} />
+    </div>
+  )
+}
+
+function Sparkline({ points }: { points: readonly ReputationTrendPoint[] }) {
+  const width = 176
+  const height = 56
+  const padding = 4
+  const plotWidth = width - padding * 2
+  const plotHeight = height - padding * 2
+  const scores = points.map((point) => point.score)
+  const minScore = Math.min(...scores)
+  const maxScore = Math.max(...scores)
+  const scoreRange = Math.max(1, maxScore - minScore)
+  const xStep = points.length > 1 ? plotWidth / (points.length - 1) : 0
+  const plotted = points.map((point, index) => {
+    const x = points.length > 1 ? padding + index * xStep : width / 2
+    const y =
+      padding +
+      plotHeight -
+      ((point.score - minScore) / scoreRange) * plotHeight
+
+    return { x, y }
+  })
+  const polyline = plotted
+    .map((point) => `${point.x.toFixed(2)},${point.y.toFixed(2)}`)
+    .join(" ")
+  const linePath = plotted
+    .map((point) => `${point.x.toFixed(2)} ${point.y.toFixed(2)}`)
+    .join(" L ")
+  const areaPath =
+    plotted.length > 1
+      ? `M ${plotted[0].x.toFixed(2)} ${height - padding} L ${linePath} L ${plotted[
+          plotted.length - 1
+        ].x.toFixed(2)} ${height - padding} Z`
+      : ""
+  const last = plotted[plotted.length - 1]
+
+  return (
+    <svg
+      role="img"
+      aria-label={`Reputation trend from ${formatShortDate(
+        points[0].date
+      )} to ${formatShortDate(points[points.length - 1].date)}`}
+      viewBox={`0 0 ${width} ${height}`}
+      className="h-14 w-full text-reputation"
+    >
+      {areaPath ? (
+        <path d={areaPath} className="fill-current opacity-15" />
+      ) : null}
+      {plotted.length > 1 ? (
+        <polyline
+          points={polyline}
+          fill="none"
+          stroke="currentColor"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth={2}
+          vectorEffect="non-scaling-stroke"
+        />
+      ) : null}
+      <circle
+        cx={last.x}
+        cy={last.y}
+        r={2.75}
+        className="fill-background stroke-current"
+        strokeWidth={2}
+      />
+    </svg>
+  )
+}
+
+function EmptyState({ showOwnerCtas }: { showOwnerCtas: boolean }) {
+  return (
+    <div className="rounded-lg border border-dashed border-border bg-muted/30 p-3 text-sm">
+      <p className="font-medium">No reputation yet</p>
+      <p className="mt-1 text-xs text-muted-foreground">
+        Complete tasks and collect reviews to start building reputation.
+      </p>
+      {showOwnerCtas ? (
+        <div className="mt-3 flex flex-wrap gap-2">
+          <Button asChild size="sm">
+            <Link href="/feed">Find a task to help with</Link>
+          </Button>
+          <Button asChild size="sm" variant="outline">
+            <Link href="/post-task">Post your first task</Link>
+          </Button>
+        </div>
+      ) : null}
+    </div>
+  )
+}
+
+function normalizeTrend(
+  trend: readonly ReputationTrendPoint[]
+): ReputationTrendPoint[] {
+  return trend
+    .map((point) => ({
+      ...point,
+      score: Number.isFinite(point.score)
+        ? Math.max(0, Math.round(point.score))
+        : 0,
+      averageRating: Number.isFinite(point.averageRating)
+        ? Math.max(0, Math.min(5, point.averageRating))
+        : 0,
+      reviewCount: Number.isFinite(point.reviewCount)
+        ? Math.max(0, Math.round(point.reviewCount))
+        : 0,
+      completedTaskCount: Number.isFinite(point.completedTaskCount)
+        ? Math.max(0, Math.round(point.completedTaskCount))
+        : 0,
+    }))
+    .filter((point) => point.date.length > 0)
+    .sort((a, b) => a.date.localeCompare(b.date))
+}
+
+function formatTrendSpan(startDate: string, endDate: string) {
+  if (startDate === endDate) {
+    return `Since ${formatShortDate(startDate)}`
+  }
+
+  return `${formatShortDate(startDate)} - ${formatShortDate(endDate)}`
+}
+
+function formatShortDate(date: string) {
+  const parsed = new Date(`${date}T00:00:00Z`)
+
+  if (Number.isNaN(parsed.getTime())) {
+    return date
+  }
+
+  return new Intl.DateTimeFormat(undefined, {
+    day: "numeric",
+    month: "short",
+  }).format(parsed)
+}
+
+function formatCount(value: number, singular: string, plural: string) {
+  const label = value === 1 ? singular : plural
+  return `${value.toLocaleString()} ${label}`
 }

--- a/frontend/components/shared/reputation-summary.tsx
+++ b/frontend/components/shared/reputation-summary.tsx
@@ -1,0 +1,100 @@
+import { HugeiconsIcon } from "@hugeicons/react"
+import { Award01Icon, TaskDone01Icon } from "@hugeicons/core-free-icons"
+
+import { RatingStars } from "@/components/shared/rating-stars"
+import { cn } from "@/lib/utils"
+
+interface ReputationSummaryProps {
+  score: number
+  averageRating: number
+  reviewCount: number
+  completedTaskCount: number
+  /** Visual density. `sm` is suitable for inline use inside cards/chips. */
+  size?: "sm" | "md"
+  /**
+   * When `false` the score chip is hidden — handy on dense list rows where
+   * stars + completion count are enough.
+   */
+  showScore?: boolean
+  className?: string
+}
+
+const SIZES = {
+  sm: {
+    gap: "gap-2.5",
+    chip: "gap-1 px-2 py-0.5 text-xs",
+    icon: "size-3.5",
+    counter: "text-xs",
+  },
+  md: {
+    gap: "gap-3",
+    chip: "gap-1.5 px-2.5 py-1 text-sm",
+    icon: "size-4",
+    counter: "text-sm",
+  },
+} as const
+
+/**
+ * Compact reputation triple — score · average rating · completed count —
+ * reusable on profile cards, feed rows, helper chips, and the dashboard
+ * widget. Render-only; data fetching belongs upstream.
+ */
+export function ReputationSummary({
+  score,
+  averageRating,
+  reviewCount,
+  completedTaskCount,
+  size = "sm",
+  showScore = true,
+  className,
+}: ReputationSummaryProps) {
+  const sizeCx = SIZES[size]
+  const safeScore = Number.isFinite(score) ? Math.max(0, Math.round(score)) : 0
+
+  return (
+    <div
+      className={cn(
+        "inline-flex flex-wrap items-center",
+        sizeCx.gap,
+        className
+      )}
+      aria-label={`Reputation score ${safeScore}, ${averageRating.toFixed(
+        1
+      )} stars from ${reviewCount} reviews, ${completedTaskCount} completed tasks`}
+    >
+      {showScore ? (
+        <span
+          className={cn(
+            "inline-flex items-center rounded-full bg-reputation/15 font-medium text-reputation tabular-nums",
+            sizeCx.chip
+          )}
+        >
+          <HugeiconsIcon
+            icon={Award01Icon}
+            className={sizeCx.icon}
+            strokeWidth={1.5}
+          />
+          {safeScore.toLocaleString()}
+        </span>
+      ) : null}
+      <RatingStars
+        size={size === "md" ? "md" : "sm"}
+        value={averageRating}
+        reviewCount={reviewCount}
+      />
+      <span
+        className={cn(
+          "inline-flex items-center gap-1 text-muted-foreground tabular-nums",
+          sizeCx.counter
+        )}
+      >
+        <HugeiconsIcon
+          icon={TaskDone01Icon}
+          className={sizeCx.icon}
+          strokeWidth={1.5}
+        />
+        {completedTaskCount.toLocaleString()}
+      </span>
+    </div>
+  )
+}

--- a/frontend/lib/api/profile.ts
+++ b/frontend/lib/api/profile.ts
@@ -32,6 +32,12 @@ export interface OwnProfileResponse {
   averageRating: number
   reviewCount: number
   completedTaskCount: number
+  /**
+   * Aggregate reputation score computed by the backend. Optional on the
+   * client so older payloads or offline fixtures can fall back to
+   * {@link computeReputationScore}.
+   */
+  reputationScore?: number
   createdAt: string
   updatedAt: string
   skillIds: string[]
@@ -50,6 +56,7 @@ export interface PublicProfileResponse {
   averageRating: number
   reviewCount: number
   completedTaskCount: number
+  reputationScore?: number
 }
 
 export interface UpdateOwnProfileRequest {
@@ -99,6 +106,14 @@ export interface ProfileTaskHistoryResponse {
   createdAt: string
 }
 
+export interface ProfileReputationTrendPointResponse {
+  date: string
+  score: number
+  averageRating: number
+  reviewCount: number
+  completedTaskCount: number
+}
+
 export interface ProfileTaskHistoryItem {
   id: string
   title: string
@@ -115,6 +130,8 @@ export const profileKeys = {
   reviews: (id: string) => [...profileKeys.public(id), "reviews"] as const,
   taskHistory: (id: string) =>
     [...profileKeys.public(id), "task-history"] as const,
+  reputationTrend: (id: string) =>
+    [...profileKeys.public(id), "reputation-trend"] as const,
   skill: (id: string) => ["skills", "detail", id] as const,
   skills: (prefix: string) => ["skills", "search", prefix] as const,
 }
@@ -209,6 +226,17 @@ export function useProfileTaskHistory(id: string) {
 
       return tasks.map(toProfileTaskHistoryItem)
     },
+    enabled: id.length > 0,
+  })
+}
+
+export function useProfileReputationTrend(id: string) {
+  return useQuery({
+    queryKey: profileKeys.reputationTrend(id),
+    queryFn: () =>
+      apiClient.get<ProfileReputationTrendPointResponse[]>(
+        `/profiles/${id}/reputation-trend`
+      ),
     enabled: id.length > 0,
   })
 }
@@ -326,13 +354,53 @@ function toTaskStatus(status: string): TaskStatus {
 function toReputation(
   profile: Pick<
     OwnProfileResponse | PublicProfileResponse,
-    "averageRating" | "reviewCount" | "completedTaskCount"
+    "averageRating" | "reviewCount" | "completedTaskCount" | "reputationScore"
   >
 ): Reputation {
+  const averageRating = Number(profile.averageRating)
+  const fallbackScore = computeReputationScore({
+    averageRating,
+    reviewCount: profile.reviewCount,
+    completedTaskCount: profile.completedTaskCount,
+  })
   return {
-    points: profile.completedTaskCount,
-    averageRating: Number(profile.averageRating),
+    // Prefer the backend value when present so the client mirrors the
+    // canonical formula; fall back to the local computation otherwise.
+    points:
+      typeof profile.reputationScore === "number" &&
+      Number.isFinite(profile.reputationScore)
+        ? Math.max(0, Math.round(profile.reputationScore))
+        : fallbackScore,
+    averageRating,
     reviewCount: profile.reviewCount,
     completedTasks: profile.completedTaskCount,
   }
+}
+
+/** Weight applied to each completed task in {@link computeReputationScore}. */
+export const COMPLETED_TASK_WEIGHT = 10
+/** Weight applied to (averageRating x reviewCount) in {@link computeReputationScore}. */
+export const REVIEW_QUALITY_WEIGHT = 2
+
+/**
+ * Aggregate reputation score derived from completed tasks weighted by review
+ * quality. Mirrors `Backend.Domain.Reputation.ReputationScoreCalculator` so
+ * the client can render a score offline or when an older API payload omits it.
+ *
+ * Formula: round(completedTasks x COMPLETED_TASK_WEIGHT
+ *               + averageRating x reviewCount x REVIEW_QUALITY_WEIGHT)
+ */
+export function computeReputationScore(input: {
+  averageRating: number
+  reviewCount: number
+  completedTaskCount: number
+}): number {
+  const rating = Number.isFinite(input.averageRating)
+    ? Math.max(0, Math.min(5, input.averageRating))
+    : 0
+  const reviews = Math.max(0, input.reviewCount)
+  const completed = Math.max(0, input.completedTaskCount)
+  return Math.round(
+    completed * COMPLETED_TASK_WEIGHT + rating * reviews * REVIEW_QUALITY_WEIGHT
+  )
 }

--- a/frontend/lib/api/profile.ts
+++ b/frontend/lib/api/profile.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 
 import { apiClient } from "@/lib/api/client"
+import { COMPLETED_TASK_WEIGHT, REVIEW_QUALITY_WEIGHT } from "@/lib/reputation"
 import type {
   Reputation,
   Review,
@@ -376,11 +377,6 @@ function toReputation(
     completedTasks: profile.completedTaskCount,
   }
 }
-
-/** Weight applied to each completed task in {@link computeReputationScore}. */
-export const COMPLETED_TASK_WEIGHT = 10
-/** Weight applied to (averageRating x reviewCount) in {@link computeReputationScore}. */
-export const REVIEW_QUALITY_WEIGHT = 2
 
 /**
  * Aggregate reputation score derived from completed tasks weighted by review

--- a/frontend/lib/reputation.ts
+++ b/frontend/lib/reputation.ts
@@ -1,0 +1,80 @@
+import { COMPLETED_TASK_WEIGHT, REVIEW_QUALITY_WEIGHT } from "@/lib/api/profile"
+
+/**
+ * Tier identifiers shown next to the reputation score. Order matters —
+ * `tierForScore` walks the list and returns the highest tier the score
+ * qualifies for.
+ */
+export type ReputationTier = "newcomer" | "bronze" | "silver" | "gold"
+
+interface TierDefinition {
+  id: ReputationTier
+  label: string
+  /** Minimum score (inclusive) required to reach this tier. */
+  minScore: number
+}
+
+/**
+ * Tier thresholds. Picked to match the score formula:
+ *   bronze ≈ a few completed tasks or a handful of decent reviews,
+ *   silver ≈ established helper with ~20 completions,
+ *   gold   ≈ power user with sustained high ratings.
+ */
+export const REPUTATION_TIERS: readonly TierDefinition[] = [
+  { id: "newcomer", label: "Newcomer", minScore: 0 },
+  { id: "bronze", label: "Bronze", minScore: 50 },
+  { id: "silver", label: "Silver", minScore: 250 },
+  { id: "gold", label: "Gold", minScore: 750 },
+]
+
+export function tierForScore(score: number): TierDefinition {
+  const safe = Number.isFinite(score) ? Math.max(0, score) : 0
+  let current = REPUTATION_TIERS[0]
+  for (const tier of REPUTATION_TIERS) {
+    if (safe >= tier.minScore) {
+      current = tier
+    }
+  }
+  return current
+}
+
+export function nextTierForScore(score: number): TierDefinition | null {
+  const safe = Number.isFinite(score) ? Math.max(0, score) : 0
+  return REPUTATION_TIERS.find((tier) => safe < tier.minScore) ?? null
+}
+
+export interface ReputationScoreBreakdown {
+  averageRating: number
+  reviewCount: number
+  completedTaskCount: number
+  /** Contribution from completed tasks: completed × COMPLETED_TASK_WEIGHT. */
+  completedComponent: number
+  /** Contribution from review quality: rating × reviewCount × REVIEW_QUALITY_WEIGHT. */
+  reviewComponent: number
+  /** Final rounded score. */
+  total: number
+}
+
+export function reputationScoreBreakdown(input: {
+  score: number
+  averageRating: number
+  reviewCount: number
+  completedTaskCount: number
+}): ReputationScoreBreakdown {
+  const rating = Number.isFinite(input.averageRating)
+    ? Math.max(0, Math.min(5, input.averageRating))
+    : 0
+  const reviews = Math.max(0, input.reviewCount)
+  const completed = Math.max(0, input.completedTaskCount)
+
+  return {
+    averageRating: rating,
+    reviewCount: reviews,
+    completedTaskCount: completed,
+    completedComponent: completed * COMPLETED_TASK_WEIGHT,
+    reviewComponent: Math.round(rating * reviews * REVIEW_QUALITY_WEIGHT),
+    total: Math.max(0, Math.round(input.score)),
+  }
+}
+
+export { COMPLETED_TASK_WEIGHT, REVIEW_QUALITY_WEIGHT }

--- a/frontend/lib/reputation.ts
+++ b/frontend/lib/reputation.ts
@@ -66,14 +66,17 @@ export function reputationScoreBreakdown(input: {
     : 0
   const reviews = Math.max(0, input.reviewCount)
   const completed = Math.max(0, input.completedTaskCount)
+  const completedComponent = completed * COMPLETED_TASK_WEIGHT
+  const rawReviewComponent = rating * reviews * REVIEW_QUALITY_WEIGHT
+  const total = Math.max(0, Math.round(completedComponent + rawReviewComponent))
 
   return {
     averageRating: rating,
     reviewCount: reviews,
     completedTaskCount: completed,
-    completedComponent: completed * COMPLETED_TASK_WEIGHT,
-    reviewComponent: Math.round(rating * reviews * REVIEW_QUALITY_WEIGHT),
-    total: Math.max(0, Math.round(input.score)),
+    completedComponent,
+    reviewComponent: total - completedComponent,
+    total,
   }
 }
 

--- a/frontend/lib/reputation.ts
+++ b/frontend/lib/reputation.ts
@@ -1,11 +1,14 @@
-import { COMPLETED_TASK_WEIGHT, REVIEW_QUALITY_WEIGHT } from "@/lib/api/profile"
-
 /**
  * Tier identifiers shown next to the reputation score. Order matters —
  * `tierForScore` walks the list and returns the highest tier the score
  * qualifies for.
  */
 export type ReputationTier = "newcomer" | "bronze" | "silver" | "gold"
+
+/** Weight applied to each completed task in the reputation score formula. */
+export const COMPLETED_TASK_WEIGHT = 10
+/** Weight applied to (averageRating × reviewCount) in the reputation score formula. */
+export const REVIEW_QUALITY_WEIGHT = 2
 
 interface TierDefinition {
   id: ReputationTier
@@ -79,5 +82,3 @@ export function reputationScoreBreakdown(input: {
     total,
   }
 }
-
-export { COMPLETED_TASK_WEIGHT, REVIEW_QUALITY_WEIGHT }


### PR DESCRIPTION
- Introduced `ReputationScoreCalculator` to compute aggregate reputation scores based on completed tasks and review quality.
- Updated `PublicProfileResponse` and `OwnProfileResponse` to include `reputationScore`.
- Implemented `ProfileReputationTrendPointResponse` for daily reputation snapshots.
- Created `ProfilesController.Reputation` to handle reputation trend API requests.
- Added `useProfileReputationTrend` hook for fetching reputation trends in the frontend.
- Developed `ReputationCard` and `ReputationSummary` components to display reputation metrics.
- Enhanced frontend components to visualize reputation trends and scores.
- Added tests for `ReputationScoreCalculator` to ensure correct score computation.