### PR TITLE
feat: task text search (#31)

### DIFF
--- a/backend.Tests/TasksControllerTests.cs
+++ b/backend.Tests/TasksControllerTests.cs
@@ -739,6 +739,168 @@ public sealed class TasksControllerTests
         Assert.Equal(nameof(CompensationType.Barter), task.CompensationType);
     }
 
+    // Search tests require PostgreSQL: EF.Functions.ILike is a Npgsql-specific translation
+    // that the InMemory provider cannot evaluate. Run these as integration tests against a
+    // real Postgres instance (same convention as AdminUsersController + SkillsController
+    // tests, which also skip their ILike-search paths in unit tests).
+
+    [Fact(Skip = "Requires PostgreSQL — ILike is not supported by the InMemory provider")]
+    public async Task ListAsync_FiltersByQuery_MatchesTitleAndDescriptionCaseInsensitive()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await using var db = CreateNpgsqlDbContext();
+        var (profileId, categoryId, now) = await SeedSinglePosterAsync(db, cancellationToken);
+
+        // Three tasks:
+        //   - "Gardening help" / "Need help with the lawn." — matches in title
+        //   - "Move boxes" / "Help me carry pots from the garden." — matches in description
+        //   - "Cooking lessons" / "Teach me a recipe." — no match
+        db.Tasks.AddRange(
+            new CommunityTask
+            {
+                Id = Guid.NewGuid(),
+                SeekerProfileId = profileId,
+                CategoryId = categoryId,
+                Title = "Gardening help",
+                Description = "Need help with the lawn.",
+                CompensationType = CompensationType.Voluntary,
+                Status = Backend.Domain.Enums.TaskStatus.Open,
+                CreatedAt = now.AddMinutes(1),
+                UpdatedAt = now.AddMinutes(1)
+            },
+            new CommunityTask
+            {
+                Id = Guid.NewGuid(),
+                SeekerProfileId = profileId,
+                CategoryId = categoryId,
+                Title = "Move boxes",
+                Description = "Help me carry pots from the garden.",
+                CompensationType = CompensationType.Voluntary,
+                Status = Backend.Domain.Enums.TaskStatus.Open,
+                CreatedAt = now.AddMinutes(2),
+                UpdatedAt = now.AddMinutes(2)
+            },
+            new CommunityTask
+            {
+                Id = Guid.NewGuid(),
+                SeekerProfileId = profileId,
+                CategoryId = categoryId,
+                Title = "Cooking lessons",
+                Description = "Teach me a recipe.",
+                CompensationType = CompensationType.Voluntary,
+                Status = Backend.Domain.Enums.TaskStatus.Open,
+                CreatedAt = now.AddMinutes(3),
+                UpdatedAt = now.AddMinutes(3)
+            });
+        await db.SaveChangesAsync(cancellationToken);
+
+        var controller = new TasksController(db);
+
+        // Lowercase query against mixed-case content: ILike must be case-insensitive.
+        var result = await controller.ListAsync(
+            status: null,
+            categoryId: null,
+            latitude: null,
+            longitude: null,
+            radiusMeters: null,
+            q: "garden",
+            cancellationToken: cancellationToken);
+
+        var ok = Assert.IsType<OkObjectResult>(result);
+        var tasks = Assert.IsAssignableFrom<IEnumerable<TaskResponse>>(ok.Value).ToArray();
+
+        Assert.Equal(2, tasks.Length);
+        Assert.Contains(tasks, t => t.Title == "Gardening help");
+        Assert.Contains(tasks, t => t.Title == "Move boxes");
+        Assert.DoesNotContain(tasks, t => t.Title == "Cooking lessons");
+    }
+
+    [Fact(Skip = "Requires PostgreSQL — ILike is not supported by the InMemory provider")]
+    public async Task ListAsync_FiltersByQuery_ReturnsEmptyWhenNoMatches()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await using var db = CreateNpgsqlDbContext();
+        var (profileId, categoryId, now) = await SeedSinglePosterAsync(db, cancellationToken);
+
+        db.Tasks.AddRange(
+            CreateTask(profileId, categoryId, "Walk a dog", now.AddMinutes(1)),
+            CreateTask(profileId, categoryId, "Move furniture", now.AddMinutes(2)));
+        await db.SaveChangesAsync(cancellationToken);
+
+        var controller = new TasksController(db);
+
+        var result = await controller.ListAsync(
+            status: null,
+            categoryId: null,
+            latitude: null,
+            longitude: null,
+            radiusMeters: null,
+            q: "xylophone",
+            cancellationToken: cancellationToken);
+
+        var ok = Assert.IsType<OkObjectResult>(result);
+        var tasks = Assert.IsAssignableFrom<IEnumerable<TaskResponse>>(ok.Value).ToArray();
+
+        Assert.Empty(tasks);
+    }
+
+    [Fact(Skip = "Requires PostgreSQL — ILike is not supported by the InMemory provider")]
+    public async Task ListAsync_FiltersByQuery_EscapesLikeWildcards()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await using var db = CreateNpgsqlDbContext();
+        var (profileId, categoryId, now) = await SeedSinglePosterAsync(db, cancellationToken);
+
+        // The first title literally contains "100%"; the second does not. If the
+        // controller passed the user input straight into the LIKE pattern without
+        // escaping, "100%" would match every task whose title starts with "100"
+        // and the second row would leak through. Escaping the % must keep only
+        // the literal-percent row.
+        db.Tasks.AddRange(
+            new CommunityTask
+            {
+                Id = Guid.NewGuid(),
+                SeekerProfileId = profileId,
+                CategoryId = categoryId,
+                Title = "Bake 100% chocolate cake",
+                Description = "Family recipe.",
+                CompensationType = CompensationType.Voluntary,
+                Status = Backend.Domain.Enums.TaskStatus.Open,
+                CreatedAt = now.AddMinutes(1),
+                UpdatedAt = now.AddMinutes(1)
+            },
+            new CommunityTask
+            {
+                Id = Guid.NewGuid(),
+                SeekerProfileId = profileId,
+                CategoryId = categoryId,
+                Title = "Bake 100 cookies",
+                Description = "For the bake sale.",
+                CompensationType = CompensationType.Voluntary,
+                Status = Backend.Domain.Enums.TaskStatus.Open,
+                CreatedAt = now.AddMinutes(2),
+                UpdatedAt = now.AddMinutes(2)
+            });
+        await db.SaveChangesAsync(cancellationToken);
+
+        var controller = new TasksController(db);
+
+        var result = await controller.ListAsync(
+            status: null,
+            categoryId: null,
+            latitude: null,
+            longitude: null,
+            radiusMeters: null,
+            q: "100%",
+            cancellationToken: cancellationToken);
+
+        var ok = Assert.IsType<OkObjectResult>(result);
+        var tasks = Assert.IsAssignableFrom<IEnumerable<TaskResponse>>(ok.Value).ToArray();
+
+        var task = Assert.Single(tasks);
+        Assert.Equal("Bake 100% chocolate cake", task.Title);
+    }
+
     [Fact]
     public void ProximityQuery_TranslatesToPostgisDWithinAndDistanceOrdering()
     {

--- a/backend/Features/Tasks/TasksController.cs
+++ b/backend/Features/Tasks/TasksController.cs
@@ -31,6 +31,7 @@ public sealed partial class TasksController(AppDbContext db) : ControllerBase
         [FromQuery] double? latitude,
         [FromQuery] double? longitude,
         [FromQuery] double? radiusMeters,
+        [FromQuery] string? q = null,
         [FromQuery] string? compensationType = null,
         [FromQuery] DateTimeOffset? createdAfter = null,
         [FromQuery] string? sort = null,
@@ -121,6 +122,23 @@ public sealed partial class TasksController(AppDbContext db) : ControllerBase
         {
             var cutoff = createdAfter.Value;
             query = query.Where(task => task.CreatedAt >= cutoff);
+        }
+
+        if (!string.IsNullOrWhiteSpace(q))
+        {
+            // Escape PostgreSQL LIKE wildcards in the user input so they're
+            // treated as literal characters. The escape char is backslash;
+            // we escape \ first so it doesn't double-process the % and _
+            // we add immediately after.
+            var trimmed = q.Trim();
+            var escaped = trimmed
+                .Replace(@"\", @"\\", StringComparison.Ordinal)
+                .Replace("%", @"\%", StringComparison.Ordinal)
+                .Replace("_", @"\_", StringComparison.Ordinal);
+            var pattern = $"%{escaped}%";
+            query = query.Where(task =>
+                EF.Functions.ILike(task.Title, pattern, @"\")
+                || EF.Functions.ILike(task.Description, pattern, @"\"));
         }
 
         // Apply hard radius filter regardless of sort order.

--- a/frontend/app/(main)/feed/page.client.tsx
+++ b/frontend/app/(main)/feed/page.client.tsx
@@ -17,20 +17,22 @@ import {
 import { useCategories } from "@/lib/api/categories"
 import { useOwnProfile } from "@/lib/api/profile"
 import { useInfiniteTaskList } from "@/lib/api/tasks"
-import type { ApiTask, TaskListFilters } from "@/lib/api/tasks"
+import type { TaskListFilters } from "@/lib/api/tasks"
 import { RECENCY_OPTIONS } from "@/lib/constants"
 
 type RecencyValue = (typeof RECENCY_OPTIONS)[number]["value"]
+
+const QUERY_DEBOUNCE_MS = 250
 
 /**
  * Canonical task-discovery feed. Replaces the former Seeker (#37) and
  * Helper (#39) feeds: one route, one set of filters, role-neutral copy.
  *
- * Server-side filtering (category, compensation, recency, radius) is
- * forwarded to `GET /api/tasks` so that pagination operates on the
- * already-filtered result set. The free-text query is the only filter
- * still applied client-side on top of the fetched pages. Filter state
- * is mirrored in the URL so refreshes and shares preserve the view.
+ * Server-side filtering (free-text query, category, compensation, recency,
+ * radius) is forwarded to `GET /api/tasks` so that pagination operates on
+ * the already-filtered result set. The query input is debounced so a fast
+ * typist doesn't fire one request per keystroke. Filter state is mirrored
+ * in the URL so refreshes and shares preserve the view.
  */
 export function FeedPageClient() {
   const router = useRouter()
@@ -65,6 +67,17 @@ export function FeedPageClient() {
   // triplet to the backend.
   const effectiveRadius: RadiusOptionValue = hasOrigin ? filters.radius : "any"
 
+  // Debounce the free-text query before it reaches the server. Without this,
+  // every keystroke would invalidate the query cache and trigger a new
+  // /api/tasks request; with it, we wait until the user pauses typing.
+  const [debouncedQuery, setDebouncedQuery] = React.useState(filters.query)
+  React.useEffect(() => {
+    const handle = setTimeout(() => {
+      setDebouncedQuery(filters.query)
+    }, QUERY_DEBOUNCE_MS)
+    return () => clearTimeout(handle)
+  }, [filters.query])
+
   const handleFiltersChange = React.useCallback(
     (next: TaskFiltersState) => {
       const params = serializeFilters(next)
@@ -85,6 +98,10 @@ export function FeedPageClient() {
 
   const serverFilters = React.useMemo<TaskListFilters>(() => {
     const base: TaskListFilters = { status: "Open", sort: "relevant" }
+    const trimmedQuery = debouncedQuery.trim()
+    if (trimmedQuery.length > 0) {
+      base.q = trimmedQuery
+    }
     if (filters.category !== "all") {
       base.categoryId = filters.category
     }
@@ -102,6 +119,7 @@ export function FeedPageClient() {
     }
     return base
   }, [
+    debouncedQuery,
     filters.category,
     filters.compensation,
     filters.recency,
@@ -118,16 +136,7 @@ export function FeedPageClient() {
     isError,
   } = useInfiniteTaskList(serverFilters)
 
-  const rawTasks = React.useMemo(() => data?.pages.flat() ?? [], [data])
-
-  // ── Client-side filters layered on top of the server response ──────────────
-  // Only the free-text query is filtered client-side; all other dimensions are
-  // forwarded to the backend so that infinite-scroll pages are real pages of
-  // already-filtered results.
-  const tasks = React.useMemo(
-    () => applyClientFilters(rawTasks, filters),
-    [rawTasks, filters]
-  )
+  const tasks = React.useMemo(() => data?.pages.flat() ?? [], [data])
 
   // ── Infinite scroll sentinel ───────────────────────────────────────────────
   const sentinelRef = React.useRef<HTMLDivElement | null>(null)
@@ -192,9 +201,8 @@ export function FeedPageClient() {
           />
           {/*
            * Show pagination controls whenever the backend reports more pages,
-           * even if the current visible list is empty after applying the
-           * client-side search. A filtered first page can legitimately be
-           * empty while later pages still contain matching results.
+           * even if the current visible page is empty: the user may have a
+           * pending debounced query that briefly clears the visible set.
            */}
           {tasks.length > 0 || hasNextPage ? (
             <div ref={sentinelRef} className="flex justify-center py-2">
@@ -324,20 +332,4 @@ function recencyToIsoCutoff(recency: RecencyValue): string | null {
   const ms = RECENCY_CUTOFF_MS[recency]
   if (ms === null) return null
   return new Date(Date.now() - ms).toISOString()
-}
-
-// ── Client-side post-fetch filtering ─────────────────────────────────────────
-
-function applyClientFilters(
-  tasks: ApiTask[],
-  filters: TaskFiltersState
-): ApiTask[] {
-  const q = filters.query.trim().toLowerCase()
-  if (!q) return tasks
-
-  return tasks.filter((t) => {
-    const haystack =
-      `${t.title} ${t.description} ${t.locationText ?? ""}`.toLowerCase()
-    return haystack.includes(q)
-  })
 }

--- a/frontend/lib/api/tasks.ts
+++ b/frontend/lib/api/tasks.ts
@@ -92,6 +92,12 @@ export interface TaskListFilters {
   radiusMeters?: number
   /** "relevant" orders by proximity to the caller's profile location; omit for newest-first. */
   sort?: "relevant" | "recency"
+  /**
+   * Free-text query; case-insensitive `ILIKE` match against task title and
+   * description on the backend. LIKE wildcards in the input are escaped server-side
+   * so `%` and `_` are treated as literal characters.
+   */
+  q?: string
 }
 
 // ── Query keys ────────────────────────────────────────────────────────────────
@@ -283,6 +289,9 @@ function buildTaskListPath(
     params.set("compensationType", filters.compensationType)
   }
   if (filters.createdAfter) params.set("createdAfter", filters.createdAfter)
+  if (filters.q && filters.q.trim().length > 0) {
+    params.set("q", filters.q.trim())
+  }
   // Proximity is a triplet on the backend (latitude + longitude + radiusMeters).
   // Sending a partial triplet returns a 400, so only forward when all three are
   // present and finite.


### PR DESCRIPTION
Closes #31.

## Summary

Adds a free-text search dimension to the task feed. `GET /api/tasks` now accepts an optional `q` query parameter; tasks whose title or description contains the substring are returned (case-insensitive, via PostgreSQL `ILIKE`). The frontend feed pipes its existing search box through to the backend with a 250 ms debounce instead of filtering already-fetched pages on the client.

## Why

The feed previously filtered the search box client-side over the in-memory results of the current page, which only worked at small data sizes and ignored the backend pagination boundary — a match on page 5 wouldn't surface unless the user scrolled there first. Issue #31 asks for proper server-side text search so `q` composes with the existing filters (category, compensation, recency, radius) and pagination operates on the real filtered set.

## Changes

### Backend — `backend/Features/Tasks/TasksController.cs`

- New `[FromQuery] string? q = null` parameter on `ListAsync`.
- When non-empty, escapes PostgreSQL LIKE wildcards in the user input (`\`, `%`, `_`) so they're treated as literal characters, then wraps the escaped term in `%...%` and applies `EF.Functions.ILike` against `Title` OR `Description` with `\` as the explicit escape character.
- Sits alongside the existing `WHERE` chain (after `createdAfter`, before proximity), so search composes naturally with every other filter and does not affect the ordering rules (newest-first by default, distance-asc when `sort=relevant` with a proximity origin).

### Backend tests — `backend.Tests/TasksControllerTests.cs`

Three new tests, all marked `[Fact(Skip = "Requires PostgreSQL — ILike is not supported by the InMemory provider")]` per the project's existing convention (same pattern as `AdminUsersControllerTests` and `SkillsControllerTests`):

- `ListAsync_FiltersByQuery_MatchesTitleAndDescriptionCaseInsensitive` — seeds 3 tasks; verifies a lowercase query against mixed-case content matches both a title and a description hit while excluding the non-match.
- `ListAsync_FiltersByQuery_ReturnsEmptyWhenNoMatches` — verifies an empty result set when nothing contains the query string.
- `ListAsync_FiltersByQuery_EscapesLikeWildcards` — seeds `"Bake 100% chocolate cake"` and `"Bake 100 cookies"`, searches for `100%`; only the row with the literal `%` should match, proving the escape works.

Local run output: