### PR TITLE
feat(backend): return 400 for invalid task status transitions

### DIFF
--- a/backend.Tests/TaskApplicationsControllerTests.cs
+++ b/backend.Tests/TaskApplicationsControllerTests.cs
@@ -107,6 +107,33 @@ public sealed class TaskApplicationsControllerTests
         Assert.Contains(db.AuditEvents, e => e.EventType == "task_application.withdrawn");
     }
 
+    [Fact]
+    public async Task PatchAsync_Accept_RejectsTransitionWhenTaskNotOpen_With400()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await using var db = CreateDbContext();
+        var scenario = await SeedScenarioAsync(db, cancellationToken);
+        var application = await SeedApplicationAsync(db, scenario, cancellationToken);
+
+        var task = await db.Tasks.FirstAsync(t => t.Id == scenario.TaskId, cancellationToken);
+        task.Status = DomainTaskStatus.InProgress;
+        await db.SaveChangesAsync(cancellationToken);
+
+        var controller = CreateController(db, scenario.SeekerUserId);
+
+        var result = await controller.PatchAsync(
+            scenario.TaskId,
+            application.Id,
+            new PatchApplicationRequest("accept"),
+            cancellationToken);
+
+        var problem = Assert.IsType<ObjectResult>(result);
+        Assert.Equal(StatusCodes.Status400BadRequest, problem.StatusCode);
+
+        var reloaded = await db.TaskApplications.AsNoTracking().FirstAsync(a => a.Id == application.Id, cancellationToken);
+        Assert.Equal(TaskApplicationStatus.Pending, reloaded.Status);
+    }
+
     private static async Task<TestScenario> SeedScenarioAsync(
         AppDbContext db,
         CancellationToken cancellationToken)

--- a/backend.Tests/TaskCompletionControllerTests.cs
+++ b/backend.Tests/TaskCompletionControllerTests.cs
@@ -85,7 +85,7 @@ public sealed class TaskCompletionControllerTests
         var result = await controller.SubmitAsync(scenario.TaskId, cancellationToken);
 
         var problem = Assert.IsType<ObjectResult>(result);
-        Assert.Equal(StatusCodes.Status409Conflict, problem.StatusCode);
+        Assert.Equal(StatusCodes.Status400BadRequest, problem.StatusCode);
 
         // No write-through side effects.
         var reloaded = await db.Tasks.AsNoTracking().FirstAsync(t => t.Id == scenario.TaskId, cancellationToken);
@@ -138,9 +138,11 @@ public sealed class TaskCompletionControllerTests
         var firstResult = await controller.ApproveAsync(scenario.TaskId, cancellationToken);
         Assert.IsType<OkObjectResult>(firstResult);
 
+        // Re-approving a Completed task is an invalid FSM transition (400), and
+        // the reward/completion side effects must not run a second time.
         var secondResult = await controller.ApproveAsync(scenario.TaskId, cancellationToken);
         var problem = Assert.IsType<ObjectResult>(secondResult);
-        Assert.Equal(StatusCodes.Status409Conflict, problem.StatusCode);
+        Assert.Equal(StatusCodes.Status400BadRequest, problem.StatusCode);
 
         // Reward and completion side effects must remain singletons.
         Assert.Single(db.PointsLedger);
@@ -202,7 +204,7 @@ public sealed class TaskCompletionControllerTests
         var result = await controller.ApproveAsync(scenario.TaskId, cancellationToken);
 
         var problem = Assert.IsType<ObjectResult>(result);
-        Assert.Equal(StatusCodes.Status409Conflict, problem.StatusCode);
+        Assert.Equal(StatusCodes.Status400BadRequest, problem.StatusCode);
         Assert.Empty(db.PointsLedger);
     }
 

