### PR TITLE
feat(backend): seed data script (categories + 50 Budapest sample tasks)

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,3 +95,61 @@ Apply migrations to the configured database:
 ```powershell
 dotnet ef database update --project backend --startup-project backend --context Backend.Infrastructure.Persistence.AppDbContext
 ```
+
+## Seeding demo data
+
+A one-shot seeder populates a fresh **development** database with realistic demo
+content: a couple of fixed login accounts, ten sample neighbour ("seeker")
+accounts, and 50 curated Budapest community tasks spread across every category,
+compensation type, and lifecycle status.
+
+With Postgres running (see above), from the **repo root**:
+
+```powershell
+npm run seed
+```
+
+This runs `dotnet run --project backend -- seed`, which applies any pending
+migrations, runs the seeders, and exits without starting the web host. The
+seeders also run automatically on normal backend startup in Development, so a
+plain `dotnet run` (or `docker compose up`) seeds too. Seeding is **idempotent**
+— each demo task carries a stable `DEMO-####` public code, so re-running never
+duplicates rows.
+
+### Development-only by design
+
+The demo accounts and tasks are **never created outside Development**. Seeders
+are only registered when `ASPNETCORE_ENVIRONMENT=Development`; in any other
+environment none of the seed accounts or tasks are inserted. Two config switches
+(section `DevSeed`) let you opt out even in Development:
+
+| Setting                    | Effect                                    |
+| -------------------------- | ----------------------------------------- |
+| `DevSeed:Enabled=false`    | Disables **all** dev seeders.             |
+| `DevSeed:SampleTasks:Enabled=false` | Disables just the 50 sample tasks (and their seeker accounts). |
+
+### Seeded login credentials
+
+All seeded accounts use addresses on the reserved `.test` TLD, so they can never
+collide with a real email. The two fixed accounts can be overridden via the
+`DevSeed:Admin` / `DevSeed:User` config sections.
+
+| Role  | Email                | Password    |
+| ----- | -------------------- | ----------- |
+| Admin | `admin@local.test`   | `Admin123!` |
+| User  | `user@local.test`    | `User123!`  |
+
+The ten sample seeker accounts all share the password `Seed123!`:
+
+| Name      | Email                    |
+| --------- | ------------------------ |
+| Anna K.   | `seed.anna@local.test`   |
+| Bence T.  | `seed.bence@local.test`  |
+| Csilla M. | `seed.csilla@local.test` |
+| Dániel P. | `seed.daniel@local.test` |
+| Eszter V. | `seed.eszter@local.test` |
+| Gábor Sz. | `seed.gabor@local.test`  |
+| Hanna B.  | `seed.hanna@local.test`  |
+| István L. | `seed.istvan@local.test` |
+| Júlia N.  | `seed.julia@local.test`  |
+| Márk H.   | `seed.mark@local.test`   |

--- a/backend.Tests/BudapestSampleDataTests.cs
+++ b/backend.Tests/BudapestSampleDataTests.cs
@@ -1,0 +1,119 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Backend.Domain.Entities;
+using Backend.Domain.Enums;
+using Backend.Infrastructure.Persistence.Seeding;
+using Xunit;
+
+namespace backend.Tests;
+
+/// <summary>
+/// Guards the demo dataset's invariants. These are the assumptions the
+/// <see cref="SampleTaskSeeder"/> and the database check-constraints rely on,
+/// so they are asserted here rather than discovered at seed time.
+/// </summary>
+public class BudapestSampleDataTests
+{
+    // Must match the codes seeded by CategoryConfiguration.HasData.
+    private static readonly HashSet<string> _knownCategoryCodes = new(StringComparer.Ordinal)
+    {
+        "moving", "tutoring", "repairs", "shopping",
+        "pet_care", "cleaning", "errands", "other",
+    };
+
+    [Fact]
+    public void Tasks_AreExactlyFifty()
+    {
+        Assert.Equal(50, BudapestSampleData.Tasks.Count);
+    }
+
+    [Fact]
+    public void EveryTask_UsesAKnownCategoryCode()
+    {
+        Assert.All(
+            BudapestSampleData.Tasks,
+            task => Assert.Contains(task.CategoryCode, _knownCategoryCodes));
+    }
+
+    [Fact]
+    public void CompensationAmount_IsConsistentWithCompensationType()
+    {
+        // Mirrors the controller rule and ck_tasks_compensation_amount checks:
+        // only Paid tasks carry a (positive) amount; every other mode is null.
+        Assert.All(BudapestSampleData.Tasks, task =>
+        {
+            if (task.CompensationType == CompensationType.Paid)
+            {
+                Assert.NotNull(task.Amount);
+                Assert.True(task.Amount > 0m);
+            }
+            else
+            {
+                Assert.Null(task.Amount);
+            }
+        });
+    }
+
+    [Fact]
+    public void EveryTask_HasCoordinatesWithinBudapest()
+    {
+        // Greater-Budapest bounding box; keeps the demo map pins in the city.
+        Assert.All(BudapestSampleData.Tasks, task =>
+        {
+            Assert.InRange(task.Latitude, 47.34, 47.61);
+            Assert.InRange(task.Longitude, 18.92, 19.34);
+        });
+    }
+
+    [Fact]
+    public void Tasks_HaveNonEmptyTitleAndDescription()
+    {
+        Assert.All(BudapestSampleData.Tasks, task =>
+        {
+            Assert.False(string.IsNullOrWhiteSpace(task.Title));
+            Assert.False(string.IsNullOrWhiteSpace(task.Description));
+            Assert.True(task.Title.Length <= 160);
+        });
+    }
+
+    [Fact]
+    public void Tasks_CoverEveryCategoryCompensationTypeAndAStatusMix()
+    {
+        var tasks = BudapestSampleData.Tasks;
+
+        Assert.Equal(
+            _knownCategoryCodes.OrderBy(code => code, StringComparer.Ordinal),
+            tasks.Select(task => task.CategoryCode)
+                .Distinct()
+                .OrderBy(code => code, StringComparer.Ordinal));
+
+        Assert.Equal(
+            Enum.GetValues<CompensationType>().Length,
+            tasks.Select(task => task.CompensationType).Distinct().Count());
+
+        // A realistic feed shows more than just Open tasks.
+        Assert.True(tasks.Select(task => task.Status).Distinct().Count() >= 3);
+    }
+
+    [Fact]
+    public void Seekers_AreEnoughForDistinctHelperAssignmentAndHaveUniqueEmails()
+    {
+        var seekers = BudapestSampleData.Seekers;
+
+        // The seeder assigns a helper that differs from the seeker, which is
+        // only guaranteed when there is more than one seeker.
+        Assert.True(seekers.Count > 1);
+
+        var emails = seekers.Select(seeker => seeker.Email).ToList();
+        Assert.Equal(emails.Count, emails.Distinct(StringComparer.OrdinalIgnoreCase).Count());
+    }
+
+    [Fact]
+    public void Category_DefaultIconConstant_StaysInSyncWithDomain()
+    {
+        // The catalogue references categories by code; this guards that the
+        // "other" fallback category the domain ships still exists.
+        Assert.False(string.IsNullOrWhiteSpace(Category.DefaultIcon));
+    }
+}

