### PR TITLE
feat(tasks): add two-step completion flow with helper points reward

### DIFF
--- a/backend.Tests/FlatTaskCompletionPointsCalculatorTests.cs
+++ b/backend.Tests/FlatTaskCompletionPointsCalculatorTests.cs
@@ -1,0 +1,26 @@
+using Backend.Application.TaskCompletion;
+using Backend.Domain.Entities;
+using Backend.Domain.Enums;
+using Xunit;
+
+namespace backend.Tests;
+
+public sealed class FlatTaskCompletionPointsCalculatorTests
+{
+    [Theory]
+    [InlineData(CompensationType.Paid, FlatTaskCompletionPointsCalculator.BasePoints)]
+    [InlineData(CompensationType.Points, FlatTaskCompletionPointsCalculator.BasePoints)]
+    [InlineData(CompensationType.Barter, FlatTaskCompletionPointsCalculator.BasePoints)]
+    [InlineData(
+        CompensationType.Voluntary,
+        FlatTaskCompletionPointsCalculator.BasePoints + FlatTaskCompletionPointsCalculator.VoluntaryBonusPoints)]
+    public void Calculate_ReturnsExpectedAmountForCompensationType(CompensationType compensationType, int expected)
+    {
+        var calculator = new FlatTaskCompletionPointsCalculator();
+        var task = new CommunityTask { CompensationType = compensationType };
+
+        var amount = calculator.Calculate(task);
+
+        Assert.Equal(expected, amount);
+    }
+}

--- a/backend.Tests/TaskCompletionControllerTests.cs
+++ b/backend.Tests/TaskCompletionControllerTests.cs
@@ -263,7 +263,7 @@ public sealed class TaskCompletionControllerTests
         });
 
         await db.SaveChangesAsync(cancellationToken);
-        return new CompletionScenario(taskId, seekerUserId, seekerProfileId, helperUserId, helperProfileId);
+        return new CompletionScenario(taskId, seekerUserId, helperUserId, helperProfileId);
     }
 
     private static async Task<CompletionScenario> SeedPendingApprovalTaskAsync(
@@ -315,7 +315,6 @@ public sealed class TaskCompletionControllerTests
     private sealed record CompletionScenario(
         Guid TaskId,
         Guid SeekerUserId,
-        Guid SeekerProfileId,
         Guid HelperUserId,
         Guid HelperProfileId);
 }