--- a/backend.Tests/TaskStatusTransitionsTests.cs
+++ b/backend.Tests/TaskStatusTransitionsTests.cs
@@ -1,0 +1,40 @@
+using Backend.Domain.Tasks;
+using Xunit;
+using DomainTaskStatus = Backend.Domain.Enums.TaskStatus;
+
+namespace backend.Tests;
+
+public sealed class TaskStatusTransitionsTests
+{
+    [Theory]
+    [InlineData(DomainTaskStatus.Open, DomainTaskStatus.InProgress)]
+    [InlineData(DomainTaskStatus.Open, DomainTaskStatus.Cancelled)]
+    [InlineData(DomainTaskStatus.InProgress, DomainTaskStatus.PendingApproval)]
+    [InlineData(DomainTaskStatus.InProgress, DomainTaskStatus.Cancelled)]
+    [InlineData(DomainTaskStatus.PendingApproval, DomainTaskStatus.Completed)]
+    [InlineData(DomainTaskStatus.PendingApproval, DomainTaskStatus.Cancelled)]
+    public void CanTransition_AllowsValidEdges(DomainTaskStatus from, DomainTaskStatus to)
+    {
+        Assert.True(TaskStatusTransitions.CanTransition(from, to));
+    }
+
+    [Theory]
+    // Skipping intermediate states is not allowed.
+    [InlineData(DomainTaskStatus.Open, DomainTaskStatus.PendingApproval)]
+    [InlineData(DomainTaskStatus.Open, DomainTaskStatus.Completed)]
+    [InlineData(DomainTaskStatus.InProgress, DomainTaskStatus.Completed)]
+    [InlineData(DomainTaskStatus.PendingApproval, DomainTaskStatus.InProgress)]
+    // No-op self transitions are invalid.
+    [InlineData(DomainTaskStatus.Open, DomainTaskStatus.Open)]
+    [InlineData(DomainTaskStatus.InProgress, DomainTaskStatus.InProgress)]
+    [InlineData(DomainTaskStatus.Completed, DomainTaskStatus.Completed)]
+    // Terminal states have no outgoing transitions.
+    [InlineData(DomainTaskStatus.Completed, DomainTaskStatus.Open)]
+    [InlineData(DomainTaskStatus.Completed, DomainTaskStatus.Cancelled)]
+    [InlineData(DomainTaskStatus.Cancelled, DomainTaskStatus.Open)]
+    [InlineData(DomainTaskStatus.Cancelled, DomainTaskStatus.Completed)]
+    public void CanTransition_RejectsInvalidEdges(DomainTaskStatus from, DomainTaskStatus to)
+    {
+        Assert.False(TaskStatusTransitions.CanTransition(from, to));
+    }
+}

--- a/backend.Tests/TasksControllerTests.cs
+++ b/backend.Tests/TasksControllerTests.cs
@@ -527,6 +527,107 @@ public sealed class TasksControllerTests
         Assert.Contains("ORDER BY", sql);
     }
 
