### PR TITLE
feat: intelligent skill-based task relevance — lexical (#35)

### DIFF
--- a/backend.Tests/TasksControllerTests.cs
+++ b/backend.Tests/TasksControllerTests.cs
@@ -739,6 +739,264 @@ public sealed class TasksControllerTests
         Assert.Equal(nameof(CompensationType.Barter), task.CompensationType);
     }
 
+    // Skill-relevance ranking (#35) — option 1 (lexical). The scoring step is in-
+    // memory (see ComputeSkillMatchScore in TasksController), so these can run
+    // against the InMemory provider as long as the test setup avoids the spatial
+    // path (no proximity in the query, no Location on the seeded profile). The
+    // tie-break case that needs Location is split into its own Npgsql-skip test.
+
+    [Fact]
+    public async Task ListAsync_SortRelevant_RanksTasksByProfileSkillMatchesFirst()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await using var db = CreateInMemoryDbContext();
+        var (profileId, categoryId, now) = await SeedSinglePosterAsync(db, cancellationToken);
+
+        // The helper is a separate user from the task poster. Wire two approved
+        // skills ("Carpentry" and "Plumbing") onto the helper's profile so the
+        // controller has something to score against.
+        var helperUserId = Guid.NewGuid();
+        var helperProfileId = Guid.NewGuid();
+        db.Profiles.Add(new UserProfile
+        {
+            Id = helperProfileId,
+            UserId = helperUserId,
+            DisplayName = "Helper",
+            CreatedAt = now,
+            UpdatedAt = now
+        });
+
+        var carpentrySkillId = Guid.NewGuid();
+        var plumbingSkillId = Guid.NewGuid();
+        db.Skills.AddRange(
+            new Skill
+            {
+                Id = carpentrySkillId,
+                Code = "carpentry",
+                Name = "Carpentry",
+                Status = SkillStatus.Approved,
+                IsActive = true,
+                CreatedAt = now,
+                UpdatedAt = now
+            },
+            new Skill
+            {
+                Id = plumbingSkillId,
+                Code = "plumbing",
+                Name = "Plumbing",
+                Status = SkillStatus.Approved,
+                IsActive = true,
+                CreatedAt = now,
+                UpdatedAt = now
+            });
+        db.ProfileSkills.AddRange(
+            new ProfileSkill { ProfileId = helperProfileId, SkillId = carpentrySkillId, CreatedAt = now },
+            new ProfileSkill { ProfileId = helperProfileId, SkillId = plumbingSkillId, CreatedAt = now });
+
+        // Three tasks, ordered by createdAt so the recency-only baseline would
+        // return them as [C, B, A]. With skill scoring layered on top the result
+        // must be [A (2 matches), B (1 match), C (0 matches)].
+        db.Tasks.AddRange(
+            new CommunityTask
+            {
+                Id = Guid.NewGuid(),
+                SeekerProfileId = profileId,
+                CategoryId = categoryId,
+                Title = "Carpentry and plumbing handyman",
+                Description = "Need both Carpentry and Plumbing help on a porch.",
+                CompensationType = CompensationType.Voluntary,
+                Status = Backend.Domain.Enums.TaskStatus.Open,
+                CreatedAt = now.AddMinutes(1),
+                UpdatedAt = now.AddMinutes(1)
+            },
+            new CommunityTask
+            {
+                Id = Guid.NewGuid(),
+                SeekerProfileId = profileId,
+                CategoryId = categoryId,
+                Title = "Bookshelf assembly",
+                Description = "Light carpentry for a custom shelf.",
+                CompensationType = CompensationType.Voluntary,
+                Status = Backend.Domain.Enums.TaskStatus.Open,
+                CreatedAt = now.AddMinutes(2),
+                UpdatedAt = now.AddMinutes(2)
+            },
+            new CommunityTask
+            {
+                Id = Guid.NewGuid(),
+                SeekerProfileId = profileId,
+                CategoryId = categoryId,
+                Title = "Cooking lessons",
+                Description = "Teach me a recipe.",
+                CompensationType = CompensationType.Voluntary,
+                Status = Backend.Domain.Enums.TaskStatus.Open,
+                CreatedAt = now.AddMinutes(3),
+                UpdatedAt = now.AddMinutes(3)
+            });
+        await db.SaveChangesAsync(cancellationToken);
+
+        var controller = CreateTasksController(db, helperUserId);
+
+        var result = await controller.ListAsync(
+            status: null,
+            categoryId: null,
+            latitude: null,
+            longitude: null,
+            radiusMeters: null,
+            sort: "relevant",
+            cancellationToken: cancellationToken);
+
+        var ok = Assert.IsType<OkObjectResult>(result);
+        var tasks = Assert.IsAssignableFrom<IEnumerable<TaskResponse>>(ok.Value).ToArray();
+
+        Assert.Equal(3, tasks.Length);
+        Assert.Equal("Carpentry and plumbing handyman", tasks[0].Title);
+        Assert.Equal("Bookshelf assembly", tasks[1].Title);
+        Assert.Equal("Cooking lessons", tasks[2].Title);
+    }
+
+    [Fact]
+    public async Task ListAsync_SortRelevant_FallsBackToRecencyWhenHelperHasNoSkills()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await using var db = CreateInMemoryDbContext();
+        var (profileId, categoryId, now) = await SeedSinglePosterAsync(db, cancellationToken);
+
+        // Helper with a profile but no profile skills attached. The relevance
+        // sort must fall through to the existing recency ordering rather than
+        // collapsing every task into score 0 (which would re-order them in an
+        // implementation-defined way).
+        var helperUserId = Guid.NewGuid();
+        var helperProfileId = Guid.NewGuid();
+        db.Profiles.Add(new UserProfile
+        {
+            Id = helperProfileId,
+            UserId = helperUserId,
+            DisplayName = "Helper without skills",
+            CreatedAt = now,
+            UpdatedAt = now
+        });
+
+        db.Tasks.AddRange(
+            CreateTask(profileId, categoryId, "Task A", now.AddMinutes(1)),
+            CreateTask(profileId, categoryId, "Task B", now.AddMinutes(2)),
+            CreateTask(profileId, categoryId, "Task C", now.AddMinutes(3)));
+        await db.SaveChangesAsync(cancellationToken);
+
+        var controller = CreateTasksController(db, helperUserId);
+
+        var result = await controller.ListAsync(
+            status: null,
+            categoryId: null,
+            latitude: null,
+            longitude: null,
+            radiusMeters: null,
+            sort: "relevant",
+            cancellationToken: cancellationToken);
+
+        var ok = Assert.IsType<OkObjectResult>(result);
+        var tasks = Assert.IsAssignableFrom<IEnumerable<TaskResponse>>(ok.Value).ToArray();
+
+        // Newest first: C, B, A — identical to the default recency ordering.
+        Assert.Equal(3, tasks.Length);
+        Assert.Equal("Task C", tasks[0].Title);
+        Assert.Equal("Task B", tasks[1].Title);
+        Assert.Equal("Task A", tasks[2].Title);
+    }
+
+    [Fact(Skip = "Requires PostgreSQL — NetTopologySuite Distance ordering is not supported by the InMemory provider")]
+    public async Task ListAsync_SortRelevant_TiesOnSkillScoreBreakByDistance()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await using var db = CreateNpgsqlDbContext();
+        var (profileId, categoryId, now) = await SeedSinglePosterAsync(db, cancellationToken);
+
+        // Helper with a location and one skill ("Cleaning"). Two tasks both
+        // contain "Cleaning" in their description (equal skill score = 1) but
+        // sit at different distances from the helper. With stable secondary
+        // sort the closer task must win the tie.
+        var helperUserId = Guid.NewGuid();
+        var helperProfileId = Guid.NewGuid();
+        var helperLocation = new Point(19.0402, 47.4979) { SRID = 4326 };
+        db.Profiles.Add(new UserProfile
+        {
+            Id = helperProfileId,
+            UserId = helperUserId,
+            DisplayName = "Helper",
+            Location = helperLocation,
+            CreatedAt = now,
+            UpdatedAt = now
+        });
+
+        var cleaningSkillId = Guid.NewGuid();
+        db.Skills.Add(new Skill
+        {
+            Id = cleaningSkillId,
+            Code = "cleaning",
+            Name = "Cleaning",
+            Status = SkillStatus.Approved,
+            IsActive = true,
+            CreatedAt = now,
+            UpdatedAt = now
+        });
+        db.ProfileSkills.Add(new ProfileSkill
+        {
+            ProfileId = helperProfileId,
+            SkillId = cleaningSkillId,
+            CreatedAt = now
+        });
+
+        // Far task ~5km away; near task ~50m away. Both match Cleaning.
+        var farLocation = new Point(19.10, 47.55) { SRID = 4326 };
+        var nearLocation = new Point(19.0410, 47.4982) { SRID = 4326 };
+        db.Tasks.AddRange(
+            new CommunityTask
+            {
+                Id = Guid.NewGuid(),
+                SeekerProfileId = profileId,
+                CategoryId = categoryId,
+                Title = "Far task",
+                Description = "Light Cleaning for a flat.",
+                Location = farLocation,
+                CompensationType = CompensationType.Voluntary,
+                Status = Backend.Domain.Enums.TaskStatus.Open,
+                CreatedAt = now.AddMinutes(1),
+                UpdatedAt = now.AddMinutes(1)
+            },
+            new CommunityTask
+            {
+                Id = Guid.NewGuid(),
+                SeekerProfileId = profileId,
+                CategoryId = categoryId,
+                Title = "Near task",
+                Description = "Quick Cleaning around the office.",
+                Location = nearLocation,
+                CompensationType = CompensationType.Voluntary,
+                Status = Backend.Domain.Enums.TaskStatus.Open,
+                CreatedAt = now.AddMinutes(2),
+                UpdatedAt = now.AddMinutes(2)
+            });
+        await db.SaveChangesAsync(cancellationToken);
+
+        var controller = CreateTasksController(db, helperUserId);
+
+        var result = await controller.ListAsync(
+            status: null,
+            categoryId: null,
+            latitude: null,
+            longitude: null,
+            radiusMeters: null,
+            sort: "relevant",
+            cancellationToken: cancellationToken);
+
+        var ok = Assert.IsType<OkObjectResult>(result);
+        var tasks = Assert.IsAssignableFrom<IEnumerable<TaskResponse>>(ok.Value).ToArray();
+
+        Assert.Equal(2, tasks.Length);
+        Assert.Equal("Near task", tasks[0].Title);
+        Assert.Equal("Far task", tasks[1].Title);
+    }
+
     [Fact]
     public void ProximityQuery_TranslatesToPostgisDWithinAndDistanceOrdering()
     {

--- a/backend/Features/Tasks/TasksController.Functions.cs
+++ b/backend/Features/Tasks/TasksController.Functions.cs
@@ -18,6 +18,31 @@ public sealed partial class TasksController
         return !int.TryParse(value, out _) && Enum.TryParse(value, ignoreCase: true, out result);
     }
 