--- a/backend.Tests/TaskCompletionControllerTests.cs
+++ b/backend.Tests/TaskCompletionControllerTests.cs
@@ -1,0 +1,321 @@
+using System.Security.Claims;
+using Backend.Application.TaskCompletion;
+using Backend.Domain.Entities;
+using Backend.Domain.Enums;
+using Backend.Features.Tasks;
+using Backend.Features.Tasks.Completion;
+using Backend.Infrastructure.Persistence;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+using DomainTaskStatus = Backend.Domain.Enums.TaskStatus;
+
+namespace backend.Tests;
+
+public sealed class TaskCompletionControllerTests
+{
+    [Fact]
+    public async Task SubmitAsync_FlipsStatusAndCreatesConfirmation()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await using var db = CreateDbContext();
+        var scenario = await SeedInProgressTaskAsync(db, CompensationType.Voluntary, cancellationToken);
+        var controller = CreateController(db, scenario.HelperUserId);
+
+        var result = await controller.SubmitAsync(scenario.TaskId, cancellationToken);
+
+        var ok = Assert.IsType<OkObjectResult>(result);
+        var response = Assert.IsType<TaskResponse>(ok.Value);
+        Assert.Equal(nameof(DomainTaskStatus.PendingApproval), response.Status);
+
+        var task = await db.Tasks.AsNoTracking().FirstAsync(t => t.Id == scenario.TaskId, cancellationToken);
+        Assert.Equal(DomainTaskStatus.PendingApproval, task.Status);
+        Assert.Null(task.CompletedAt);
+
+        var confirmation = Assert.Single(db.TaskCompletionConfirmations);
+        Assert.Equal(scenario.HelperProfileId, confirmation.ProfileId);
+        Assert.Equal(scenario.TaskId, confirmation.TaskId);
+
+        var historyEntry = Assert.Single(db.TaskStatusHistory);
+        Assert.Equal(DomainTaskStatus.InProgress, historyEntry.OldStatus);
+        Assert.Equal(DomainTaskStatus.PendingApproval, historyEntry.NewStatus);
+        Assert.Equal(scenario.HelperProfileId, historyEntry.ChangedByProfileId);
+
+        var audit = Assert.Single(db.AuditEvents);
+        Assert.Equal("task.completion_submitted", audit.EventType);
+
+        // No completion-related activity event fires on submission.
+        Assert.Empty(db.ActivityEvents);
+
+        // Submission must not award points until the seeker approves.
+        Assert.Empty(db.PointsLedger);
+    }
+
+    [Fact]
+    public async Task SubmitAsync_ReturnsForbid_WhenCallerIsNotAcceptedHelper()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await using var db = CreateDbContext();
+        var scenario = await SeedInProgressTaskAsync(db, CompensationType.Paid, cancellationToken);
+        var controller = CreateController(db, scenario.SeekerUserId);
+
+        var result = await controller.SubmitAsync(scenario.TaskId, cancellationToken);
+
+        Assert.IsType<ForbidResult>(result);
+        Assert.Empty(db.TaskCompletionConfirmations);
+    }
+
+    [Theory]
+    [InlineData(DomainTaskStatus.Open)]
+    [InlineData(DomainTaskStatus.Cancelled)]
+    [InlineData(DomainTaskStatus.Completed)]
+    [InlineData(DomainTaskStatus.PendingApproval)]
+    public async Task SubmitAsync_RejectsNonInProgressStatuses(DomainTaskStatus initialStatus)
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await using var db = CreateDbContext();
+        var scenario = await SeedInProgressTaskAsync(db, CompensationType.Paid, cancellationToken);
+        var task = await db.Tasks.FirstAsync(t => t.Id == scenario.TaskId, cancellationToken);
+        task.Status = initialStatus;
+        await db.SaveChangesAsync(cancellationToken);
+
+        var controller = CreateController(db, scenario.HelperUserId);
+
+        var result = await controller.SubmitAsync(scenario.TaskId, cancellationToken);
+
+        var problem = Assert.IsType<ObjectResult>(result);
+        Assert.Equal(StatusCodes.Status409Conflict, problem.StatusCode);
+
+        // No write-through side effects.
+        var reloaded = await db.Tasks.AsNoTracking().FirstAsync(t => t.Id == scenario.TaskId, cancellationToken);
+        Assert.Equal(initialStatus, reloaded.Status);
+        Assert.Empty(db.TaskCompletionConfirmations);
+        Assert.Empty(db.PointsLedger);
+    }
+
+    [Fact]
+    public async Task ApproveAsync_CompletesTaskAndAwardsPoints()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await using var db = CreateDbContext();
+        var scenario = await SeedPendingApprovalTaskAsync(db, CompensationType.Voluntary, cancellationToken);
+        var controller = CreateController(db, scenario.SeekerUserId);
+
+        var result = await controller.ApproveAsync(scenario.TaskId, cancellationToken);
+
+        var ok = Assert.IsType<OkObjectResult>(result);
+        var response = Assert.IsType<TaskResponse>(ok.Value);
+        Assert.Equal(nameof(DomainTaskStatus.Completed), response.Status);
+
+        var task = await db.Tasks.AsNoTracking().FirstAsync(t => t.Id == scenario.TaskId, cancellationToken);
+        Assert.Equal(DomainTaskStatus.Completed, task.Status);
+        Assert.NotNull(task.CompletedAt);
+
+        var entry = Assert.Single(db.PointsLedger);
+        Assert.Equal(PointEntryType.TaskCompletedReward, entry.EntryType);
+        Assert.Equal(scenario.HelperProfileId, entry.ProfileId);
+        Assert.Equal(scenario.TaskId, entry.TaskId);
+        Assert.Equal(
+            FlatTaskCompletionPointsCalculator.BasePoints
+                + FlatTaskCompletionPointsCalculator.VoluntaryBonusPoints,
+            entry.Amount);
+
+        Assert.Contains(db.ActivityEvents, a => a.EventType == ActivityEventType.TaskCompleted);
+        Assert.Contains(db.AuditEvents, a => a.EventType == "task.completion_approved");
+
+        Assert.Equal(2, db.TaskCompletionConfirmations.Count());
+    }
+
+    [Fact]
+    public async Task ApproveAsync_IsIdempotent_WhenRetriedAfterReward()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await using var db = CreateDbContext();
+        var scenario = await SeedPendingApprovalTaskAsync(db, CompensationType.Paid, cancellationToken);
+        var controller = CreateController(db, scenario.SeekerUserId);
+
+        var firstResult = await controller.ApproveAsync(scenario.TaskId, cancellationToken);
+        Assert.IsType<OkObjectResult>(firstResult);
+
+        var secondResult = await controller.ApproveAsync(scenario.TaskId, cancellationToken);
+        var problem = Assert.IsType<ObjectResult>(secondResult);
+        Assert.Equal(StatusCodes.Status409Conflict, problem.StatusCode);
+
+        // Reward and completion side effects must remain singletons.
+        Assert.Single(db.PointsLedger);
+        Assert.Single(db.ActivityEvents.Where(a => a.EventType == ActivityEventType.TaskCompleted));
+    }
+
+    [Fact]
+    public async Task ApproveAsync_RewardIsSeparateFromPaidCompensation()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await using var db = CreateDbContext();
+        var scenario = await SeedPendingApprovalTaskAsync(db, CompensationType.Paid, cancellationToken);
+        var task = await db.Tasks.FirstAsync(t => t.Id == scenario.TaskId, cancellationToken);
+        task.CompensationAmount = 5000m;
+        await db.SaveChangesAsync(cancellationToken);
+
+        var controller = CreateController(db, scenario.SeekerUserId);
+
+        var result = await controller.ApproveAsync(scenario.TaskId, cancellationToken);
+
+        Assert.IsType<OkObjectResult>(result);
+        var entry = Assert.Single(db.PointsLedger);
+        Assert.Equal(FlatTaskCompletionPointsCalculator.BasePoints, entry.Amount);
+
+        // Paid amount on the task is preserved and lives outside the points economy.
+        var reloaded = await db.Tasks.AsNoTracking().FirstAsync(t => t.Id == scenario.TaskId, cancellationToken);
+        Assert.Equal(5000m, reloaded.CompensationAmount);
+    }
+
+    [Fact]
+    public async Task ApproveAsync_ReturnsForbid_WhenCallerIsNotSeeker()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await using var db = CreateDbContext();
+        var scenario = await SeedPendingApprovalTaskAsync(db, CompensationType.Voluntary, cancellationToken);
+        var controller = CreateController(db, scenario.HelperUserId);
+
+        var result = await controller.ApproveAsync(scenario.TaskId, cancellationToken);
+
+        Assert.IsType<ForbidResult>(result);
+        Assert.Empty(db.PointsLedger);
+    }
+
+    [Theory]
+    [InlineData(DomainTaskStatus.Open)]
+    [InlineData(DomainTaskStatus.InProgress)]
+    [InlineData(DomainTaskStatus.Cancelled)]
+    public async Task ApproveAsync_RejectsNonPendingApprovalStatuses(DomainTaskStatus initialStatus)
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await using var db = CreateDbContext();
+        var scenario = await SeedPendingApprovalTaskAsync(db, CompensationType.Voluntary, cancellationToken);
+        var task = await db.Tasks.FirstAsync(t => t.Id == scenario.TaskId, cancellationToken);
+        task.Status = initialStatus;
+        await db.SaveChangesAsync(cancellationToken);
+
+        var controller = CreateController(db, scenario.SeekerUserId);
+
+        var result = await controller.ApproveAsync(scenario.TaskId, cancellationToken);
+
+        var problem = Assert.IsType<ObjectResult>(result);
+        Assert.Equal(StatusCodes.Status409Conflict, problem.StatusCode);
+        Assert.Empty(db.PointsLedger);
+    }
+
+    private static async Task<CompletionScenario> SeedInProgressTaskAsync(
+        AppDbContext db,
+        CompensationType compensationType,
+        CancellationToken cancellationToken)
+    {
+        var categoryId = Guid.NewGuid();
+        var seekerUserId = Guid.NewGuid();
+        var seekerProfileId = Guid.NewGuid();
+        var helperUserId = Guid.NewGuid();
+        var helperProfileId = Guid.NewGuid();
+        var now = DateTimeOffset.UtcNow;
+
+        db.Categories.Add(new Category
+        {
+            Id = categoryId,
+            Code = "help",
+            Name = "Help",
+            Icon = Category.DefaultIcon,
+            IsActive = true,
+            CreatedAt = now,
+            UpdatedAt = now
+        });
+        db.Profiles.Add(new UserProfile
+        {
+            Id = seekerProfileId,
+            UserId = seekerUserId,
+            DisplayName = "Seeker",
+            CreatedAt = now,
+            UpdatedAt = now
+        });
+        db.Profiles.Add(new UserProfile
+        {
+            Id = helperProfileId,
+            UserId = helperUserId,
+            DisplayName = "Helper",
+            CreatedAt = now,
+            UpdatedAt = now
+        });
+
+        var taskId = Guid.NewGuid();
+        db.Tasks.Add(new CommunityTask
+        {
+            Id = taskId,
+            PublicCode = "TASK-TEST-000123",
+            SeekerProfileId = seekerProfileId,
+            AcceptedHelperProfileId = helperProfileId,
+            CategoryId = categoryId,
+            Title = "Carry boxes",
+            Description = "Need help carrying boxes.",
+            CompensationType = compensationType,
+            Status = DomainTaskStatus.InProgress,
+            CreatedAt = now,
+            UpdatedAt = now,
+            AcceptedAt = now
+        });
+
+        await db.SaveChangesAsync(cancellationToken);
+        return new CompletionScenario(taskId, seekerUserId, seekerProfileId, helperUserId, helperProfileId);
+    }
+
+    private static async Task<CompletionScenario> SeedPendingApprovalTaskAsync(
+        AppDbContext db,
+        CompensationType compensationType,
+        CancellationToken cancellationToken)
+    {
+        var scenario = await SeedInProgressTaskAsync(db, compensationType, cancellationToken);
+        var task = await db.Tasks.FirstAsync(t => t.Id == scenario.TaskId, cancellationToken);
+        task.Status = DomainTaskStatus.PendingApproval;
+        db.TaskCompletionConfirmations.Add(new TaskCompletionConfirmation
+        {
+            Id = Guid.NewGuid(),
+            TaskId = task.Id,
+            ProfileId = scenario.HelperProfileId,
+            ConfirmedAt = DateTimeOffset.UtcNow
+        });
+        await db.SaveChangesAsync(cancellationToken);
+        return scenario;
+    }
+
+    private static AppDbContext CreateDbContext()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString(), options => options.EnableNullChecks(false))
+            .Options;
+
+        return new AppDbContext(options);
+    }
+
+    private static TaskCompletionController CreateController(AppDbContext db, Guid userId)
+    {
+        var rewardService = new TaskCompletionRewardService(db, new FlatTaskCompletionPointsCalculator());
+        return new TaskCompletionController(db, rewardService)
+        {
+            ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext
+                {
+                    User = new ClaimsPrincipal(new ClaimsIdentity(
+                    [
+                        new Claim(ClaimTypes.NameIdentifier, userId.ToString())
+                    ], "TestAuth"))
+                }
+            }
+        };
+    }
+
+    private sealed record CompletionScenario(
+        Guid TaskId,
+        Guid SeekerUserId,
+        Guid SeekerProfileId,
+        Guid HelperUserId,
+        Guid HelperProfileId);
+}