+    [Fact]
+    public async Task UpdateAsync_CancelsActiveTask_PersistsCancellation()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await using var db = CreateInMemoryDbContext();
+        var userId = Guid.NewGuid();
+        var taskId = await SeedOwnedTaskAsync(db, userId, Backend.Domain.Enums.TaskStatus.Open, cancellationToken);
+
+        var controller = CreateTasksController(db, userId);
+
+        var result = await controller.UpdateAsync(
+            taskId,
+            new UpdateTaskRequest(null, null, null, null, null, null, null, null, "Cancelled", "Changed my mind."),
+            cancellationToken);
+
+        var ok = Assert.IsType<OkObjectResult>(result);
+        var response = Assert.IsType<TaskResponse>(ok.Value);
+        Assert.Equal(nameof(Backend.Domain.Enums.TaskStatus.Cancelled), response.Status);
+
+        var reloaded = await db.Tasks.AsNoTracking().FirstAsync(t => t.Id == taskId, cancellationToken);
+        Assert.Equal(Backend.Domain.Enums.TaskStatus.Cancelled, reloaded.Status);
+        Assert.NotNull(reloaded.CancelledAt);
+
+        var history = Assert.Single(db.TaskStatusHistory);
+        Assert.Equal(Backend.Domain.Enums.TaskStatus.Open, history.OldStatus);
+        Assert.Equal(Backend.Domain.Enums.TaskStatus.Cancelled, history.NewStatus);
+    }
+
+    [Theory]
+    [InlineData(Backend.Domain.Enums.TaskStatus.Completed)]
+    [InlineData(Backend.Domain.Enums.TaskStatus.Cancelled)]
+    public async Task UpdateAsync_RejectsCancellationOfTerminalTask_With400(
+        Backend.Domain.Enums.TaskStatus terminalStatus)
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await using var db = CreateInMemoryDbContext();
+        var userId = Guid.NewGuid();
+        var taskId = await SeedOwnedTaskAsync(db, userId, terminalStatus, cancellationToken);
+
+        var controller = CreateTasksController(db, userId);
+
+        var result = await controller.UpdateAsync(
+            taskId,
+            new UpdateTaskRequest(null, null, null, null, null, null, null, null, "Cancelled", null),
+            cancellationToken);
+
+        var problem = Assert.IsType<ObjectResult>(result);
+        Assert.Equal(StatusCodes.Status400BadRequest, problem.StatusCode);
+
+        var reloaded = await db.Tasks.AsNoTracking().FirstAsync(t => t.Id == taskId, cancellationToken);
+        Assert.Equal(terminalStatus, reloaded.Status);
+        Assert.Empty(db.TaskStatusHistory);
+    }
+
+    private static async Task<Guid> SeedOwnedTaskAsync(
+        AppDbContext db,
+        Guid userId,
+        Backend.Domain.Enums.TaskStatus status,
+        CancellationToken cancellationToken)
+    {
+        var profileId = Guid.NewGuid();
+        var categoryId = Guid.NewGuid();
+        var now = DateTimeOffset.UtcNow;
+
+        db.Profiles.Add(new UserProfile
+        {
+            Id = profileId,
+            UserId = userId,
+            DisplayName = "Task seeker",
+            CreatedAt = now,
+            UpdatedAt = now
+        });
+        db.Categories.Add(new Category
+        {
+            Id = categoryId,
+            Code = "help",
+            Name = "Help",
+            Icon = Category.DefaultIcon,
+            IsActive = true,
+            CreatedAt = now,
+            UpdatedAt = now
+        });
+
+        var taskId = Guid.NewGuid();
+        db.Tasks.Add(new CommunityTask
+        {
+            Id = taskId,
+            SeekerProfileId = profileId,
+            CategoryId = categoryId,
+            Title = "Carry boxes",
+            Description = "Need help carrying boxes.",
+            CompensationType = CompensationType.Voluntary,
+            Status = status,
+            CreatedAt = now,
+            UpdatedAt = now
+        });
+
+        await db.SaveChangesAsync(cancellationToken);
+        return taskId;
+    }
+
     private static async Task<(Guid ProfileId, Guid CategoryId, DateTimeOffset Now)> SeedSinglePosterAsync(
         AppDbContext db,
         CancellationToken cancellationToken)

--- a/backend.Tests/TasksControllerTests.cs
+++ b/backend.Tests/TasksControllerTests.cs
@@ -854,6 +854,8 @@ public sealed class TasksControllerTests
 
         await db.SaveChangesAsync(cancellationToken);
         return taskId;
