### PR TITLE
feat(tasks): confirmation dialogs for Start, Complete, and Cancel actions

### DIFF
--- a/frontend/app/(main)/tasks/[id]/page.client.tsx
+++ b/frontend/app/(main)/tasks/[id]/page.client.tsx
@@ -12,6 +12,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Separator } from "@/components/ui/separator"
 import { ApplicationControls } from "@/components/tasks/application-controls"
 import { ApproveCompletionButton } from "@/components/tasks/approve-completion-button"
+import { CancelTaskButton } from "@/components/tasks/cancel-task-button"
 import { CategoryBadge } from "@/components/tasks/category-badge"
 import { CompensationBadge } from "@/components/tasks/compensation-badge"
 import { ReviewDialog } from "@/components/tasks/review-dialog"
@@ -163,13 +164,10 @@ function TaskActions({ task }: { task: ApiTask }) {
               <Button variant="outline" asChild>
                 <Link href={`/tasks/${task.id}/edit`}>Edit task</Link>
               </Button>
-              <Button
-                variant="ghost"
-                disabled={isCancelling}
-                onClick={handleCancel}
-              >
-                {isCancelling ? "Cancelling…" : "Cancel task"}
-              </Button>
+              <CancelTaskButton
+                onCancel={handleCancel}
+                isPending={isCancelling}
+              />
             </>
           )}
         </div>
@@ -199,13 +197,7 @@ function TaskActions({ task }: { task: ApiTask }) {
           <SubmitCompletionButton taskId={task.id} />
         ) : null}
         {isSeeker ? (
-          <Button
-            variant="ghost"
-            disabled={isCancelling}
-            onClick={handleCancel}
-          >
-            {isCancelling ? "Cancelling…" : "Cancel task"}
-          </Button>
+          <CancelTaskButton onCancel={handleCancel} isPending={isCancelling} />
         ) : null}
       </div>
     )