--- a/backend.Tests/TaskCompletionRewardServiceTests.cs
+++ b/backend.Tests/TaskCompletionRewardServiceTests.cs
@@ -36,6 +36,27 @@ public sealed class TaskCompletionRewardServiceTests
     }
 
     [Fact]
+    public async Task StageCompletionRewardAsync_IsIdempotent_WhenAwardIsStagedInSameContext()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await using var db = CreateInMemoryDbContext();
+        var task = SeedCompletedTask(db, CompensationType.Voluntary);
+        await db.SaveChangesAsync(cancellationToken);
+
+        var service = new TaskCompletionRewardService(db, new FlatTaskCompletionPointsCalculator());
+
+        var firstAward = await service.StageCompletionRewardAsync(task, cancellationToken);
+        // No SaveChanges between calls — the second call must see the change-tracker
+        // entry, not just the persisted DB rows.
+        var secondAward = await service.StageCompletionRewardAsync(task, cancellationToken);
+        await db.SaveChangesAsync(cancellationToken);
+
+        Assert.NotNull(firstAward);
+        Assert.Null(secondAward);
+        Assert.Single(db.PointsLedger);
+    }
+
+    [Fact]
     public async Task StageCompletionRewardAsync_IsIdempotent_WhenAwardAlreadyExists()
     {
         var cancellationToken = TestContext.Current.CancellationToken;

--- a/backend.Tests/TaskCompletionRewardServiceTests.cs
+++ b/backend.Tests/TaskCompletionRewardServiceTests.cs
@@ -1,0 +1,157 @@
+using Backend.Application.TaskCompletion;
+using Backend.Domain.Entities;
+using Backend.Domain.Enums;
+using Backend.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+using DomainTaskStatus = Backend.Domain.Enums.TaskStatus;
+
+namespace backend.Tests;
+
+public sealed class TaskCompletionRewardServiceTests
+{
+    [Fact]
+    public async Task StageCompletionRewardAsync_AddsExpectedLedgerEntry()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await using var db = CreateInMemoryDbContext();
+        var task = SeedCompletedTask(db, CompensationType.Voluntary);
+        await db.SaveChangesAsync(cancellationToken);
+
+        var service = new TaskCompletionRewardService(db, new FlatTaskCompletionPointsCalculator());
+
+        var awarded = await service.StageCompletionRewardAsync(task, cancellationToken);
+        await db.SaveChangesAsync(cancellationToken);
+
+        Assert.Equal(
+            FlatTaskCompletionPointsCalculator.BasePoints
+                + FlatTaskCompletionPointsCalculator.VoluntaryBonusPoints,
+            awarded);
+
+        var entry = Assert.Single(db.PointsLedger);
+        Assert.Equal(task.Id, entry.TaskId);
+        Assert.Equal(task.AcceptedHelperProfileId, entry.ProfileId);
+        Assert.Equal(PointEntryType.TaskCompletedReward, entry.EntryType);
+        Assert.Equal(awarded, entry.Amount);
+    }
+
+    [Fact]
+    public async Task StageCompletionRewardAsync_IsIdempotent_WhenAwardAlreadyExists()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await using var db = CreateInMemoryDbContext();
+        var task = SeedCompletedTask(db, CompensationType.Paid);
+        db.PointsLedger.Add(new PointsLedgerEntry
+        {
+            Id = Guid.NewGuid(),
+            ProfileId = task.AcceptedHelperProfileId!.Value,
+            TaskId = task.Id,
+            Amount = 10,
+            EntryType = PointEntryType.TaskCompletedReward,
+            CreatedAt = DateTimeOffset.UtcNow
+        });
+        await db.SaveChangesAsync(cancellationToken);
+
+        var service = new TaskCompletionRewardService(db, new FlatTaskCompletionPointsCalculator());
+
+        var awarded = await service.StageCompletionRewardAsync(task, cancellationToken);
+        await db.SaveChangesAsync(cancellationToken);
+
+        Assert.Null(awarded);
+        Assert.Single(db.PointsLedger);
+    }
+
+    [Fact]
+    public async Task StageCompletionRewardAsync_Throws_WhenTaskNotCompleted()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await using var db = CreateInMemoryDbContext();
+        var task = SeedCompletedTask(db, CompensationType.Paid);
+        task.Status = DomainTaskStatus.InProgress;
+        await db.SaveChangesAsync(cancellationToken);
+
+        var service = new TaskCompletionRewardService(db, new FlatTaskCompletionPointsCalculator());
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => service.StageCompletionRewardAsync(task, cancellationToken));
+        Assert.Empty(db.PointsLedger);
+    }
+
+    [Fact]
+    public async Task StageCompletionRewardAsync_Throws_WhenAcceptedHelperMissing()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await using var db = CreateInMemoryDbContext();
+        var task = SeedCompletedTask(db, CompensationType.Paid);
+        task.AcceptedHelperProfileId = null;
+        await db.SaveChangesAsync(cancellationToken);
+
+        var service = new TaskCompletionRewardService(db, new FlatTaskCompletionPointsCalculator());
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => service.StageCompletionRewardAsync(task, cancellationToken));
+        Assert.Empty(db.PointsLedger);
+    }
+
+    private static CommunityTask SeedCompletedTask(AppDbContext db, CompensationType compensationType)
+    {
+        var categoryId = Guid.NewGuid();
+        var seekerId = Guid.NewGuid();
+        var helperId = Guid.NewGuid();
+        var now = DateTimeOffset.UtcNow;
+
+        db.Categories.Add(new Category
+        {
+            Id = categoryId,
+            Code = "help",
+            Name = "Help",
+            Icon = Category.DefaultIcon,
+            IsActive = true,
+            CreatedAt = now,
+            UpdatedAt = now
+        });
+        db.Profiles.Add(new UserProfile
+        {
+            Id = seekerId,
+            UserId = Guid.NewGuid(),
+            DisplayName = "Seeker",
+            CreatedAt = now,
+            UpdatedAt = now
+        });
+        db.Profiles.Add(new UserProfile
+        {
+            Id = helperId,
+            UserId = Guid.NewGuid(),
+            DisplayName = "Helper",
+            CreatedAt = now,
+            UpdatedAt = now
+        });
+
+        var task = new CommunityTask
+        {
+            Id = Guid.NewGuid(),
+            PublicCode = "TASK-TEST-000001",
+            SeekerProfileId = seekerId,
+            AcceptedHelperProfileId = helperId,
+            CategoryId = categoryId,
+            Title = "Sample task",
+            Description = "Test seed task.",
+            CompensationType = compensationType,
+            Status = DomainTaskStatus.Completed,
+            CreatedAt = now,
+            UpdatedAt = now,
+            CompletedAt = now
+        };
+        db.Tasks.Add(task);
+        return task;
+    }
+
+    private static AppDbContext CreateInMemoryDbContext()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString(), options => options.EnableNullChecks(false))
+            .Options;
+
+        return new AppDbContext(options);
+    }
+}