+    }
+
     private static CommunityTask CreateTask(
         Guid profileId,
         Guid categoryId,

--- a/backend/Domain/Tasks/TaskStatusTransitions.cs
+++ b/backend/Domain/Tasks/TaskStatusTransitions.cs
@@ -1,0 +1,43 @@
+using DomainTaskStatus = Backend.Domain.Enums.TaskStatus;
+
+namespace Backend.Domain.Tasks;
+
+/// <summary>
+/// Single source of truth for the task status lifecycle (finite state machine).
+///
+/// Lifecycle:
+///     Open ──► InProgress ──► PendingApproval ──► Completed
+///       │           │                 │
+///       └───────────┴─────────────────┴──► Cancelled
+///
+/// Completed and Cancelled are terminal: they have no outgoing transitions.
+/// Controllers consult this map so an invalid transition fails the same way
+/// everywhere instead of each call site re-deriving the rules.
+/// </summary>
+public static class TaskStatusTransitions
+{
+    private static readonly Dictionary<DomainTaskStatus, IReadOnlySet<DomainTaskStatus>> _allowed =
+        new()
+        {
+            [DomainTaskStatus.Open] = new HashSet<DomainTaskStatus>
+            {
+                DomainTaskStatus.InProgress,
+                DomainTaskStatus.Cancelled
+            },
+            [DomainTaskStatus.InProgress] = new HashSet<DomainTaskStatus>
+            {
+                DomainTaskStatus.PendingApproval,
+                DomainTaskStatus.Cancelled
+            },
+            [DomainTaskStatus.PendingApproval] = new HashSet<DomainTaskStatus>
+            {
+                DomainTaskStatus.Completed,
+                DomainTaskStatus.Cancelled
+            },
+            [DomainTaskStatus.Completed] = new HashSet<DomainTaskStatus>(),
+            [DomainTaskStatus.Cancelled] = new HashSet<DomainTaskStatus>()
+        };
+
+    public static bool CanTransition(DomainTaskStatus from, DomainTaskStatus to) =>
+        _allowed.TryGetValue(from, out var targets) && targets.Contains(to);
+}

--- a/backend/Features/Tasks/Applications/TaskApplicationsController.cs
+++ b/backend/Features/Tasks/Applications/TaskApplicationsController.cs
@@ -1,6 +1,7 @@
 using Backend.Common;
 using Backend.Domain.Entities;
 using Backend.Domain.Enums;
+using Backend.Domain.Tasks;
 using Backend.Features.Conversations;
 using Backend.Infrastructure.Persistence;
 using Microsoft.AspNetCore.Authorization;
@@ -289,12 +290,12 @@ public sealed partial class TaskApplicationsController(
 
         if (isAccept)
         {
-            if (task.Status != DomainTaskStatus.Open)
+            if (!TaskStatusTransitions.CanTransition(task.Status, DomainTaskStatus.InProgress))
             {
                 return Problem(
-                    title: "Task is not open",
+                    title: "Invalid task status transition",
                     detail: "An application can only be accepted when the task has Open status.",
-                    statusCode: StatusCodes.Status409Conflict);
+                    statusCode: StatusCodes.Status400BadRequest);
             }
 
             if (application.Status != TaskApplicationStatus.Pending)

--- a/backend/Features/Tasks/Completion/TaskCompletionController.cs
+++ b/backend/Features/Tasks/Completion/TaskCompletionController.cs
@@ -2,6 +2,7 @@ using System.Security.Claims;
 using Backend.Application.TaskCompletion;
 using Backend.Domain.Entities;
 using Backend.Domain.Enums;
+using Backend.Domain.Tasks;
 using Backend.Infrastructure.Persistence;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -42,15 +43,15 @@ public sealed class TaskCompletionController(
             return Forbid();
         }
 
-        if (task.Status != DomainTaskStatus.InProgress)
+        if (!TaskStatusTransitions.CanTransition(task.Status, DomainTaskStatus.PendingApproval))
         {
             var submitDetail = task.Status == DomainTaskStatus.PendingApproval
                 ? "This task is already awaiting the seeker's approval."
                 : "Only in-progress tasks can be marked as done.";
             return Problem(
-                title: "Task cannot be marked as done",
+                title: "Invalid task status transition",
                 detail: submitDetail,
-                statusCode: StatusCodes.Status409Conflict);
+                statusCode: StatusCodes.Status400BadRequest);
         }
 
         var now = DateTimeOffset.UtcNow;
@@ -128,15 +129,15 @@ public sealed class TaskCompletionController(
             return Forbid();
         }
 
-        if (task.Status != DomainTaskStatus.PendingApproval)
+        if (!TaskStatusTransitions.CanTransition(task.Status, DomainTaskStatus.Completed))
         {
             var approveDetail = task.Status == DomainTaskStatus.Completed
                 ? "This task has already been marked as completed."
                 : "Only tasks awaiting approval can be approved.";
             return Problem(
-                title: "Task cannot be approved",
+                title: "Invalid task status transition",
                 detail: approveDetail,
-                statusCode: StatusCodes.Status409Conflict);
+                statusCode: StatusCodes.Status400BadRequest);
         }
 
         if (task.AcceptedHelperProfileId is null)

--- a/backend/Features/Tasks/TasksController.cs
+++ b/backend/Features/Tasks/TasksController.cs
@@ -1,6 +1,7 @@
 using Backend.Common;
 using Backend.Domain.Entities;
 using Backend.Domain.Enums;
