### PR TITLE
feat(rate-limiting): cap previously uncapped API endpoints (#264)

### DIFF
--- a/backend.Tests/RateLimitingTests.cs
+++ b/backend.Tests/RateLimitingTests.cs
@@ -17,6 +17,11 @@ public sealed class RateLimitingTests
     [InlineData(RateLimitingExtensions.AuthPolicy, "Auth")]
     [InlineData(RateLimitingExtensions.ConversationsPolicy, "Conversations")]
     [InlineData(RateLimitingExtensions.ReviewsPolicy, "Reviews")]
+    [InlineData(RateLimitingExtensions.PhotoUploadPolicy, "PhotoUpload")]
+    [InlineData(RateLimitingExtensions.TasksReadPolicy, "TasksRead")]
+    [InlineData(RateLimitingExtensions.TasksWritePolicy, "TasksWrite")]
+    [InlineData(RateLimitingExtensions.LocationsPolicy, "Locations")]
+    [InlineData(RateLimitingExtensions.AdminPolicy, "Admin")]
     public async Task ExceedingPermitLimit_Returns429(string policy, string configKey)
     {
         const int permitLimit = 3;

--- a/backend/Features/Admin/Analytics/AdminAnalyticsController.cs
+++ b/backend/Features/Admin/Analytics/AdminAnalyticsController.cs
@@ -1,6 +1,8 @@
 using Backend.Infrastructure.Persistence;
+using Backend.Infrastructure.Security;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
 using Microsoft.EntityFrameworkCore;
 
 namespace Backend.Features.Admin.Analytics;
@@ -8,6 +10,7 @@ namespace Backend.Features.Admin.Analytics;
 [ApiController]
 [Route("api/admin/analytics")]
 [Authorize(Roles = "Admin")]
+[EnableRateLimiting(RateLimitingExtensions.AdminPolicy)]
 public sealed class AdminAnalyticsController(AppDbContext db) : ControllerBase
 {
     [HttpGet("kpi")]

--- a/backend/Features/Admin/AuditLog/AdminAuditLogController.cs
+++ b/backend/Features/Admin/AuditLog/AdminAuditLogController.cs
@@ -1,6 +1,8 @@
 using Backend.Infrastructure.Persistence;
+using Backend.Infrastructure.Security;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
 using Microsoft.EntityFrameworkCore;
 
 namespace Backend.Features.Admin.AuditLog;
@@ -8,6 +10,7 @@ namespace Backend.Features.Admin.AuditLog;
 [ApiController]
 [Route("api/admin/audit-log")]
 [Authorize(Roles = "Admin")]
+[EnableRateLimiting(RateLimitingExtensions.AdminPolicy)]
 public sealed class AdminAuditLogController(AppDbContext db) : ControllerBase
 {
     private const int DefaultPageSize = 20;

--- a/backend/Features/Admin/Categories/AdminCategoriesController.cs
+++ b/backend/Features/Admin/Categories/AdminCategoriesController.cs
@@ -1,10 +1,12 @@
 using Backend.Common;
 using Backend.Domain.Entities;
 using Backend.Infrastructure.Persistence;
+using Backend.Infrastructure.Security;
 using Backend.Infrastructure.Validation;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.OutputCaching;
+using Microsoft.AspNetCore.RateLimiting;
 using Microsoft.EntityFrameworkCore;
 
 namespace Backend.Features.Admin.Categories;
@@ -12,6 +14,7 @@ namespace Backend.Features.Admin.Categories;
 [Authorize(Roles = "Admin")]
 [ApiController]
 [Route("api/admin/categories")]
+[EnableRateLimiting(RateLimitingExtensions.AdminPolicy)]
 public sealed partial class AdminCategoriesController(
     AppDbContext db,
     IOutputCacheStore outputCacheStore)

--- a/backend/Features/Admin/Skills/AdminSkillsController.cs
+++ b/backend/Features/Admin/Skills/AdminSkillsController.cs
@@ -1,7 +1,9 @@
 using Backend.Domain.Enums;
 using Backend.Infrastructure.Persistence;
+using Backend.Infrastructure.Security;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
 using Microsoft.EntityFrameworkCore;
 
 namespace Backend.Features.Admin.Skills;
@@ -9,6 +11,7 @@ namespace Backend.Features.Admin.Skills;
 [ApiController]
 [Route("api/admin/skills")]
 [Authorize(Roles = "Admin")]
+[EnableRateLimiting(RateLimitingExtensions.AdminPolicy)]
 public sealed partial class AdminSkillsController(AppDbContext db) : ControllerBase
 {
     private const int DefaultPageSize = 20;

--- a/backend/Features/Admin/Terms/AdminTermsController.cs
+++ b/backend/Features/Admin/Terms/AdminTermsController.cs
@@ -3,9 +3,11 @@ using System.Text.Json;
 using Backend.Domain.Entities;
 using Backend.Features.Terms;
 using Backend.Infrastructure.Persistence;
+using Backend.Infrastructure.Security;
 using Ganss.Xss;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
 using Microsoft.EntityFrameworkCore;
 
 namespace Backend.Features.Admin.Terms;
@@ -13,6 +15,7 @@ namespace Backend.Features.Admin.Terms;
 [ApiController]
 [Route("api/admin/terms")]
 [Authorize(Roles = "Admin")]
+[EnableRateLimiting(RateLimitingExtensions.AdminPolicy)]
 public sealed class AdminTermsController(AppDbContext db) : ControllerBase
 {
     [HttpGet]

--- a/backend/Features/Admin/Users/AdminUsersController.cs
+++ b/backend/Features/Admin/Users/AdminUsersController.cs
@@ -2,9 +2,11 @@ using System.Security.Claims;
 using Backend.Domain.Entities;
 using Backend.Infrastructure.Identity;
 using Backend.Infrastructure.Persistence;
+using Backend.Infrastructure.Security;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
 using Microsoft.EntityFrameworkCore;
 
 namespace Backend.Features.Admin.Users;
@@ -12,6 +14,7 @@ namespace Backend.Features.Admin.Users;
 [ApiController]
 [Route("api/admin/users")]
 [Authorize(Roles = "Admin")]
+[EnableRateLimiting(RateLimitingExtensions.AdminPolicy)]
 public sealed class AdminUsersController(
     AppDbContext db,
     UserManager<ApplicationUser> userManager) : ControllerBase

--- a/backend/Features/Categories/CategoriesController.cs
+++ b/backend/Features/Categories/CategoriesController.cs
@@ -1,11 +1,14 @@
 using Backend.Application.Categories;
+using Backend.Infrastructure.Security;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.OutputCaching;
+using Microsoft.AspNetCore.RateLimiting;
 
 namespace Backend.Features.Categories;
 
 [ApiController]
 [Route("api/categories")]
+[EnableRateLimiting(RateLimitingExtensions.TasksReadPolicy)]
 public sealed class CategoriesController(IListCategoriesQuery listCategoriesQuery) : ControllerBase
 {
     [HttpGet]

--- a/backend/Features/Locations/LocationsController.cs
+++ b/backend/Features/Locations/LocationsController.cs
@@ -1,5 +1,7 @@
+using Backend.Infrastructure.Security;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
 using Microsoft.Extensions.Caching.Memory;
 
 namespace Backend.Features.Locations;
@@ -7,6 +9,7 @@ namespace Backend.Features.Locations;
 [ApiController]
 [Route("api/locations")]
 [AllowAnonymous]
+[EnableRateLimiting(RateLimitingExtensions.LocationsPolicy)]
 public sealed partial class LocationsController(
     IHttpClientFactory httpClientFactory,
     IConfiguration configuration,

--- a/backend/Features/Profiles/ProfilesController.cs
+++ b/backend/Features/Profiles/ProfilesController.cs
@@ -302,6 +302,7 @@ public sealed partial class ProfilesController(AppDbContext db, IBlobStorageServ
     /// 401 Unauthorized if not authenticated.
     /// </returns>
     [HttpPut("me")]
+    [EnableRateLimiting(RateLimitingExtensions.TasksWritePolicy)]
     public async Task<IActionResult> UpdateOwnProfileAsync(
         UpdateOwnProfileRequest request,
         CancellationToken cancellationToken)
@@ -418,6 +419,7 @@ public sealed partial class ProfilesController(AppDbContext db, IBlobStorageServ
     /// 401 Unauthorized if not authenticated.
     /// </returns>
     [HttpPut("me/privacy")]
+    [EnableRateLimiting(RateLimitingExtensions.TasksWritePolicy)]
     public async Task<IActionResult> UpdatePrivacySettingsAsync(
         UpdateProfilePrivacySettingsRequest request,
         CancellationToken cancellationToken)
@@ -561,6 +563,7 @@ public sealed partial class ProfilesController(AppDbContext db, IBlobStorageServ
     /// 401 Unauthorized if not authenticated.
     /// </returns>
     [HttpDelete("me/photo")]
+    [EnableRateLimiting(RateLimitingExtensions.PhotoUploadPolicy)]
     public async Task<IActionResult> DeleteProfilePhotoAsync(CancellationToken cancellationToken)
     {
         var userId = User.FindFirst(ClaimTypes.NameIdentifier)?.Value;

--- a/backend/Features/Profiles/ProfilesController.cs
+++ b/backend/Features/Profiles/ProfilesController.cs
@@ -15,6 +15,7 @@ namespace Backend.Features.Profiles;
 [ApiController]
 [Route("api/profiles")]
 [Authorize]
+[EnableRateLimiting(RateLimitingExtensions.TasksReadPolicy)]
 public sealed partial class ProfilesController(AppDbContext db, IBlobStorageService blobStorage, ILogger<ProfilesController> logger) : ControllerBase
 {
     /// <summary>

--- a/backend/Features/Skills/SkillsController.cs
+++ b/backend/Features/Skills/SkillsController.cs
@@ -2,9 +2,11 @@ using Backend.Common;
 using Backend.Domain.Entities;
 using Backend.Domain.Enums;
 using Backend.Infrastructure.Persistence;
+using Backend.Infrastructure.Security;
 using Backend.Infrastructure.Validation;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
 using Microsoft.EntityFrameworkCore;
 
 namespace Backend.Features.Skills;
@@ -12,6 +14,7 @@ namespace Backend.Features.Skills;
 [ApiController]
 [Route("api/skills")]
 [Authorize]
+[EnableRateLimiting(RateLimitingExtensions.TasksReadPolicy)]
 public sealed partial class SkillsController(AppDbContext db) : ControllerBase
 {
     private const int MaxSearchResults = 20;
@@ -76,6 +79,7 @@ public sealed partial class SkillsController(AppDbContext db) : ControllerBase
     }
 
     [HttpPost]
+    [EnableRateLimiting(RateLimitingExtensions.TasksWritePolicy)]
     public async Task<IActionResult> CreateAsync(
         CreateSkillRequest request,
         CancellationToken cancellationToken)

--- a/backend/Features/Tasks/Applications/TaskApplicationsController.cs
+++ b/backend/Features/Tasks/Applications/TaskApplicationsController.cs
@@ -4,8 +4,10 @@ using Backend.Domain.Enums;
 using Backend.Domain.Tasks;
 using Backend.Features.Conversations;
 using Backend.Infrastructure.Persistence;
+using Backend.Infrastructure.Security;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.EntityFrameworkCore;
 using DomainTaskStatus = Backend.Domain.Enums.TaskStatus;
@@ -15,12 +17,14 @@ namespace Backend.Features.Tasks.Applications;
 [ApiController]
 [Route("api/tasks/{taskId:guid}/applications")]
 [Authorize]
+[EnableRateLimiting(RateLimitingExtensions.TasksReadPolicy)]
 public sealed partial class TaskApplicationsController(
     AppDbContext db,
     CosmosMessageService cosmosMessages,
     IHubContext<ChatHub> chatHub) : ControllerBase
 {
     [HttpPost]
+    [EnableRateLimiting(RateLimitingExtensions.TasksWritePolicy)]
     public async Task<IActionResult> ApplyAsync(
         Guid taskId,
         ApplyToTaskRequest request,
@@ -242,6 +246,7 @@ public sealed partial class TaskApplicationsController(
     }
 
     [HttpPatch("{appId:guid}")]
+    [EnableRateLimiting(RateLimitingExtensions.TasksWritePolicy)]
     public async Task<IActionResult> PatchAsync(
         Guid taskId,
         Guid appId,
@@ -481,6 +486,7 @@ public sealed partial class TaskApplicationsController(
     }
 
     [HttpDelete("{appId:guid}")]
+    [EnableRateLimiting(RateLimitingExtensions.TasksWritePolicy)]
     public async Task<IActionResult> WithdrawAsync(
         Guid taskId,
         Guid appId,

--- a/backend/Features/Tasks/Completion/TaskCompletionController.cs
+++ b/backend/Features/Tasks/Completion/TaskCompletionController.cs
@@ -4,8 +4,10 @@ using Backend.Domain.Entities;
 using Backend.Domain.Enums;
 using Backend.Domain.Tasks;
 using Backend.Infrastructure.Persistence;
+using Backend.Infrastructure.Security;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
 using Microsoft.EntityFrameworkCore;
 using DomainTaskStatus = Backend.Domain.Enums.TaskStatus;
 
@@ -14,6 +16,7 @@ namespace Backend.Features.Tasks.Completion;
 [ApiController]
 [Route("api/tasks/{taskId:guid}")]
 [Authorize]
+[EnableRateLimiting(RateLimitingExtensions.TasksWritePolicy)]
 public sealed class TaskCompletionController(
     AppDbContext db,
     ITaskCompletionRewardService rewardService) : ControllerBase

--- a/backend/Features/Tasks/TasksController.cs
+++ b/backend/Features/Tasks/TasksController.cs
@@ -3,9 +3,11 @@ using Backend.Domain.Entities;
 using Backend.Domain.Enums;
 using Backend.Domain.Tasks;
 using Backend.Infrastructure.Persistence;
+using Backend.Infrastructure.Security;
 using Backend.Infrastructure.Validation;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
 using Microsoft.EntityFrameworkCore;
 using NetTopologySuite.Geometries;
 using DomainTaskStatus = Backend.Domain.Enums.TaskStatus;
@@ -15,6 +17,7 @@ namespace Backend.Features.Tasks;
 [ApiController]
 [Route("api/tasks")]
 [Authorize]
+[EnableRateLimiting(RateLimitingExtensions.TasksReadPolicy)]
 public sealed partial class TasksController(AppDbContext db) : ControllerBase
 {
     private const int DefaultPageSize = 20;
@@ -199,6 +202,7 @@ public sealed partial class TasksController(AppDbContext db) : ControllerBase
     }
 
     [HttpPost]
+    [EnableRateLimiting(RateLimitingExtensions.TasksWritePolicy)]
     public async Task<IActionResult> CreateAsync(
         CreateTaskRequest request,
         CancellationToken cancellationToken)
@@ -297,6 +301,7 @@ public sealed partial class TasksController(AppDbContext db) : ControllerBase
     }
 
     [HttpPatch("{id:guid}")]
+    [EnableRateLimiting(RateLimitingExtensions.TasksWritePolicy)]
     public async Task<IActionResult> UpdateAsync(
         Guid id,
         UpdateTaskRequest request,

--- a/backend/Features/Terms/TermsController.cs
+++ b/backend/Features/Terms/TermsController.cs
@@ -4,6 +4,7 @@ using Backend.Infrastructure.Persistence;
 using Backend.Infrastructure.Security;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
 using Microsoft.EntityFrameworkCore;
 
 namespace Backend.Features.Terms;
@@ -11,6 +12,7 @@ namespace Backend.Features.Terms;
 [ApiController]
 [Route("api/terms")]
 [Authorize]
+[EnableRateLimiting(RateLimitingExtensions.TasksReadPolicy)]
 public sealed class TermsController(AppDbContext db, IClientIpAccessor clientIpAccessor) : ControllerBase
 {
     /// <summary>
@@ -59,6 +61,7 @@ public sealed class TermsController(AppDbContext db, IClientIpAccessor clientIpA
     /// 401 Unauthorized if not authenticated.
     /// </returns>
     [HttpPost("accept")]
+    [EnableRateLimiting(RateLimitingExtensions.TasksWritePolicy)]
     public async Task<IActionResult> AcceptTermsAsync(
         AcceptTermsRequest request,
         CancellationToken cancellationToken)

--- a/backend/Infrastructure/Security/RateLimitingExtensions.cs
+++ b/backend/Infrastructure/Security/RateLimitingExtensions.cs
@@ -8,6 +8,10 @@ public static class RateLimitingExtensions
     public const string ConversationsPolicy = "conversations";
     public const string ReviewsPolicy = "reviews";
     public const string PhotoUploadPolicy = "photo-upload";
+    public const string TasksReadPolicy = "tasks-read";
+    public const string TasksWritePolicy = "tasks-write";
+    public const string LocationsPolicy = "locations";
+    public const string AdminPolicy = "admin";
 
     public static IServiceCollection AddAppRateLimiting(
         this IServiceCollection services,
@@ -20,47 +24,32 @@ public static class RateLimitingExtensions
         {
             limiterOptions.RejectionStatusCode = StatusCodes.Status429TooManyRequests;
 
-            limiterOptions.AddPolicy(AuthPolicy, context =>
-            {
-                var ip = context.RequestServices.GetRequiredService<IClientIpAccessor>().GetClientIp() ?? "unknown";
-                return RateLimitPartition.GetFixedWindowLimiter(ip, _ => new FixedWindowRateLimiterOptions
-                {
-                    PermitLimit = opts.Auth.PermitLimit,
-                    Window = TimeSpan.FromSeconds(opts.Auth.WindowSeconds)
-                });
-            });
-
-            limiterOptions.AddPolicy(ConversationsPolicy, context =>
-            {
-                var ip = context.RequestServices.GetRequiredService<IClientIpAccessor>().GetClientIp() ?? "unknown";
-                return RateLimitPartition.GetFixedWindowLimiter(ip, _ => new FixedWindowRateLimiterOptions
-                {
-                    PermitLimit = opts.Conversations.PermitLimit,
-                    Window = TimeSpan.FromSeconds(opts.Conversations.WindowSeconds)
-                });
-            });
-
-            limiterOptions.AddPolicy(ReviewsPolicy, context =>
-            {
-                var ip = context.RequestServices.GetRequiredService<IClientIpAccessor>().GetClientIp() ?? "unknown";
-                return RateLimitPartition.GetFixedWindowLimiter(ip, _ => new FixedWindowRateLimiterOptions
-                {
-                    PermitLimit = opts.Reviews.PermitLimit,
-                    Window = TimeSpan.FromSeconds(opts.Reviews.WindowSeconds)
-                });
-            });
-
-            limiterOptions.AddPolicy(PhotoUploadPolicy, context =>
-            {
-                var ip = context.RequestServices.GetRequiredService<IClientIpAccessor>().GetClientIp() ?? "unknown";
-                return RateLimitPartition.GetFixedWindowLimiter(ip, _ => new FixedWindowRateLimiterOptions
-                {
-                    PermitLimit = opts.PhotoUpload.PermitLimit,
-                    Window = TimeSpan.FromSeconds(opts.PhotoUpload.WindowSeconds)
-                });
-            });
+            AddIpFixedWindowPolicy(limiterOptions, AuthPolicy, opts.Auth);
+            AddIpFixedWindowPolicy(limiterOptions, ConversationsPolicy, opts.Conversations);
+            AddIpFixedWindowPolicy(limiterOptions, ReviewsPolicy, opts.Reviews);
+            AddIpFixedWindowPolicy(limiterOptions, PhotoUploadPolicy, opts.PhotoUpload);
+            AddIpFixedWindowPolicy(limiterOptions, TasksReadPolicy, opts.TasksRead);
+            AddIpFixedWindowPolicy(limiterOptions, TasksWritePolicy, opts.TasksWrite);
+            AddIpFixedWindowPolicy(limiterOptions, LocationsPolicy, opts.Locations);
+            AddIpFixedWindowPolicy(limiterOptions, AdminPolicy, opts.Admin);
         });
 
         return services;
+    }
+
+    private static void AddIpFixedWindowPolicy(
+        Microsoft.AspNetCore.RateLimiting.RateLimiterOptions limiterOptions,
+        string policyName,
+        WindowPolicyOptions policy)
+    {
+        limiterOptions.AddPolicy(policyName, context =>
+        {
+            var ip = context.RequestServices.GetRequiredService<IClientIpAccessor>().GetClientIp() ?? "unknown";
+            return RateLimitPartition.GetFixedWindowLimiter(ip, _ => new FixedWindowRateLimiterOptions
+            {
+                PermitLimit = policy.PermitLimit,
+                Window = TimeSpan.FromSeconds(policy.WindowSeconds)
+            });
+        });
     }
 }

--- a/backend/Infrastructure/Security/RateLimitingOptions.cs
+++ b/backend/Infrastructure/Security/RateLimitingOptions.cs
@@ -8,6 +8,23 @@ public sealed class RateLimitingOptions
     public WindowPolicyOptions Conversations { get; init; } = new();
     public WindowPolicyOptions Reviews { get; init; } = new();
     public WindowPolicyOptions PhotoUpload { get; init; } = new() { PermitLimit = 10, WindowSeconds = 600 };
+
+    // Generous read budget for high-frequency browsing (tasks list/detail and
+    // reference catalogues like categories, skills, terms, profile reads).
+    public WindowPolicyOptions TasksRead { get; init; } = new() { PermitLimit = 120, WindowSeconds = 60 };
+
+    // Tighter budget for state-changing endpoints (post / update / cancel a
+    // task, apply / withdraw / accept an application, submit / approve a
+    // completion). Abuse here costs real domain integrity.
+    public WindowPolicyOptions TasksWrite { get; init; } = new() { PermitLimit = 20, WindowSeconds = 60 };
+
+    // External geocoding (Nominatim) proxy — each call has a real upstream
+    // cost and the provider's own usage policy, so cap independently.
+    public WindowPolicyOptions Locations { get; init; } = new() { PermitLimit = 30, WindowSeconds = 60 };
+
+    // Admin endpoints are already gated behind the Admin role, so the cap is
+    // mainly a guard against runaway scripts and accidental misuse.
+    public WindowPolicyOptions Admin { get; init; } = new() { PermitLimit = 60, WindowSeconds = 60 };
 }
 
 public sealed class WindowPolicyOptions

--- a/backend/appsettings.json
+++ b/backend/appsettings.json
@@ -22,7 +22,12 @@
   "RateLimit": {
     "Auth": { "PermitLimit": 10, "WindowSeconds": 60 },
     "Conversations": { "PermitLimit": 30, "WindowSeconds": 60 },
-    "Reviews": { "PermitLimit": 20, "WindowSeconds": 60 }
+    "Reviews": { "PermitLimit": 20, "WindowSeconds": 60 },
+    "PhotoUpload": { "PermitLimit": 10, "WindowSeconds": 600 },
+    "TasksRead": { "PermitLimit": 120, "WindowSeconds": 60 },
+    "TasksWrite": { "PermitLimit": 20, "WindowSeconds": 60 },
+    "Locations": { "PermitLimit": 30, "WindowSeconds": 60 },
+    "Admin": { "PermitLimit": 60, "WindowSeconds": 60 }
   },
   "Logging": {
     "LogLevel": {


### PR DESCRIPTION
Closes #264.

## Summary

Adds four new IP-partitioned fixed-window rate-limit policies and applies `[EnableRateLimiting]` to every public/user-facing and admin controller that was running without a cap. Before this change only 2 of 17 controllers were limited (auth, conversations) plus two policy attributes on `ProfilesController` (reviews, photo upload).

## New policies

| Policy | Default | Applied to |
|--------|---------|------------|
| `tasks-read` (120 / 60s) | generous browsing budget | `TasksController` (class), `CategoriesController`, `SkillsController`, `TermsController`, `ProfilesController`, `TaskApplicationsController` (class) |
| `tasks-write` (20 / 60s) | abuse-prone state changes | `TasksController` POST/PATCH, `TaskApplicationsController` POST/PATCH/DELETE, `TaskCompletionController` (class), `SkillsController` POST, `TermsController` POST `/accept` |
| `locations` (30 / 60s) | proxies external Nominatim | `LocationsController` |
| `admin` (60 / 60s) | already gated by Admin role | all five `Admin*Controller`s |

Method-level `[EnableRateLimiting]` correctly overrides the controller-level attribute on mixed-read/write controllers (e.g. `TasksController.CreateAsync` is on `tasks-write` despite the class declaring `tasks-read`).

## Implementation notes

- `RateLimitingExtensions` now uses a shared `AddIpFixedWindowPolicy` helper so all 8 policies share one IP-partitioned fixed-window construction path — no more 8 near-identical lambdas.
- Each policy is independently tunable from `appsettings.json` under the existing `RateLimit` section.
- Extended the existing `RateLimitingTests` theory to cover the four new policies plus the previously untested `photo-upload`, so the suite now asserts `429 Too Many Requests` once the per-IP permit limit is exceeded for every named policy (8/8 pass locally).

## Test plan
- [ ] CI green (backend unit tests, format, frontend, e2e)
- [ ] Manual: exceeding `tasks-write` limit on `POST /api/tasks` returns 429
- [ ] Manual: admin endpoint returns 429 after burst beyond the admin limit

🤖 Generated with [Claude Code](https://claude.com/claude-code)