--- a/backend/Application/TaskCompletion/FlatTaskCompletionPointsCalculator.cs
+++ b/backend/Application/TaskCompletion/FlatTaskCompletionPointsCalculator.cs
@@ -1,0 +1,29 @@
+using Backend.Domain.Entities;
+using Backend.Domain.Enums;
+
+namespace Backend.Application.TaskCompletion;
+
+/// <summary>
+/// Flat v1 algorithm: every completed task awards a base reward, with a small bonus for
+/// voluntary tasks (where the seeker offers no other compensation, so the platform
+/// recognises the helper more). Paid and barter tasks award only the base reward because
+/// the helper already receives compensation outside the points economy.
+/// </summary>
+public sealed class FlatTaskCompletionPointsCalculator : ITaskCompletionPointsCalculator
+{
+    public const int BasePoints = 10;
+    public const int VoluntaryBonusPoints = 5;
+
+    public int Calculate(CommunityTask task)
+    {
+        ArgumentNullException.ThrowIfNull(task);
+
+        var points = BasePoints;
+        if (task.CompensationType == CompensationType.Voluntary)
+        {
+            points += VoluntaryBonusPoints;
+        }
+
+        return points;
+    }
+}

--- a/backend/Application/TaskCompletion/ITaskCompletionPointsCalculator.cs
+++ b/backend/Application/TaskCompletion/ITaskCompletionPointsCalculator.cs
@@ -1,0 +1,18 @@
+using Backend.Domain.Entities;
+
+namespace Backend.Application.TaskCompletion;
+
+/// <summary>
+/// Calculates the platform points reward earned by the accepted helper when a task is completed.
+/// Server-owned and deterministic so the client cannot influence the awarded amount.
+/// </summary>
+public interface ITaskCompletionPointsCalculator
+{
+    /// <summary>
+    /// Returns the points to award the accepted helper for completing <paramref name="task"/>.
+    /// Must return a positive integer; callers must not invoke this for non-completed tasks.
+    /// </summary>
+    /// <param name="task">The completed task whose accepted helper is being rewarded.</param>
+    /// <returns>The number of platform points to credit to the helper.</returns>
+    int Calculate(CommunityTask task);
+}

--- a/backend/Application/TaskCompletion/ITaskCompletionRewardService.cs
+++ b/backend/Application/TaskCompletion/ITaskCompletionRewardService.cs
@@ -1,0 +1,22 @@
+using Backend.Domain.Entities;
+
+namespace Backend.Application.TaskCompletion;
+
+/// <summary>
+/// Awards the helper's automatic points reward for a completed task.
+/// Idempotent: a task/helper pair can only earn one <c>TaskCompletedReward</c> entry
+/// (enforced both by an in-context pre-check and by the partial unique index
+/// <c>ux_points_ledger_task_reward_once</c>).
+/// </summary>
+public interface ITaskCompletionRewardService
+{
+    /// <summary>
+    /// Stages a <c>TaskCompletedReward</c> ledger entry for the accepted helper of
+    /// <paramref name="task"/> if one does not already exist. The caller owns the
+    /// transaction and must call <c>SaveChangesAsync</c> for the entry to be persisted.
+    /// </summary>
+    /// <param name="task">The task being completed. Must have <c>Status = Completed</c> and a non-null accepted helper.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The amount awarded, or <c>null</c> when the reward was already recorded.</returns>
+    Task<int?> StageCompletionRewardAsync(CommunityTask task, CancellationToken cancellationToken);
+}