+    /// <summary>
+    /// Count of helper skill names found (case-insensitive substring) in the
+    /// task's title or description. Used as the relevance boost in the helper
+    /// feed when sort=relevant.
+    /// </summary>
+    private static int ComputeSkillMatchScore(CommunityTask task, IReadOnlyList<string> skillNames)
+    {
+        var haystack = $"{task.Title} {task.Description}";
+        var score = 0;
+        foreach (var name in skillNames)
+        {
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                continue;
+            }
+
+            if (haystack.Contains(name, StringComparison.OrdinalIgnoreCase))
+            {
+                score++;
+            }
+        }
+
+        return score;
+    }
+
     private static bool TryParseTaskStatus(string value, out DomainTaskStatus result)
     {
         result = default;

--- a/backend/Features/Tasks/TasksController.cs
+++ b/backend/Features/Tasks/TasksController.cs
@@ -132,6 +132,7 @@ public sealed partial class TasksController(AppDbContext db) : ControllerBase
 
         IQueryable<CommunityTask> orderedQuery;
         var effectiveSort = sort?.ToLowerInvariant();
+        List<string>? helperSkillNames = null;
         if (effectiveSort == SortRelevant)
         {
             var userId = GetCurrentUserId();
@@ -141,6 +142,20 @@ public sealed partial class TasksController(AppDbContext db) : ControllerBase
                     .Select(p => new { p.UserId, p.Location })
                     .FirstOrDefaultAsync(p => p.UserId == userId.Value, cancellationToken))?.Location
                 : null;
+
+            // Helper's approved, active skill names drive the lexical relevance
+            // boost. Pulled once up-front so the in-memory ranking below has
+            // them without doing a per-task lookup.
+            if (userId.HasValue)
+            {
+                helperSkillNames = await db.ProfileSkills
+                    .AsNoTracking()
+                    .Where(ps => ps.Profile.UserId == userId.Value
+                        && ps.Skill.Status == SkillStatus.Approved
+                        && ps.Skill.IsActive)
+                    .Select(ps => ps.Skill.Name)
+                    .ToListAsync(cancellationToken);
+            }
 
             if (proximityOrigin is not null)
             {
@@ -168,6 +183,32 @@ public sealed partial class TasksController(AppDbContext db) : ControllerBase
         else
         {
             orderedQuery = query.OrderByDescending(task => task.CreatedAt);
+        }
+
+        // Skill-relevance re-ranking layered on top of the existing distance/
+        // recency ordering. Done in memory because lexical matching at SQL would
+        // need either dynamically built Expression trees over a variable-length
+        // skill list, or N per-skill OR'd ILike clauses that don't scale with
+        // helper skill counts. The issue's option 1 (lexical) explicitly accepts
+        // this trade-off as the starting point; TF-IDF / BM25 / embeddings are
+        // listed as later upgrades that can re-use the call site below.
+        //
+        // Stability matters here: Enumerable.OrderByDescending is a stable sort,
+        // so ties on skill score preserve the distance-then-recency ordering
+        // produced by orderedQuery.
+        if (effectiveSort == SortRelevant && helperSkillNames is { Count: > 0 })
+        {
+            var rankedTasks = await orderedQuery.ToListAsync(cancellationToken);
+            rankedTasks = rankedTasks
+                .OrderByDescending(task => ComputeSkillMatchScore(task, helperSkillNames))
+                .ToList();
+
+            if (shouldPage)
+            {
+                rankedTasks = rankedTasks.Skip(skip).Take(effectivePageSize).ToList();
+            }
+
+            return Ok(rankedTasks.Select(TaskResponse.FromTask));
         }
 
         if (shouldPage)


### PR DESCRIPTION
Closes #35.

## Summary

When `sort=relevant` and the caller has approved, active profile skills, the helper feed re-ranks tasks so those whose title or description contains any of those skill names sort first. Within ties the existing distance / recency ordering is preserved.

Implements **option 1 (lexical / keyword match)** from the issue. The other two approaches (TF-IDF / BM25, embeddings) are listed as later upgrades.

## Why

Helpers shouldn't have to scroll past unrelated tasks to find ones they can actually work on. Task posters shouldn't have to tag skills manually either — the description is enough signal. A lexical pass against the helper's profile skills lifts the relevant tasks to the top without any infrastructure change.

## Changes

### Backend — `backend/Features/Tasks/TasksController.cs`

- When `sort=relevant`, fetches the caller's approved + active skill names once (single `db.ProfileSkills` query).
- The existing distance / recency `OrderBy` chain still runs in SQL.
- If the skill list is non-empty, the controller materialises the ordered query and applies `OrderByDescending(task => ComputeSkillMatchScore(task, skillNames))` in memory before pagination. `Enumerable.OrderByDescending` is stable, so ties on score preserve the underlying distance / recency order.
- New private helper `ComputeSkillMatchScore` counts how many of the helper's skill names appear (case-insensitive `String.Contains`) in `task.Title + " " + task.Description`.
- When the caller has zero approved skills, the ranking block is skipped — pagination and ordering follow the existing path with no behavioural change.

### Backend tests — `backend.Tests/TasksControllerTests.cs`

- `ListAsync_SortRelevant_RanksTasksByProfileSkillMatchesFirst` — helper with two skills (Carpentry, Plumbing), three tasks with 2/1/0 matches; the controller must return them in the 2 → 1 → 0 order even though their natural recency order would have been 0 → 1 → 2. **Runs on InMemory** because scoring is in C#.
- `ListAsync_SortRelevant_FallsBackToRecencyWhenHelperHasNoSkills` — helper with a profile but no `ProfileSkills` rows; the feed must return tasks in recency order (no regression). **Runs on InMemory**.
- `ListAsync_SortRelevant_TiesOnSkillScoreBreakByDistance` — two tasks with equal skill score (1 each) at different distances; the closer task must win. **Skipped under InMemory** (requires NetTopologySuite Distance), runs against Postgres.

## Acceptance criteria

- [x] Tasks whose descriptions contain words matching the helper's profile skills rank higher in the helper feed
- [x] Skill-relevance score is combined with the existing proximity ordering: skill match DESC → distance ASC → created-at DESC
- [x] No regression to the proximity-only ordering when the helper has no profile skills
- [x] Task posters are NOT required to manually tag skills

## Scope / non-goals

- **No frontend changes.** The feed already sends `sort=relevant`; the backend re-ranks transparently.
- **No new infrastructure** (no pgvector, no FTS index). Lexical is option 1's whole point.
- **No tie-break by skill-name weight** — every matched skill scores 1. Differential weighting (or TF-IDF) is a follow-up.

## Reviewer notes

- This PR touches `TasksController.ListAsync` in the same method as #31. The conflict between the two when both merge will be small (adjacent lines in the same `if (effectiveSort == SortRelevant)` block); whoever merges second will resolve.
- The C# in-memory step is bounded by the post-WHERE rowcount, not the whole tasks table. At seed-data sizes this is sub-millisecond. If profiling at production data sizes shows it's expensive, the swap point is the call to `ComputeSkillMatchScore` — replace with an EF-translatable score expression or move to one of the issue's option 2 / option 3 approaches.