--- a/frontend/components/tasks/approve-completion-button.tsx
+++ b/frontend/components/tasks/approve-completion-button.tsx
@@ -50,8 +50,8 @@ export function ApproveCompletionButton({
         </AlertDialogHeader>
         <AlertDialogFooter>
           <AlertDialogCancel>Go back</AlertDialogCancel>
-          <AlertDialogAction onClick={handleApprove}>
-            Approve completion
+          <AlertDialogAction disabled={isPending} onClick={handleApprove}>
+            {isPending ? "Approving…" : "Approve completion"}
           </AlertDialogAction>
         </AlertDialogFooter>
       </AlertDialogContent>

--- a/frontend/components/tasks/approve-completion-button.tsx
+++ b/frontend/components/tasks/approve-completion-button.tsx
@@ -2,6 +2,17 @@
 
 import { toast } from "sonner"
 
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog"
 import { Button } from "@/components/ui/button"
 import { useApproveTaskCompletion } from "@/lib/api/tasks"
 
@@ -9,10 +20,6 @@ interface ApproveCompletionButtonProps {
   taskId: string
 }
 
-/**
- * "Approve completion" button shown to the seeker while the task is
- * PendingApproval. Approving transitions the task to Completed.
- */
 export function ApproveCompletionButton({
   taskId,
 }: ApproveCompletionButtonProps) {
@@ -27,8 +34,27 @@ export function ApproveCompletionButton({
   }
 
   return (
-    <Button disabled={isPending} onClick={handleApprove}>
-      {isPending ? "Approving…" : "Approve completion"}
-    </Button>
+    <AlertDialog>
+      <AlertDialogTrigger asChild>
+        <Button disabled={isPending}>
+          {isPending ? "Approving…" : "Approve completion"}
+        </Button>
+      </AlertDialogTrigger>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Approve task completion?</AlertDialogTitle>
+          <AlertDialogDescription>
+            This will mark the task as complete and release the helper&apos;s
+            reward. This action cannot be undone.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Go back</AlertDialogCancel>
+          <AlertDialogAction onClick={handleApprove}>
+            Approve completion
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
   )
 }

--- a/frontend/components/tasks/cancel-task-button.tsx
+++ b/frontend/components/tasks/cancel-task-button.tsx
@@ -39,7 +39,9 @@ export function CancelTaskButton({
         </AlertDialogHeader>
         <AlertDialogFooter>
           <AlertDialogCancel>Go back</AlertDialogCancel>
-          <AlertDialogAction onClick={onCancel}>Cancel task</AlertDialogAction>
+          <AlertDialogAction disabled={isPending} onClick={onCancel}>
+            {isPending ? "Cancelling…" : "Cancel task"}
+          </AlertDialogAction>
         </AlertDialogFooter>
       </AlertDialogContent>
     </AlertDialog>

--- a/frontend/components/tasks/cancel-task-button.tsx
+++ b/frontend/components/tasks/cancel-task-button.tsx
@@ -1,0 +1,44 @@
+"use client"
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog"
+import { Button } from "@/components/ui/button"
+
+interface CancelTaskButtonProps {
+  onCancel: () => void
+  isPending: boolean
+}
+
+export function CancelTaskButton({ onCancel, isPending }: CancelTaskButtonProps) {
+  return (
+    <AlertDialog>
+      <AlertDialogTrigger asChild>
+        <Button variant="ghost" disabled={isPending}>
+          {isPending ? "Cancelling…" : "Cancel task"}
+        </Button>
+      </AlertDialogTrigger>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Cancel this task?</AlertDialogTitle>
+          <AlertDialogDescription>
+            This will cancel the task and notify any involved helpers. This
+            action cannot be undone.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Go back</AlertDialogCancel>
+          <AlertDialogAction onClick={onCancel}>Cancel task</AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}

--- a/frontend/components/tasks/cancel-task-button.tsx
+++ b/frontend/components/tasks/cancel-task-button.tsx
@@ -18,7 +18,10 @@ interface CancelTaskButtonProps {
   isPending: boolean
 }
 
-export function CancelTaskButton({ onCancel, isPending }: CancelTaskButtonProps) {
+export function CancelTaskButton({
+  onCancel,
+  isPending,
+}: CancelTaskButtonProps) {
   return (
     <AlertDialog>
       <AlertDialogTrigger asChild>

--- a/frontend/components/tasks/submit-completion-button.tsx
+++ b/frontend/components/tasks/submit-completion-button.tsx
@@ -50,8 +50,8 @@ export function SubmitCompletionButton({
         </AlertDialogHeader>
         <AlertDialogFooter>
           <AlertDialogCancel>Go back</AlertDialogCancel>
-          <AlertDialogAction onClick={handleSubmit}>
-            Mark as done
+          <AlertDialogAction disabled={isPending} onClick={handleSubmit}>
+            {isPending ? "Submitting…" : "Mark as done"}
           </AlertDialogAction>
         </AlertDialogFooter>
       </AlertDialogContent>

--- a/frontend/components/tasks/submit-completion-button.tsx
+++ b/frontend/components/tasks/submit-completion-button.tsx
@@ -2,6 +2,17 @@
 
 import { toast } from "sonner"
 
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog"
 import { Button } from "@/components/ui/button"
 import { useSubmitTaskCompletion } from "@/lib/api/tasks"
 
@@ -9,10 +20,6 @@ interface SubmitCompletionButtonProps {
   taskId: string
 }
 
-/**
- * "Mark as done" button shown to the accepted helper while the task is
- * InProgress. Submitting transitions the task to PendingApproval.
- */
 export function SubmitCompletionButton({
   taskId,
 }: SubmitCompletionButtonProps) {
@@ -27,8 +34,27 @@ export function SubmitCompletionButton({
   }
 
   return (
-    <Button disabled={isPending} onClick={handleSubmit}>
-      {isPending ? "Submitting…" : "Mark as done"}
-    </Button>
+    <AlertDialog>
+      <AlertDialogTrigger asChild>
+        <Button disabled={isPending}>
+          {isPending ? "Submitting…" : "Mark as done"}
+        </Button>
+      </AlertDialogTrigger>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Mark task as done?</AlertDialogTitle>
+          <AlertDialogDescription>
+            This will notify the seeker that you have finished. They will review
+            and approve before the task is marked as complete.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Go back</AlertDialogCancel>
+          <AlertDialogAction onClick={handleSubmit}>
+            Mark as done
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
   )
 }

--- a/frontend/components/tasks/task-applications-panel.tsx
+++ b/frontend/components/tasks/task-applications-panel.tsx
@@ -3,6 +3,17 @@
 import Link from "next/link"
 import { toast } from "sonner"
 
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { UserAvatar } from "@/components/shared/user-avatar"
@@ -87,13 +98,36 @@ export function TaskApplicationsPanel({
                 ) : null}
                 {application.status === "Pending" ? (
                   <>
-                    <Button
-                      size="sm"
-                      disabled={isPending}
-                      onClick={() => handleAction(application.id, "accept")}
-                    >
-                      Accept
-                    </Button>
+                    <AlertDialog>
+                      <AlertDialogTrigger asChild>
+                        <Button size="sm" disabled={isPending}>
+                          Accept
+                        </Button>
+                      </AlertDialogTrigger>
+                      <AlertDialogContent>
+                        <AlertDialogHeader>
+                          <AlertDialogTitle>
+                            Accept this application?
+                          </AlertDialogTitle>
+                          <AlertDialogDescription>
+                            {application.helperDisplayName} will be assigned to
+                            this task and it will move to In Progress. Other
+                            pending applications will be closed.
+                          </AlertDialogDescription>
+                        </AlertDialogHeader>
+                        <AlertDialogFooter>
+                          <AlertDialogCancel>Go back</AlertDialogCancel>
+                          <AlertDialogAction
+                            disabled={isPending}
+                            onClick={() =>
+                              handleAction(application.id, "accept")
+                            }
+                          >
+                            {isPending ? "Accepting…" : "Accept"}
+                          </AlertDialogAction>
+                        </AlertDialogFooter>
+                      </AlertDialogContent>
+                    </AlertDialog>
                     <Button
                       size="sm"
                       variant="ghost"


### PR DESCRIPTION
Closes #61

## Summary
- Wraps **Mark as done** (`InProgress → PendingApproval`) in an `AlertDialog` confirming the seeker will need to approve
- Wraps **Approve completion** (`PendingApproval → Completed`) in an `AlertDialog` warning the action is irreversible and releases the helper's reward
- Wraps **Cancel task** (`Open / InProgress → Cancelled`) in an `AlertDialog` — extracted into a reusable `CancelTaskButton` component to avoid duplicating the dialog across the two status branches in the task detail page

All dialogs use `AlertDialogCancel` ("Go back") + `AlertDialogAction` (labelled with the action name) so there is no ambiguous double-negative.

## Test plan
- [ ] Open a task as a helper while it is `InProgress` — click "Mark as done", confirm the dialog appears, verify the task moves to `PendingApproval` on confirm and stays unchanged on dismiss
- [ ] Open a task as the seeker while it is `PendingApproval` — click "Approve completion", confirm the dialog appears, verify the task moves to `Completed` on confirm and stays unchanged on dismiss
- [ ] Open a task as the seeker while it is `Open` — click "Cancel task", confirm the dialog appears, verify the task moves to `Cancelled` on confirm and stays unchanged on dismiss
- [ ] Repeat the cancel test with the task in `InProgress` state

🤖 Generated with [Claude Code](https://claude.com/claude-code)