--- a/backend/Application/TaskCompletion/TaskCompletionRewardService.cs
+++ b/backend/Application/TaskCompletion/TaskCompletionRewardService.cs
@@ -26,6 +26,19 @@ public sealed class TaskCompletionRewardService(
                 $"Cannot award completion points for task {task.Id}: no accepted helper.");
         }
 
+        // Check the change tracker first so an entry staged earlier in this same
+        // DbContext (but not yet saved) is treated as an existing award. AnyAsync
+        // would miss it.
+        var stagedLocally = db.PointsLedger.Local.Any(
+            entry => entry.TaskId == task.Id
+                && entry.ProfileId == helperProfileId
+                && entry.EntryType == PointEntryType.TaskCompletedReward);
+
+        if (stagedLocally)
+        {
+            return null;
+        }
+
         var alreadyAwarded = await db.PointsLedger.AnyAsync(
             entry => entry.TaskId == task.Id
                 && entry.ProfileId == helperProfileId

--- a/backend/Application/TaskCompletion/TaskCompletionRewardService.cs
+++ b/backend/Application/TaskCompletion/TaskCompletionRewardService.cs
@@ -1,0 +1,53 @@
+using Backend.Domain.Entities;
+using Backend.Domain.Enums;
+using Backend.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
+using DomainTaskStatus = Backend.Domain.Enums.TaskStatus;
+
+namespace Backend.Application.TaskCompletion;
+
+public sealed class TaskCompletionRewardService(
+    AppDbContext db,
+    ITaskCompletionPointsCalculator calculator) : ITaskCompletionRewardService
+{
+    public async Task<int?> StageCompletionRewardAsync(CommunityTask task, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(task);
+
+        if (task.Status != DomainTaskStatus.Completed)
+        {
+            throw new InvalidOperationException(
+                $"Cannot award completion points for task {task.Id}: status is {task.Status}, not Completed.");
+        }
+
+        if (task.AcceptedHelperProfileId is not { } helperProfileId)
+        {
+            throw new InvalidOperationException(
+                $"Cannot award completion points for task {task.Id}: no accepted helper.");
+        }
+
+        var alreadyAwarded = await db.PointsLedger.AnyAsync(
+            entry => entry.TaskId == task.Id
+                && entry.ProfileId == helperProfileId
+                && entry.EntryType == PointEntryType.TaskCompletedReward,
+            cancellationToken);
+
+        if (alreadyAwarded)
+        {
+            return null;
+        }
+
+        var amount = calculator.Calculate(task);
+
+        db.PointsLedger.Add(new PointsLedgerEntry
+        {
+            ProfileId = helperProfileId,
+            TaskId = task.Id,
+            Amount = amount,
+            EntryType = PointEntryType.TaskCompletedReward,
+            Description = $"Reward for completing task {task.PublicCode}"
+        });
+
+        return amount;
+    }
+}

--- a/backend/Domain/Enums/ActivityEventType.cs
+++ b/backend/Domain/Enums/ActivityEventType.cs
@@ -11,6 +11,7 @@ public enum ActivityEventType
     TaskApplicationWithdrawn,
     TaskAccepted,
     TaskCancelled,
+    TaskCompletionSubmitted,
     TaskCompleted,
     ReviewSubmitted,
     MessageSent

--- a/backend/Domain/Enums/TaskStatus.cs
+++ b/backend/Domain/Enums/TaskStatus.cs
@@ -4,6 +4,7 @@ public enum TaskStatus
 {
     Open,
     InProgress,
+    PendingApproval,
     Completed,
     Cancelled
 }

--- a/backend/Features/Tasks/Completion/TaskCompletionController.cs
+++ b/backend/Features/Tasks/Completion/TaskCompletionController.cs
@@ -1,0 +1,238 @@
+using System.Security.Claims;
+using Backend.Application.TaskCompletion;
+using Backend.Domain.Entities;
+using Backend.Domain.Enums;
+using Backend.Infrastructure.Persistence;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using DomainTaskStatus = Backend.Domain.Enums.TaskStatus;
+
+namespace Backend.Features.Tasks.Completion;
+
+[ApiController]
+[Route("api/tasks/{taskId:guid}")]
+[Authorize]
+public sealed class TaskCompletionController(
+    AppDbContext db,
+    ITaskCompletionRewardService rewardService) : ControllerBase
+{
+    [HttpPost("completion-submission")]
+    public async Task<IActionResult> SubmitAsync(Guid taskId, CancellationToken cancellationToken)
+    {
+        var profile = await GetCurrentProfileAsync(cancellationToken);
+        if (profile is null)
+        {
+            return Unauthorized();
+        }
+
+        var task = await db.Tasks
+            .Include(t => t.SeekerProfile)
+            .Include(t => t.AcceptedHelperProfile)
+            .Include(t => t.Category)
+            .FirstOrDefaultAsync(t => t.Id == taskId, cancellationToken);
+
+        if (task is null)
+        {
+            return NotFound();
+        }
+
+        if (task.AcceptedHelperProfileId != profile.Id)
+        {
+            return Forbid();
+        }
+
+        if (task.Status != DomainTaskStatus.InProgress)
+        {
+            var submitDetail = task.Status == DomainTaskStatus.PendingApproval
+                ? "This task is already awaiting the seeker's approval."
+                : "Only in-progress tasks can be marked as done.";
+            return Problem(
+                title: "Task cannot be marked as done",
+                detail: submitDetail,
+                statusCode: StatusCodes.Status409Conflict);
+        }
+
+        var now = DateTimeOffset.UtcNow;
+        var oldStatus = task.Status;
+
+        task.Status = DomainTaskStatus.PendingApproval;
+        task.UpdatedAt = now;
+
+        db.TaskCompletionConfirmations.Add(new TaskCompletionConfirmation
+        {
+            Id = Guid.NewGuid(),
+            TaskId = task.Id,
+            ProfileId = profile.Id,
+            ConfirmedAt = now
+        });
+
+        db.TaskStatusHistory.Add(new TaskStatusHistoryEntry
+        {
+            TaskId = task.Id,
+            OldStatus = oldStatus,
+            NewStatus = DomainTaskStatus.PendingApproval,
+            ChangedByProfileId = profile.Id,
+            Reason = "Helper submitted completion"
+        });
+
+        db.AddAuditEvent(
+            profile.UserId,
+            "task.completion_submitted",
+            nameof(CommunityTask),
+            task.Id,
+            new
+            {
+                task.SeekerProfileId,
+                HelperProfileId = profile.Id,
+                SubmittedAt = now
+            });
+
+        try
+        {
+            await db.SaveChangesAsync(cancellationToken);
+        }
+        catch (DbUpdateException ex) when (PostgresExceptionHelpers.IsDuplicateTaskCompletionConfirmation(ex))
+        {
+            return Problem(
+                title: "Already submitted",
+                detail: "You have already marked this task as done.",
+                statusCode: StatusCodes.Status409Conflict);
+        }
+
+        return Ok(TaskResponse.FromTask(task));
+    }
+
+    [HttpPost("completion-approval")]
+    public async Task<IActionResult> ApproveAsync(Guid taskId, CancellationToken cancellationToken)
+    {
+        var profile = await GetCurrentProfileAsync(cancellationToken);
+        if (profile is null)
+        {
+            return Unauthorized();
+        }
+
+        var task = await db.Tasks
+            .Include(t => t.SeekerProfile)
+            .Include(t => t.AcceptedHelperProfile)
+            .Include(t => t.Category)
+            .FirstOrDefaultAsync(t => t.Id == taskId, cancellationToken);
+
+        if (task is null)
+        {
+            return NotFound();
+        }
+
+        if (task.SeekerProfileId != profile.Id)
+        {
+            return Forbid();
+        }
+
+        if (task.Status != DomainTaskStatus.PendingApproval)
+        {
+            var approveDetail = task.Status == DomainTaskStatus.Completed
+                ? "This task has already been marked as completed."
+                : "Only tasks awaiting approval can be approved.";
+            return Problem(
+                title: "Task cannot be approved",
+                detail: approveDetail,
+                statusCode: StatusCodes.Status409Conflict);
+        }
+
+        if (task.AcceptedHelperProfileId is null)
+        {
+            return Problem(
+                title: "Task is missing an accepted helper",
+                detail: "Approval requires an accepted helper on the task.",
+                statusCode: StatusCodes.Status409Conflict);
+        }
+
+        var now = DateTimeOffset.UtcNow;
+        var oldStatus = task.Status;
+
+        task.Status = DomainTaskStatus.Completed;
+        task.CompletedAt = now;
+        task.UpdatedAt = now;
+
+        var seekerAlreadyConfirmed = await db.TaskCompletionConfirmations.AnyAsync(
+            confirmation => confirmation.TaskId == task.Id && confirmation.ProfileId == profile.Id,
+            cancellationToken);
+
+        if (!seekerAlreadyConfirmed)
+        {
+            db.TaskCompletionConfirmations.Add(new TaskCompletionConfirmation
+            {
+                Id = Guid.NewGuid(),
+                TaskId = task.Id,
+                ProfileId = profile.Id,
+                ConfirmedAt = now
+            });
+        }
+
+        var awardedPoints = await rewardService.StageCompletionRewardAsync(task, cancellationToken);
+
+        db.TaskStatusHistory.Add(new TaskStatusHistoryEntry
+        {
+            TaskId = task.Id,
+            OldStatus = oldStatus,
+            NewStatus = DomainTaskStatus.Completed,
+            ChangedByProfileId = profile.Id,
+            Reason = "Seeker approved completion"
+        });
+
+        db.AddActivityEvent(
+            profile.UserId,
+            profile.Id,
+            ActivityEventType.TaskCompleted,
+            nameof(CommunityTask),
+            task.Id,
+            new
+            {
+                task.AcceptedHelperProfileId,
+                AwardedPoints = awardedPoints
+            });
+
+        db.AddAuditEvent(
+            profile.UserId,
+            "task.completion_approved",
+            nameof(CommunityTask),
+            task.Id,
+            new
+            {
+                task.SeekerProfileId,
+                task.AcceptedHelperProfileId,
+                ApprovedAt = now,
+                AwardedPoints = awardedPoints
+            });
+
+        try
+        {
+            await db.SaveChangesAsync(cancellationToken);
+        }
+        catch (DbUpdateException ex) when (PostgresExceptionHelpers.IsDuplicateTaskCompletionReward(ex))
+        {
+            // Belt-and-suspenders for the partial unique index. Treat as idempotent success
+            // by re-reading current state.
+            await db.Entry(task).ReloadAsync(cancellationToken);
+            return Ok(TaskResponse.FromTask(task));
+        }
+        catch (DbUpdateException ex) when (PostgresExceptionHelpers.IsDuplicateTaskCompletionConfirmation(ex))
+        {
+            await db.Entry(task).ReloadAsync(cancellationToken);
+            return Ok(TaskResponse.FromTask(task));
+        }
+
+        return Ok(TaskResponse.FromTask(task));
+    }
+
+    private async Task<UserProfile?> GetCurrentProfileAsync(CancellationToken cancellationToken)
+    {
+        var claim = User.FindFirstValue(ClaimTypes.NameIdentifier);
+        if (!Guid.TryParse(claim, out var userId))
+        {
+            return null;
+        }
+
+        return await db.Profiles.FirstOrDefaultAsync(p => p.UserId == userId, cancellationToken);
+    }
+}

--- a/backend/Infrastructure/Persistence/Migrations/20260525123207_AddPendingApprovalTaskStatus.Designer.cs
+++ b/backend/Infrastructure/Persistence/Migrations/20260525123207_AddPendingApprovalTaskStatus.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Backend.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NetTopologySuite.Geometries;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Backend.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260525123207_AddPendingApprovalTaskStatus")]
+    partial class AddPendingApprovalTaskStatus
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/Infrastructure/Persistence/Migrations/20260525123207_AddPendingApprovalTaskStatus.cs
+++ b/backend/Infrastructure/Persistence/Migrations/20260525123207_AddPendingApprovalTaskStatus.cs
@@ -1,0 +1,40 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Backend.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPendingApprovalTaskStatus : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropCheckConstraint(
+                name: "ck_tasks_status",
+                schema: "data",
+                table: "tasks");
+
+            migrationBuilder.AddCheckConstraint(
+                name: "ck_tasks_status",
+                schema: "data",
+                table: "tasks",
+                sql: "status IN ('Open', 'InProgress', 'PendingApproval', 'Completed', 'Cancelled')");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropCheckConstraint(
+                name: "ck_tasks_status",
+                schema: "data",
+                table: "tasks");
+
+            migrationBuilder.AddCheckConstraint(
+                name: "ck_tasks_status",
+                schema: "data",
+                table: "tasks",
+                sql: "status IN ('Open', 'InProgress', 'Completed', 'Cancelled')");
+        }
+    }
+}