--- a/backend.Tests/BudapestSampleDataTests.cs
+++ b/backend.Tests/BudapestSampleDataTests.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using Backend.Domain.Entities;
 using Backend.Domain.Enums;
 using Backend.Infrastructure.Persistence.Seeding;
@@ -59,6 +56,7 @@ public class BudapestSampleDataTests
     public void EveryTask_HasCoordinatesWithinBudapest()
     {
         // Greater-Budapest bounding box; keeps the demo map pins in the city.
+        // ReSharper disable once ParameterOnlyUsedForPreconditionCheck.Local -- assertion-only lambda over the catalogue.
         Assert.All(BudapestSampleData.Tasks, task =>
         {
             Assert.InRange(task.Latitude, 47.34, 47.61);
@@ -69,6 +67,7 @@ public class BudapestSampleDataTests
     [Fact]
     public void Tasks_HaveNonEmptyTitleAndDescription()
     {
+        // ReSharper disable once ParameterOnlyUsedForPreconditionCheck.Local -- assertion-only lambda over the catalogue.
         Assert.All(BudapestSampleData.Tasks, task =>
         {
             Assert.False(string.IsNullOrWhiteSpace(task.Title));

--- a/backend/Infrastructure/Persistence/Seeding/BudapestSampleData.cs
+++ b/backend/Infrastructure/Persistence/Seeding/BudapestSampleData.cs
@@ -1,0 +1,129 @@
+using Backend.Domain.Enums;
+using DomainTaskStatus = Backend.Domain.Enums.TaskStatus;
+
+namespace Backend.Infrastructure.Persistence.Seeding;
+
+/// <summary>
+/// Curated, deterministic demo dataset for the Budapest marketplace: a fixed
+/// set of sample seeker accounts and 50 realistic community tasks spread across
+/// every category, compensation mode, and lifecycle status.
+/// </summary>
+/// <remarks>
+/// Pure data with no behaviour — the <see cref="SampleTaskSeeder"/> owns the
+/// idempotent persistence logic. Keeping the catalogue here (SRP) lets the
+/// dataset grow or be tuned without touching the seeding mechanics.
+/// </remarks>
+internal static class BudapestSampleData
+{
+    /// <summary>
+    /// Shared password for every seeded sample account. Local-development only;
+    /// these accounts are never created outside Development.
+    /// </summary>
+    public const string SeekerPassword = "Seed123!";
+
+    /// <summary>
+    /// <c>PublicCode</c> prefix marking a task as part of this demo dataset.
+    /// Used as the idempotency key so re-running the seeder never duplicates.
+    /// </summary>
+    public const string TaskCodePrefix = "DEMO-";
+
+    /// <summary>Gets the sample seeker accounts that own the demo tasks.</summary>
+    public static IReadOnlyList<SampleSeeker> Seekers { get; } =
+    [
+        new("seed.anna@local.test", "Anna K.", "XI. kerület", "Újbudai lakos, szívesen segítek és kérek segítséget a környéken."),
+        new("seed.bence@local.test", "Bence T.", "VII. kerület", "Belvárosi srác, sokat biciklizem a városban."),
+        new("seed.csilla@local.test", "Csilla M.", "XIII. kerület", "Két gyerek mellett mindig jól jön egy kis kéz a környékről."),
+        new("seed.daniel@local.test", "Dániel P.", "II. kerület", "Budai oldalon élek, barkácsolni is szeretek."),
+        new("seed.eszter@local.test", "Eszter V.", "IX. kerület", "Ferencvárosi egyetemista, rugalmas időbeosztással."),
+        new("seed.gabor@local.test", "Gábor Sz.", "XIV. kerület", "Zuglói családapa, hétvégente érek rá igazán."),
+        new("seed.hanna@local.test", "Hanna B.", "VI. kerület", "Terézvárosban lakom, imádom a közösségi dolgokat."),
+        new("seed.istvan@local.test", "István L.", "III. kerület", "Óbudai nyugdíjas, sok mindenhez értek még."),
+        new("seed.julia@local.test", "Júlia N.", "V. kerület", "Belvárosi lakó, gyakran van szükségem apró segítségre."),
+        new("seed.mark@local.test", "Márk H.", "VIII. kerület", "Józsefvárosi fiatal, megbízható és pontos."),
+    ];
+
+    /// <summary>
+    /// Gets the 50 demo tasks. Order is significant: the task's stable
+    /// <c>PublicCode</c> is derived from its 1-based position, so entries must
+    /// only ever be appended, never reordered, to keep seeding idempotent.
+    /// </summary>
+    public static IReadOnlyList<SampleTask> Tasks { get; } =
+    [
+        new("Költözés: dobozok cipelése", "Néhány doboz és egy kanapé levitele a harmadik emeletről, lift nincs. Két erős kéz kellene szombat délelőttre.", "moving", CompensationType.Paid, 8000m, "XI. kerület, Bartók Béla út", 47.4760, 19.0400, DomainTaskStatus.Open),
+        new("Bútorszállítás kisteherautóval", "Egy szekrényt vinnék át Zuglóból Óbudára. Ha van kisbuszod, megegyezünk.", "moving", CompensationType.Paid, 15000m, "XIV. kerület, Bosnyák tér", 47.5210, 19.1080, DomainTaskStatus.InProgress),
+        new("Zongora mozgatása a lakáson belül", "Egy pianínót kellene áttolni a másik szobába, egyedül nem megy. Negyed óra az egész.", "moving", CompensationType.Voluntary, null, "II. kerület, Margit körút", 47.5120, 19.0290, DomainTaskStatus.Open),
+        new("Albérletbe költözés segítség", "Diákként költözöm, pár bőrönd és könyvesdoboz. Sörrel és pizzával hálálom meg.", "moving", CompensationType.Barter, null, "IX. kerület, Ferenc körút", 47.4830, 19.0680, DomainTaskStatus.Open),
+        new("Mosógép leszerelése és elszállítása", "Régi mosógépet kéne kivinni a lépcsőházból a konténerhez. Nehéz darab.", "moving", CompensationType.Paid, 6000m, "XIII. kerület, Lehel tér", 47.5340, 19.0700, DomainTaskStatus.Completed),
+        new("Hűtő felvitele a 4. emeletre", "Új hűtőt hoztak, de a futár csak a kapuig hozta. Lift van, de szűk.", "moving", CompensationType.Points, null, "VI. kerület, Nagymező utca", 47.5050, 19.0610, DomainTaskStatus.Open),
+        new("Lomtalanításra pakolás", "Pincét ürítek, sok a régi cucc. Aki segít cipelni, az vihet is belőle, ami tetszik.", "moving", CompensationType.Barter, null, "III. kerület, Flórián tér", 47.5680, 19.0410, DomainTaskStatus.Open),
+
+        new("Matek korrepetálás 8. osztályosnak", "Felvételire készülünk, heti két alkalom kellene. Türelmes tanárt keresek.", "tutoring", CompensationType.Paid, 5000m, "V. kerület, Deák Ferenc tér", 47.4979, 19.0513, DomainTaskStatus.Open),
+        new("Angol társalgási gyakorlás", "Középfokom megvan, csak a beszéd megy nehezen. Heti egy óra kötetlen beszélgetés.", "tutoring", CompensationType.Paid, 4000m, "VII. kerület, Wesselényi utca", 47.5000, 19.0700, DomainTaskStatus.InProgress),
+        new("Programozás alapok – Python", "Pályamódosító vagyok, a legelején tartok. Valaki, aki érthetően el tudja magyarázni.", "tutoring", CompensationType.Paid, 7000m, "XIII. kerület, Váci út", 47.5380, 19.0680, DomainTaskStatus.Open),
+        new("Gitároktatás kezdőnek", "Most kezdtem, pár akkordot szeretnék megtanulni. Cserébe szívesen sütök neked.", "tutoring", CompensationType.Barter, null, "XIV. kerület, Thököly út", 47.5150, 19.0900, DomainTaskStatus.Open),
+        new("Német házi feladat segítség", "Gimnazista lányomnak kellene rendszeres segítség németből. Hétköznap délután.", "tutoring", CompensationType.Paid, 4500m, "II. kerület, Széll Kálmán tér", 47.5070, 19.0250, DomainTaskStatus.Open),
+        new("Fizika érettségire felkészítés", "Emelt szintű fizikára készülök, sok a hiányosság. Tapasztalt korrepetálót keresek.", "tutoring", CompensationType.Paid, 6000m, "XI. kerület, Móricz Zsigmond körtér", 47.4770, 19.0450, DomainTaskStatus.PendingApproval),
+        new("Számítógép-használat idős szomszédnak", "Édesanyámat tanítaná valaki türelmesen e-mailezni, videóhívni. Önkéntes alapon hálás lennék.", "tutoring", CompensationType.Voluntary, null, "IV. kerület, Újpest-központ", 47.5640, 19.0900, DomainTaskStatus.Open),
+
+        new("Csöpögő csap megjavítása", "A konyhai csap folyamatosan csöpög, biztos csak egy tömítés. Aki ért hozzá, jöjjön.", "repairs", CompensationType.Paid, 5000m, "VIII. kerület, Baross utca", 47.4870, 19.0750, DomainTaskStatus.Open),
+        new("Polc felfúrása a falra", "Két polcot szeretnék a nappaliba, a tipli is megvan. Fúró kell hozzá.", "repairs", CompensationType.Paid, 4000m, "VI. kerület, Andrássy út", 47.5070, 19.0660, DomainTaskStatus.Completed),
+        new("Konnektor cseréje", "Egy konnektor kilazult, biztonságosan kicserélném. Aki konyít az elektromossághoz.", "repairs", CompensationType.Points, null, "IX. kerület, Üllői út", 47.4760, 19.0820, DomainTaskStatus.Open),
+        new("Kerékpár fékállítás", "A hátsó fék gyengén fog, nem merek vele tekerni. Cserébe megjavítom a gépedet, ha kell.", "repairs", CompensationType.Barter, null, "XIII. kerület, Pozsonyi út", 47.5260, 19.0540, DomainTaskStatus.Open),
+        new("Beázott parketta – szakértő szem", "Kis folt a parkettán, nem tudom, komoly-e. Valaki, aki ránézne és tanácsot adna.", "repairs", CompensationType.Voluntary, null, "II. kerület, Pasarét", 47.5160, 19.0150, DomainTaskStatus.Open),
+        new("Redőny javítása – elakadt", "A hálószobai redőny félúton megállt, nem megy se fel, se le.", "repairs", CompensationType.Paid, 6500m, "XIV. kerület, Zugló", 47.5210, 19.1080, DomainTaskStatus.InProgress),
+
+        new("Heti bevásárlás idős néninek", "A szomszéd néni nehezen mozog, hetente egyszer behoznám neki a boltból az alapokat.", "shopping", CompensationType.Voluntary, null, "VII. kerület, Klauzál tér", 47.4980, 19.0660, DomainTaskStatus.Open),
+        new("IKEA-túra autóval", "Pár bútort vennék az IKEA-ban, de nincs autóm. Aki elvinne és segítene behozni.", "shopping", CompensationType.Paid, 7000m, "XIX. kerület, Kispest", 47.4560, 19.1450, DomainTaskStatus.Open),
+        new("Gyógyszer kiváltása a patikában", "Lázas vagyok, nem tudok kimozdulni. Valaki kiváltaná a felírt gyógyszert?", "shopping", CompensationType.Points, null, "V. kerület, Bálvány utca", 47.5000, 19.0500, DomainTaskStatus.Completed),
+        new("Piaci bevásárlás hétvégén", "Vásárcsarnokba mennék zöldségért, de nehéz cipelni. Segítség a cipekedésben.", "shopping", CompensationType.Barter, null, "IX. kerület, Fővám tér", 47.4870, 19.0590, DomainTaskStatus.Open),
+        new("Karácsonyi ajándékok beszerzése", "Nincs időm végigjárni a boltokat, a lista megvan. Megbízható segítőt keresek.", "shopping", CompensationType.Paid, 5000m, "VI. kerület, WestEnd", 47.5110, 19.0570, DomainTaskStatus.Open),
+        new("Nagybevásárlás – cipelés", "Havi nagybevásárlás a Sparban, sok a nehéz cucc. Egy óra, jó hangulatban.", "shopping", CompensationType.Points, null, "XI. kerület, Allee", 47.4760, 19.0490, DomainTaskStatus.Open),
+
+        new("Kutyasétáltatás munkanapokon", "Hétköznap délben nem érek haza, a kutyusom kimaradna. Napi egy séta kellene.", "pet_care", CompensationType.Paid, 3000m, "XIII. kerület, Szent István park", 47.5300, 19.0500, DomainTaskStatus.Open),
+        new("Macskafelügyelet hétvégére", "Elutazunk két napra, a cicát etetni kéne és kicsit foglalkozni vele.", "pet_care", CompensationType.Paid, 8000m, "II. kerület, Rózsadomb", 47.5230, 19.0230, DomainTaskStatus.InProgress),
+        new("Kutyakozmetikába szállítás", "A kutyám fél a busztól, autóval kéne elvinni a kozmetikushoz és vissza.", "pet_care", CompensationType.Points, null, "XIV. kerület, Bosnyák tér", 47.5210, 19.1080, DomainTaskStatus.Open),
+        new("Akvárium gondozás nyaralás alatt", "Egy hétre elmegyünk, az akváriumot etetni és figyelni kéne. Megmutatom a teendőket.", "pet_care", CompensationType.Voluntary, null, "XI. kerület, Gazdagrét", 47.4660, 19.0150, DomainTaskStatus.Open),
+        new("Papagáj-felügyelet", "Hosszú hétvégére keresek valakit, aki ránéz a papagájomra és tölt neki vizet.", "pet_care", CompensationType.Barter, null, "VII. kerület, Almássy tér", 47.5010, 19.0720, DomainTaskStatus.Open),
+        new("Idős kutya esti séta", "A kutyusunk már lassan jár, csak egy nyugodt esti sétára van szüksége.", "pet_care", CompensationType.Points, null, "III. kerület, Békásmegyer", 47.5950, 19.0500, DomainTaskStatus.Cancelled),
+
+        new("Nagytakarítás költözés után", "Kiköltöztünk, az üres lakást kéne alaposan kitakarítani átadás előtt.", "cleaning", CompensationType.Paid, 12000m, "VIII. kerület, Corvin-negyed", 47.4860, 19.0720, DomainTaskStatus.Open),
+        new("Ablaktisztítás tavaszra", "Négy nagy ablak a nappaliban, kívül-belül. Akinek a magasban dolgozás nem ijesztő.", "cleaning", CompensationType.Paid, 6000m, "XIII. kerület, Angyalföld", 47.5400, 19.0780, DomainTaskStatus.Open),
+        new("Erkély rendrakás", "Az erkély tele van télen felgyűlt kacattal, kéne két kéz a pakoláshoz.", "cleaning", CompensationType.Barter, null, "VI. kerület, Oktogon", 47.5060, 19.0640, DomainTaskStatus.Completed),
+        new("Konyha alapos sikálás", "Zsíros lett a konyha a sok főzéstől, kéne egy alapos nagytakarítás.", "cleaning", CompensationType.Paid, 7000m, "IX. kerület, Boráros tér", 47.4730, 19.0660, DomainTaskStatus.Open),
+        new("Garázs kipakolás és söprés", "Évek óta gyűlik a garázsban a lom, kéne segítség a kipakoláshoz.", "cleaning", CompensationType.Points, null, "II. kerület, Hűvösvölgy", 47.5300, 18.9900, DomainTaskStatus.Open),
+        new("Lépcsőház nagytakarítás", "Társasházban közösen takarítanánk a lépcsőházat, jó csapatban. Önkéntes alapon.", "cleaning", CompensationType.Voluntary, null, "VII. kerület, Rottenbiller utca", 47.5070, 19.0760, DomainTaskStatus.Open),
+
+        new("Csomag feladása a postán", "Két csomagot kéne feladni, de munkaidőben nem érek oda. Kis ügyintézés.", "errands", CompensationType.Points, null, "V. kerület, Október 6. utca", 47.5000, 19.0510, DomainTaskStatus.Open),
+        new("Sorban állás az okmányirodában", "Hosszú a sor az okmányirodában, valaki beülne helyettem, amíg dolgozom?", "errands", CompensationType.Paid, 4000m, "XIII. kerület, Visegrádi utca", 47.5300, 19.0600, DomainTaskStatus.Open),
+        new("Növények locsolása nyaralás alatt", "Egy hétre elutazom, a sok szobanövényt kéne meglocsolni kétnaponta.", "errands", CompensationType.Voluntary, null, "XI. kerület, Lágymányos", 47.4720, 19.0560, DomainTaskStatus.Open),
+        new("Bútor házhozszállítás átvétele", "Szállításra várok, de nem tudok otthon lenni. Valaki átvenné helyettem.", "errands", CompensationType.Barter, null, "XIV. kerület, Füredi utca", 47.5170, 19.1180, DomainTaskStatus.Open),
+        new("Kulcs leadása a szomszédnál", "A takarítónak kéne kulcsot adni, de elcsúsztam időben. Pár perc az egész.", "errands", CompensationType.Points, null, "VI. kerület, Teréz körút", 47.5080, 19.0620, DomainTaskStatus.Completed),
+        new("Biciklis futár rövid távra", "Egy fontos iratot kéne átvinni a belvárosba még ma. Aki gyorsan tekerne.", "errands", CompensationType.Paid, 3500m, "VII. kerület, Károly körút", 47.4960, 19.0590, DomainTaskStatus.InProgress),
+
+        new("Fényképezés egy családi eseményre", "Kis kerti összejövetel lesz, valaki, aki kapna pár jó képet rólunk. Telefonnal is jó.", "other", CompensationType.Paid, 10000m, "XII. kerület, Normafa", 47.4970, 18.9900, DomainTaskStatus.Open),
+        new("Számítógép összerakása alkatrészekből", "Megvettem a részeket egy géphez, de nem merek nekiállni. Aki ért hozzá.", "other", CompensationType.Paid, 8000m, "XIII. kerület, Dózsa György út", 47.5280, 19.0750, DomainTaskStatus.Open),
+        new("Önéletrajz átnézése, tanács", "Először keresek munkát, kéne egy szem, aki átnézi a CV-met és tanácsot ad.", "other", CompensationType.Voluntary, null, "IX. kerület, Corvin", 47.4850, 19.0710, DomainTaskStatus.Open),
+        new("Kerti gázgrill beüzemelése", "Új gázgrillt vettünk, de nem merjük bekötni. Aki ért a gázpalackhoz.", "other", CompensationType.Points, null, "XVI. kerület, Sashalom", 47.5180, 19.1900, DomainTaskStatus.Open),
+        new("Társasjáték-est szervezése", "Keresek lelkes embereket egy havi társasjáték-estre a környéken. Jó hangulat garantált.", "other", CompensationType.Voluntary, null, "VIII. kerület, Palotanegyed", 47.4900, 19.0680, DomainTaskStatus.Open),
+        new("Régi fotók digitalizálása", "Egy doboznyi papírkép, amit szkennelni kéne. Cserébe főzök egy jó ebédet.", "other", CompensationType.Barter, null, "II. kerület, Marczibányi tér", 47.5130, 19.0220, DomainTaskStatus.Open),
+    ];
+}
+
+/// <summary>One seeded sample seeker account.</summary>
+internal sealed record SampleSeeker(
+    string Email,
+    string DisplayName,
+    string District,
+    string Bio);
+
+/// <summary>One curated demo task template.</summary>
+internal sealed record SampleTask(
+    string Title,
+    string Description,
+    string CategoryCode,
+    CompensationType CompensationType,
+    decimal? Amount,
+    string LocationText,
+    double Latitude,
+    double Longitude,
+    DomainTaskStatus Status);

--- a/backend/Infrastructure/Persistence/Seeding/DataSeederExtensions.cs
+++ b/backend/Infrastructure/Persistence/Seeding/DataSeederExtensions.cs
@@ -32,6 +32,11 @@ public static partial class DataSeederExtensions
             .AddDataSeeder<DevelopmentAdminSeeder>()
             .AddDataSeeder<DevelopmentUserSeeder>();
 
+        if (options.SampleTasks.Enabled)
+        {
+            services.AddDataSeeder<SampleTaskSeeder>();
+        }
+
         return services;
     }
 

--- a/backend/Infrastructure/Persistence/Seeding/DevSeederOptions.cs
+++ b/backend/Infrastructure/Persistence/Seeding/DevSeederOptions.cs
@@ -37,6 +37,22 @@ public sealed class DevSeederOptions
         Workplace = "Neighbourhood",
         Position = "Community member",
     };
+
+    /// <summary>Gets or sets the sample marketplace-data seeding options.</summary>
+    public SampleTaskSeedOptions SampleTasks { get; set; } = new();
+}
+
+/// <summary>
+/// Controls seeding of the demo marketplace dataset — sample seeker accounts
+/// and the curated Budapest community tasks. Bound from the
+/// <c>DevSeed:SampleTasks</c> configuration section.
+/// </summary>
+public sealed class SampleTaskSeedOptions
+{
+    /// <summary>
+    /// Gets or sets a value indicating whether the sample-task seeder runs.
+    /// </summary>
+    public bool Enabled { get; set; } = true;
 }
 
 /// <summary>

--- a/backend/Infrastructure/Persistence/Seeding/SampleTaskSeeder.cs
+++ b/backend/Infrastructure/Persistence/Seeding/SampleTaskSeeder.cs
@@ -2,7 +2,6 @@ using Backend.Domain.Entities;
 using Backend.Domain.Enums;
 using Backend.Infrastructure.Identity;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Options;
 using NetTopologySuite.Geometries;
 using DomainTaskStatus = Backend.Domain.Enums.TaskStatus;
 

--- a/backend/Infrastructure/Persistence/Seeding/SampleTaskSeeder.cs
+++ b/backend/Infrastructure/Persistence/Seeding/SampleTaskSeeder.cs
@@ -1,0 +1,207 @@
+using Backend.Domain.Entities;
+using Backend.Domain.Enums;
+using Backend.Infrastructure.Identity;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+using NetTopologySuite.Geometries;
+using DomainTaskStatus = Backend.Domain.Enums.TaskStatus;
+
+namespace Backend.Infrastructure.Persistence.Seeding;
+
+/// <summary>
+/// Seeds the demo marketplace dataset — sample seeker accounts plus the curated
+/// <see cref="BudapestSampleData.Tasks"/> Budapest community tasks — so a fresh
+/// development database has realistic data for demos and manual testing.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Idempotent: each task carries a stable <c>PublicCode</c> derived from its
+/// position in <see cref="BudapestSampleData.Tasks"/>, and only codes not
+/// already present are inserted. Re-running on every startup is therefore safe.
+/// </para>
+/// <para>
+/// Categories themselves are static reference data seeded via EF Core
+/// <c>HasData</c> (see <c>CategoryConfiguration</c>); this seeder only links
+/// tasks to those existing categories by their stable <c>Code</c>.
+/// </para>
+/// </remarks>
+public sealed class SampleTaskSeeder(
+    UserSeedingHelper userSeedingHelper,
+    AppDbContext db,
+    ILogger<SampleTaskSeeder> logger) : IDataSeeder
+{
+    private const int Wgs84Srid = 4326;
+
+    /// <summary>
+    /// Gets the relative ordering hint. Runs after the account seeders so any
+    /// shared infrastructure (roles, active terms) is already in place.
+    /// </summary>
+    public int Order => 200;
+
+    public async Task SeedAsync(CancellationToken cancellationToken)
+    {
+        var seekerProfileIds = await EnsureSeekersAsync(cancellationToken);
+        var categoryIdsByCode = await LoadCategoryIdsByCodeAsync(cancellationToken);
+
+        var existingCodes = await db.Tasks
+            .Where(task => task.PublicCode != null
+                && task.PublicCode.StartsWith(BudapestSampleData.TaskCodePrefix))
+            .Select(task => task.PublicCode!)
+            .ToListAsync(cancellationToken);
+        var existing = existingCodes.ToHashSet(StringComparer.Ordinal);
+
+        var now = DateTimeOffset.UtcNow;
+        var inserted = 0;
+
+        for (var index = 0; index < BudapestSampleData.Tasks.Count; index++)
+        {
+            var publicCode = $"{BudapestSampleData.TaskCodePrefix}{index + 1:D4}";
+            if (existing.Contains(publicCode))
+            {
+                continue;
+            }
+
+            var template = BudapestSampleData.Tasks[index];
+            if (!categoryIdsByCode.TryGetValue(template.CategoryCode, out var categoryId))
+            {
+                logger.LogWarning(
+                    "Skipping sample task {PublicCode}: unknown category code '{Code}'.",
+                    publicCode,
+                    template.CategoryCode);
+                continue;
+            }
+
+            db.Tasks.Add(BuildTask(template, publicCode, categoryId, seekerProfileIds, index, now));
+            inserted++;
+        }
+
+        if (inserted > 0)
+        {
+            await db.SaveChangesAsync(cancellationToken);
+        }
+
+        if (logger.IsEnabled(LogLevel.Information))
+        {
+            logger.LogInformation(
+                "Sample tasks ready ({Inserted} inserted, {Total} total in catalogue).",
+                inserted,
+                BudapestSampleData.Tasks.Count);
+        }
+    }
+
+    private static CommunityTask BuildTask(
+        SampleTask template,
+        string publicCode,
+        Guid categoryId,
+        IReadOnlyList<Guid> seekerProfileIds,
+        int index,
+        DateTimeOffset now)
+    {
+        var seekerCount = seekerProfileIds.Count;
+        var seekerProfileId = seekerProfileIds[index % seekerCount];
+
+        // Stagger creation timestamps so the demo feed has a natural ordering.
+        var createdAt = now.AddHours(-index * 6);
+
+        var task = new CommunityTask
+        {
+            Id = Guid.NewGuid(),
+            PublicCode = publicCode,
+            SeekerProfileId = seekerProfileId,
+            CategoryId = categoryId,
+            Title = template.Title,
+            Description = template.Description,
+            Location = new Point(template.Longitude, template.Latitude) { SRID = Wgs84Srid },
+            LocationText = template.LocationText,
+            CompensationType = template.CompensationType,
+            CompensationAmount = template.CompensationType == CompensationType.Paid ? template.Amount : null,
+            Status = template.Status,
+            CreatedAt = createdAt,
+            UpdatedAt = createdAt,
+        };
+
+        ApplyLifecycle(task, template.Status, seekerProfileIds, index, createdAt);
+        return task;
+    }
+
+    /// <summary>
+    /// Fill in the status-dependent fields (accepted helper, lifecycle
+    /// timestamps, cancellation reason) so every non-open task is internally
+    /// consistent with the domain's check constraints.
+    /// </summary>
+    private static void ApplyLifecycle(
+        CommunityTask task,
+        DomainTaskStatus status,
+        IReadOnlyList<Guid> seekerProfileIds,
+        int index,
+        DateTimeOffset createdAt)
+    {
+        if (status == DomainTaskStatus.Open)
+        {
+            return;
+        }
+
+        if (status == DomainTaskStatus.Cancelled)
+        {
+            task.CancelledAt = createdAt.AddHours(3);
+            task.CancellationReason = "A feladatra már nincs szükség.";
+            task.UpdatedAt = task.CancelledAt.Value;
+            return;
+        }
+
+        // InProgress / PendingApproval / Completed all have an accepted helper —
+        // a different sample profile than the seeker (ck_tasks_distinct_profiles).
+        var seekerCount = seekerProfileIds.Count;
+        task.AcceptedHelperProfileId = seekerProfileIds[(index + 1) % seekerCount];
+        task.AcceptedAt = createdAt.AddHours(2);
+        task.UpdatedAt = task.AcceptedAt.Value;
+
+        if (status == DomainTaskStatus.Completed)
+        {
+            task.CompletedAt = createdAt.AddHours(26);
+            task.UpdatedAt = task.CompletedAt.Value;
+        }
+    }
+
+    private async Task<IReadOnlyList<Guid>> EnsureSeekersAsync(CancellationToken cancellationToken)
+    {
+        var profileIds = new List<Guid>(BudapestSampleData.Seekers.Count);
+
+        foreach (var seeker in BudapestSampleData.Seekers)
+        {
+            var account = new DevSeedAccount
+            {
+                Email = seeker.Email,
+                Password = BudapestSampleData.SeekerPassword,
+                DisplayName = seeker.DisplayName,
+                LocationText = $"Budapest, {seeker.District}",
+                Bio = seeker.Bio,
+            };
+
+            var user = await userSeedingHelper.EnsureUserAsync(
+                account,
+                [ApplicationRoleNames.User],
+                cancellationToken);
+
+            var profileId = await db.Profiles
+                .Where(profile => profile.UserId == user.Id)
+                .Select(profile => profile.Id)
+                .FirstAsync(cancellationToken);
+
+            profileIds.Add(profileId);
+        }
+
+        return profileIds;
+    }
+
+    private async Task<Dictionary<string, Guid>> LoadCategoryIdsByCodeAsync(
+        CancellationToken cancellationToken)
+    {
+        return await db.Set<Category>()
+            .ToDictionaryAsync(
+                category => category.Code,
+                category => category.Id,
+                StringComparer.Ordinal,
+                cancellationToken);
+    }
+}

--- a/backend/Infrastructure/Persistence/Seeding/UserSeedingHelper.cs
+++ b/backend/Infrastructure/Persistence/Seeding/UserSeedingHelper.cs
@@ -27,7 +27,8 @@ public sealed class UserSeedingHelper(
     /// Ensure the supplied development account exists and has the supplied
     /// roles, creating the user, profile, and privacy settings as needed.
     /// </summary>
-    public async Task EnsureUserAsync(
+    /// <returns>The ensured <see cref="ApplicationUser"/>.</returns>
+    public async Task<ApplicationUser> EnsureUserAsync(
         DevSeedAccount account,
         IReadOnlyCollection<string> roles,
         CancellationToken cancellationToken)
@@ -36,6 +37,7 @@ public sealed class UserSeedingHelper(
         await EnsureRolesAsync(user, roles);
         await EnsureProfileAsync(user, account, cancellationToken);
         await EnsureTermsAcceptedAsync(user, cancellationToken);
+        return user;
     }
 
     private async Task EnsureTermsAcceptedAsync(

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -23,6 +23,10 @@ using Npgsql;
 
 var builder = WebApplication.CreateBuilder(args);
 
+// `seed` runs the data seeders against the configured database and exits,
+// without starting the web host. Wired to `npm run seed` for demo data.
+var seedOnly = args.Any(arg => string.Equals(arg, "seed", StringComparison.OrdinalIgnoreCase));
+
 // Bind application-owned Azure settings from the "Azure" configuration section.
 // Values flow through any ASP.NET Core configuration provider (appsettings,
 // environment variables like Azure__CosmosEndpoint / Azure__Postgres__Host, etc.).
@@ -259,6 +263,19 @@ using (var scope = app.Services.CreateScope())
         logger.LogError(ex, "Database connection check failed");
         throw;
     }
+}
+
+if (seedOnly)
+{
+    using var scope = app.Services.CreateScope();
+    var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+    var logger = scope.ServiceProvider.GetRequiredService<ILogger<Program>>();
+
+    await db.Database.MigrateAsync();
+    await scope.ServiceProvider.RunDataSeedersAsync();
+
+    logger.LogInformation("Seed-only run complete; exiting without starting the web host.");
+    return;
 }
 
 {

--- a/backend/backend.csproj
+++ b/backend/backend.csproj
@@ -9,6 +9,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="backend.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <EmbeddedResource Include="Features/Auth/EmailTemplates/VerifyEmail.html" />
     <!-- WithCulture=false: the ".hu" infix would otherwise be parsed as the
          Hungarian culture and the template emitted into a satellite assembly,

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "description": "Monorepo dev tooling (husky + lint-staged). Backend lives in /backend, frontend in /frontend.",
   "scripts": {
-    "prepare": "husky || true"
+    "prepare": "husky || true",
+    "seed": "dotnet run --project backend -- seed"
   },
   "devDependencies": {
     "husky": "^9.1.7",


### PR DESCRIPTION
## Summary

Implements #45 — a development-only, idempotent seeder that gives a fresh dev database realistic demo content.

- **`npm run seed`** runs a seed-only mode that migrates, runs the seeders, and exits without starting the web host. Seeders also run on normal Development startup.
- **Catalogue** ([`BudapestSampleData.cs`](backend/Infrastructure/Persistence/Seeding/BudapestSampleData.cs)): 10 sample seeker accounts + 50 curated Budapest tasks spanning every category, all 4 compensation types, and 5 lifecycle statuses. Pure data (SRP), kept separate from the seeding mechanics.
- **Seeder** ([`SampleTaskSeeder.cs`](backend/Infrastructure/Persistence/Seeding/SampleTaskSeeder.cs)): `IDataSeeder` (Order 200), idempotent via stable `DEMO-####` public codes, builds PostGIS points, and fills status-consistent lifecycle fields so every task satisfies the domain check-constraints.
- Categories are already reference data (`HasData`); this only links tasks to them by code.

## Safety

- Nothing is seeded outside `Development` — seeders are only registered when `ASPNETCORE_ENVIRONMENT=Development`.
- Opt-out switches: `DevSeed:Enabled=false` (all dev seeders) or `DevSeed:SampleTasks:Enabled=false` (just the sample tasks).
- All seeded accounts use the reserved `.test` TLD so they can't collide with real emails.

## Docs

README gains a "Seeding demo data" section: how to run it, the Development-only guarantee, and the full seeded-credentials list.

## Test plan

- [x] Backend build + `dotnet format --verify-no-changes` clean
- [x] 8 new catalogue-invariant tests pass (count, known categories, compensation rule, Budapest bounding box, status/compensation coverage, unique seeker emails)
- [x] Live `npm run seed` against Postgres: 50 tasks inserted, all geo-located in Budapest, 11 with distinct helpers, 0 compensation-constraint violations, 10 seeker profiles created
- [x] Re-run is idempotent (0 inserted on second run)

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)