+using Backend.Domain.Tasks;
 using Backend.Infrastructure.Persistence;
 using Backend.Infrastructure.Validation;
 using Microsoft.AspNetCore.Authorization;
@@ -323,7 +324,26 @@ public sealed partial class TasksController(AppDbContext db) : ControllerBase
             return Forbid();
         }
 
-        if (task.Status is DomainTaskStatus.Completed or DomainTaskStatus.Cancelled)
+        // A status change request is only ever a cancellation (enforced below).
+        // Validate the transition against the FSM up front so an invalid
+        // transition fails with 400 before any field-level edits are applied.
+        if (request.Status is not null)
+        {
+            if (!string.Equals(request.Status, nameof(DomainTaskStatus.Cancelled), StringComparison.OrdinalIgnoreCase))
+            {
+                ModelState.AddModelError(nameof(request.Status), "Status can only be changed to 'Cancelled'.");
+                return ValidationProblem(ModelState);
+            }
+
+            if (!TaskStatusTransitions.CanTransition(task.Status, DomainTaskStatus.Cancelled))
+            {
+                return Problem(
+                    title: "Invalid task status transition",
+                    detail: $"A task with status '{task.Status}' cannot be transitioned to 'Cancelled'.",
+                    statusCode: StatusCodes.Status400BadRequest);
+            }
+        }
+        else if (task.Status is DomainTaskStatus.Completed or DomainTaskStatus.Cancelled)
         {
             return Problem(
                 title: "Task cannot be modified",
@@ -427,12 +447,7 @@ public sealed partial class TasksController(AppDbContext db) : ControllerBase
 
         if (request.Status is not null)
         {
-            if (!string.Equals(request.Status, nameof(DomainTaskStatus.Cancelled), StringComparison.OrdinalIgnoreCase))
-            {
-                ModelState.AddModelError(nameof(request.Status), "Status can only be changed to 'Cancelled'.");
-                return ValidationProblem(ModelState);
-            }
-
+            // Target status and transition validity already verified above.
             var oldStatus = task.Status;
             var cancelledAt = DateTimeOffset.UtcNow;
             var cancellationReason = StringUtilities.Normalize(request.CancellationReason);


### PR DESCRIPTION
## Summary
Wraps up #36 (Task status lifecycle FSM). The lifecycle (`Open → InProgress → PendingApproval → Completed`, plus `Cancelled` from any active state) was already implemented, but **invalid transitions returned `409 Conflict` instead of the `400` required by the acceptance criteria**. This PR makes the FSM explicit and aligns the response codes.

- Adds `Backend.Domain.Tasks.TaskStatusTransitions` — a single source of truth for allowed status edges. `Completed`/`Cancelled` are terminal.
- Routes the four status-changing operations through the FSM and returns **400** on an invalid transition:
  - accept application → `InProgress`
  - completion submission → `PendingApproval`
  - completion approval → `Completed`
  - cancel (`PATCH /api/tasks/{id}`) → `Cancelled`
- **Kept `409`** where the conflict is genuine and *not* an FSM transition: optimistic-concurrency races on accept (`DbUpdateConcurrencyException`, lost update), duplicate-resource conflicts (already applied / already confirmed / DB-level idempotency), and field edits on a terminal task.

## Acceptance criteria
- ✅ Invalid transitions return 400
- ✅ Valid ones persist the state change (verified by existing + new tests)

## Notes for reviewer
- Applying to a non-open task still returns `409` — applying is a precondition conflict, not a task *status* transition, so it's intentionally left out of the FSM scope.
- A retried approval of an already-`Completed` task now returns `400` (invalid transition) rather than `409`; side effects (points, completion events) remain singletons.
- No frontend change needed: the UI surfaces problem responses generically and already renders all five statuses.

## Test plan
- [x] `dotnet build -c Release` — clean (0 warnings)
- [x] `dotnet test -c Release` — 298 passed / 3 skipped
- [x] `dotnet format --verify-no-changes` — clean
- [x] New `TaskStatusTransitionsTests` covers the full valid/invalid edge matrix
- [x] New cancel-path tests (valid cancel persists; cancelling a terminal task → 400)
- [x] New accept-on-non-open test → 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)