--- a/backend/Infrastructure/Persistence/PostgresExceptionHelpers.cs
+++ b/backend/Infrastructure/Persistence/PostgresExceptionHelpers.cs
@@ -77,4 +77,26 @@ public static class PostgresExceptionHelpers
     {
         return IsUniqueConstraintViolation(exception, "ux_task_conversations_task_helper");
     }
+
+    /// <summary>
+    /// Checks if a DbUpdateException is a duplicate task completion confirmation violation
+    /// (same task + same profile already confirmed completion).
+    /// </summary>
+    /// <param name="exception">The DbUpdateException to check.</param>
+    /// <returns>True if the exception is a duplicate completion confirmation violation, false otherwise.</returns>
+    public static bool IsDuplicateTaskCompletionConfirmation(DbUpdateException exception)
+    {
+        return IsUniqueConstraintViolation(exception, "ux_task_completion_confirmations_task_profile");
+    }
+
+    /// <summary>
+    /// Checks if a DbUpdateException is a duplicate task-completion points reward
+    /// (the partial unique index covering <c>EntryType = 'TaskCompletedReward'</c>).
+    /// </summary>
+    /// <param name="exception">The DbUpdateException to check.</param>
+    /// <returns>True if the exception is a duplicate completion reward violation, false otherwise.</returns>
+    public static bool IsDuplicateTaskCompletionReward(DbUpdateException exception)
+    {
+        return IsUniqueConstraintViolation(exception, "ux_points_ledger_task_reward_once");
+    }
 }

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -2,6 +2,7 @@ using System.Net;
 using Azure.Core;
 using Azure.Identity;
 using Backend.Application.Categories;
+using Backend.Application.TaskCompletion;
 using Backend.Features.Auth;
 using Backend.Features.Conversations;
 using Backend.Infrastructure.Email;
@@ -118,6 +119,8 @@ builder.Services.AddDbContext<AppDbContext>((serviceProvider, options) =>
     options.UseNpgsql(dataSource, npgsql => npgsql.UseNetTopologySuite());
 });
 builder.Services.AddScoped<IListCategoriesQuery, EfListCategoriesQuery>();
+builder.Services.AddSingleton<ITaskCompletionPointsCalculator, FlatTaskCompletionPointsCalculator>();
+builder.Services.AddScoped<ITaskCompletionRewardService, TaskCompletionRewardService>();
 builder.Services.AddScoped<IAuthTokenService, AuthTokenService>();
 builder.Services.AddScoped<RefreshTokenPruner>();
 builder.Services.AddMemoryCache();

--- a/frontend/app/(main)/tasks/[id]/page.client.tsx
+++ b/frontend/app/(main)/tasks/[id]/page.client.tsx
@@ -28,6 +28,7 @@ import { TaskStatusBadge } from "@/components/tasks/task-status-badge"
 import { UserAvatar } from "@/components/shared/user-avatar"
 import { RichTextContent } from "@/components/shared/rich-text-content"
 import { formatRelativeTime } from "@/lib/format"
+import { normalizeTaskStatus } from "@/lib/task-status"
 import { useAuth } from "@/lib/auth-context"
 import {
   useApplyToTask,
@@ -120,7 +121,7 @@ function TaskActions({ task }: { task: ApiTask }) {
   const { mutate: startConversation, isPending: isStarting } =
     useStartConversation()
   const isSeeker = task.seekerProfileId === user?.profileId
-  const status = task.status.toLowerCase().replace(/([a-z])([A-Z])/g, "$1_$2")
+  const status = normalizeTaskStatus(task.status)
   const canOpenInProgressChat =
     status === "in_progress" &&
     (isSeeker || task.acceptedHelperProfileId === user?.profileId)

--- a/frontend/app/(main)/tasks/[id]/page.client.tsx
+++ b/frontend/app/(main)/tasks/[id]/page.client.tsx
@@ -31,8 +31,10 @@ import { formatRelativeTime } from "@/lib/format"
 import { useAuth } from "@/lib/auth-context"
 import {
   useApplyToTask,
+  useApproveTaskCompletion,
   useMyTaskApplications,
   usePatchTaskApplication,
+  useSubmitTaskCompletion,
   useTask,
   useTaskApplications,
   useUpdateTask,
@@ -204,6 +206,9 @@ function TaskActions({ task }: { task: ApiTask }) {
             {isStarting ? "Opening…" : "Open chat"}
           </Button>
         ) : null}
+        {task.acceptedHelperProfileId === user?.profileId ? (
+          <SubmitCompletionButton taskId={task.id} />
+        ) : null}
         {isSeeker ? (
           <Button
             variant="ghost"
@@ -217,6 +222,32 @@ function TaskActions({ task }: { task: ApiTask }) {
     )
   }
 
+  if (status === "pending_approval") {
+    const canOpenChat =
+      isSeeker || task.acceptedHelperProfileId === user?.profileId
+    return (
+      <div className="flex flex-col gap-3">
+        <p className="text-sm text-muted-foreground">
+          {isSeeker
+            ? `${task.acceptedHelperDisplayName ?? "The helper"} marked this task as done. Approve to complete it.`
+            : "Waiting for the seeker to approve completion."}
+        </p>
+        <div className="flex flex-wrap gap-2">
+          {isSeeker ? <ApproveCompletionButton taskId={task.id} /> : null}
+          {canOpenChat ? (
+            <Button
+              variant="outline"
+              disabled={isStarting || isLoadingConversations}
+              onClick={handleMessage}
+            >
+              {isStarting ? "Opening…" : "Open chat"}
+            </Button>
+          ) : null}
+        </div>
+      </div>
+    )
+  }
+
   if (status === "completed") {
     return (
       <div className="flex flex-wrap gap-2">
@@ -226,6 +257,42 @@ function TaskActions({ task }: { task: ApiTask }) {
   }
 
   return null
+}
+
+function SubmitCompletionButton({ taskId }: { taskId: string }) {
+  const { mutate: submitCompletion, isPending } =
+    useSubmitTaskCompletion(taskId)
+
+  function handleSubmit() {
+    submitCompletion(undefined, {
+      onSuccess: () => toast.success("Marked as done. Awaiting approval."),
+      onError: () => toast.error("Could not mark this task as done."),
+    })
+  }
+
+  return (
+    <Button disabled={isPending} onClick={handleSubmit}>
+      {isPending ? "Submitting…" : "Mark as done"}
+    </Button>
+  )
+}
+
+function ApproveCompletionButton({ taskId }: { taskId: string }) {
+  const { mutate: approveCompletion, isPending } =
+    useApproveTaskCompletion(taskId)
+
+  function handleApprove() {
+    approveCompletion(undefined, {
+      onSuccess: () => toast.success("Task completed."),
+      onError: () => toast.error("Could not approve completion."),
+    })
+  }
+
+  return (
+    <Button disabled={isPending} onClick={handleApprove}>
+      {isPending ? "Approving…" : "Approve completion"}
+    </Button>
+  )
 }
 
 function ApplicationControls({

--- a/frontend/components/tasks/task-status-badge.tsx
+++ b/frontend/components/tasks/task-status-badge.tsx
@@ -12,6 +12,7 @@ interface StatusDisplay {
 const STATUS_DISPLAY: Record<string, StatusDisplay> = {
   open: { label: "Open", variant: "outline" },
   in_progress: { label: "In progress", variant: "default" },
+  pending_approval: { label: "Awaiting approval", variant: "warning" },
   completed: { label: "Completed", variant: "success" },
   reviewed: { label: "Reviewed", variant: "secondary" },
   cancelled: { label: "Cancelled", variant: "destructive" },

--- a/frontend/components/tasks/task-status-badge.tsx
+++ b/frontend/components/tasks/task-status-badge.tsx
@@ -1,4 +1,5 @@
 import { Badge } from "@/components/ui/badge"
+import { normalizeTaskStatus } from "@/lib/task-status"
 
 interface TaskStatusBadgeProps {
   status: string
@@ -18,13 +19,8 @@ const STATUS_DISPLAY: Record<string, StatusDisplay> = {
   cancelled: { label: "Cancelled", variant: "destructive" },
 }
 
-function normalize(status: string): string {
-  // "InProgress" → "in_progress", "Open" → "open", "in_progress" unchanged
-  return status.replace(/([a-z])([A-Z])/g, "$1_$2").toLowerCase()
-}
-
 export function TaskStatusBadge({ status }: TaskStatusBadgeProps) {
-  const key = normalize(status)
+  const key = normalizeTaskStatus(status)
   const display = STATUS_DISPLAY[key] ?? { label: status, variant: "secondary" }
 
   return <Badge variant={display.variant}>{display.label}</Badge>

--- a/frontend/lib/api/tasks.ts
+++ b/frontend/lib/api/tasks.ts
@@ -27,7 +27,7 @@ export interface ApiTask {
   longitude: number | null
   compensationType: string
   compensationAmount: number | null
-  status: "Open" | "InProgress" | "Completed" | "Cancelled"
+  status: "Open" | "InProgress" | "PendingApproval" | "Completed" | "Cancelled"
   createdAt: string
   updatedAt: string
 }
@@ -214,6 +214,30 @@ export function usePatchTaskApplication(taskId: string) {
       void qc.invalidateQueries({ queryKey: taskKeys.detail(taskId) })
       void qc.invalidateQueries({ queryKey: taskKeys.lists() })
       void qc.invalidateQueries({ queryKey: ["conversations"] })
+    },
+  })
+}
+
+export function useSubmitTaskCompletion(taskId: string) {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: () =>
+      apiClient.post<ApiTask>(`/tasks/${taskId}/completion-submission`, {}),
+    onSuccess: (updated) => {
+      qc.setQueryData(taskKeys.detail(taskId), updated)
+      void qc.invalidateQueries({ queryKey: taskKeys.lists() })
+    },
+  })
+}
+
+export function useApproveTaskCompletion(taskId: string) {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: () =>
+      apiClient.post<ApiTask>(`/tasks/${taskId}/completion-approval`, {}),
+    onSuccess: (updated) => {
+      qc.setQueryData(taskKeys.detail(taskId), updated)
+      void qc.invalidateQueries({ queryKey: taskKeys.lists() })
     },
   })
 }

--- a/frontend/lib/task-status.ts
+++ b/frontend/lib/task-status.ts
@@ -1,0 +1,10 @@
+/**
+ * Normalises a task status string to a stable snake_case form, e.g.
+ * "InProgress" -> "in_progress", "PendingApproval" -> "pending_approval".
+ * The regex MUST run before lowercasing — lowercasing first removes the
+ * uppercase letters the regex looks for and would silently collapse
+ * multi-word statuses into a single word.
+ */
+export function normalizeTaskStatus(status: string): string {
+  return status.replace(/([a-z])([A-Z])/g, "$1_$2").toLowerCase()
+}


### PR DESCRIPTION
Implements the automatic platform points reward for helpers and the two-step task completion flow that gates when that reward fires.

Algorithm + service:
- ITaskCompletionPointsCalculator + FlatTaskCompletionPointsCalculator (server-owned, deterministic): base 10 points, +5 bonus for Voluntary tasks. Paid and Barter tasks award only the base because the helper already receives compensation outside the points economy.
- ITaskCompletionRewardService stages a TaskCompletedReward ledger entry idempotently. Pre-checks the in-context ledger; the existing partial unique index ux_points_ledger_task_reward_once is the belt-and-suspenders against retries.
- Replaces the hardcoded "10 points per completed task" assumption from the original ledger spec (#53) with this explicit, testable policy.

Two-step completion flow (#239):
- New TaskStatus.PendingApproval. Transition is InProgress -> PendingApproval -> Completed; cancellation paths and open/cancelled tasks cannot enter the completion flow.
- POST /api/tasks/{id}/completion-submission: accepted helper marks the task done. Writes a TaskCompletionConfirmation, status history entry, and audit event. No points awarded yet.
- POST /api/tasks/{id}/completion-approval: seeker approves. Flips status to Completed, sets CompletedAt, creates the seeker's confirmation, awards points via the reward service, logs the TaskCompleted activity event and the approval audit.
- EF migration AddPendingApprovalTaskStatus updates the ck_tasks_status check constraint.

Frontend:
- "Mark as done" button for the accepted helper while InProgress.
- "Approve completion" button for the seeker while PendingApproval, plus copy for both actors describing the waiting state.
- New "Awaiting approval" warning badge on the task status pill.
- React Query hooks useSubmitTaskCompletion and useApproveTaskCompletion.

Tests:
- Calculator: one inline-data case per compensation type.
- Reward service: happy path, idempotency on retry, guards for non-completed and helper-less tasks.
- Controller: golden submit/approve paths, idempotent re-approval, forbid for wrong actor, 409 for invalid status transitions, and a case proving paid CompensationAmount coexists with the points award. 167 backend tests pass.

Closes #239
Refs #53, #54, #65