### PR TITLE
fix(ui): visual/UX polish + responsive mobile QA (#75)

### DIFF
--- a/frontend/app/(main)/feed/page.client.tsx
+++ b/frontend/app/(main)/feed/page.client.tsx
@@ -25,7 +25,7 @@ import { RECENCY_OPTIONS } from "@/lib/constants"
 
 type RecencyValue = (typeof RECENCY_OPTIONS)[number]
 
-const QUERY_DEBOUNCE_MS = 250
+const QUERY_DEBOUNCE_MS = 450
 
 /**
  * Canonical task-discovery feed. Replaces the former Seeker (#37) and

--- a/frontend/app/(main)/tasks/[id]/page.client.tsx
+++ b/frontend/app/(main)/tasks/[id]/page.client.tsx
@@ -108,7 +108,7 @@ export function TaskDetailPageClient({ id }: TaskDetailPageClientProps) {
 
 function TaskActions({ task }: { task: ApiTask }) {
   const t = useTranslations("tasks.detail")
-  const { user } = useAuth()
+  const { user, isLoading: isAuthLoading } = useAuth()
   const router = useRouter()
   const { mutate: updateTask, isPending: isCancelling } = useUpdateTask(task.id)
   const { data: myApplications = [], isLoading: isLoadingMyApplications } =
@@ -170,7 +170,10 @@ function TaskActions({ task }: { task: ApiTask }) {
             <ApplicationControls
               taskId={task.id}
               application={currentApplication}
-              isLoadingApplication={isLoadingMyApplications}
+              // Keep Apply disabled until auth resolves: until we know the
+              // viewer's profile we can't tell if they own this task, and the
+              // owner must never see an actionable Apply button.
+              isLoadingApplication={isLoadingMyApplications || isAuthLoading}
             />
           ) : (
             <>

--- a/frontend/components/tasks/task-filters.tsx
+++ b/frontend/components/tasks/task-filters.tsx
@@ -87,8 +87,8 @@ export function TaskFilters({
 
   return (
     <div className="flex flex-col gap-2">
-      <div className="flex flex-col gap-3 sm:grid sm:grid-cols-2 lg:grid-cols-[1fr_auto_auto_auto_auto]">
-        <div className="relative">
+      <div className="flex flex-col gap-3 lg:flex-row lg:items-center">
+        <div className="relative lg:flex-1">
           <HugeiconsIcon
             icon={Search01Icon}
             aria-hidden="true"
@@ -104,84 +104,95 @@ export function TaskFilters({
           />
         </div>
 
-        <Select
-          value={value.category}
-          onValueChange={(v) => update({ category: v })}
-        >
-          <SelectTrigger aria-label={t("categoryAria")} className="lg:w-44">
-            <SelectValue placeholder={t("categoryPlaceholder")} />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="all">{t("allCategories")}</SelectItem>
-            {categories.map((c) => (
-              <SelectItem key={c.id} value={c.id}>
-                {tCategories.has(c.code) ? tCategories(c.code) : c.name}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-
-        <Select
-          value={value.compensation}
-          onValueChange={(v) =>
-            update({ compensation: v as TaskFiltersState["compensation"] })
-          }
-        >
-          <SelectTrigger aria-label={t("rewardAria")} className="lg:w-40">
-            <SelectValue placeholder={t("rewardPlaceholder")} />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="all">{t("anyReward")}</SelectItem>
-            {COMPENSATION_OPTIONS.map((value) => (
-              <SelectItem key={value} value={value}>
-                {tCompensation(value)}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-
-        <Select
-          value={value.radius}
-          onValueChange={(v) =>
-            update({ radius: v as TaskFiltersState["radius"] })
-          }
-          disabled={!hasOrigin}
-        >
-          <SelectTrigger
-            aria-label={t("distanceAria")}
-            aria-describedby={!hasOrigin ? "radius-helper" : undefined}
-            className="lg:w-40"
+        <div className="grid grid-cols-2 gap-3 sm:grid-cols-4 lg:flex lg:gap-2">
+          <Select
+            value={value.category}
+            onValueChange={(v) => update({ category: v })}
           >
-            <SelectValue placeholder={t("distancePlaceholder")} />
-          </SelectTrigger>
-          <SelectContent>
-            {RADIUS_OPTIONS.map((opt) => (
-              <SelectItem key={opt.value} value={opt.value}>
-                {opt.km == null
-                  ? t("anyDistance")
-                  : t("within", { km: opt.km })}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
+            <SelectTrigger
+              aria-label={t("categoryAria")}
+              className="w-full lg:w-44"
+            >
+              <SelectValue placeholder={t("categoryPlaceholder")} />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">{t("allCategories")}</SelectItem>
+              {categories.map((c) => (
+                <SelectItem key={c.id} value={c.id}>
+                  {tCategories.has(c.code) ? tCategories(c.code) : c.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
 
-        <Select
-          value={value.recency}
-          onValueChange={(v) =>
-            update({ recency: v as TaskFiltersState["recency"] })
-          }
-        >
-          <SelectTrigger aria-label={t("recencyAria")} className="lg:w-40">
-            <SelectValue placeholder={t("recencyPlaceholder")} />
-          </SelectTrigger>
-          <SelectContent>
-            {RECENCY_OPTIONS.map((value) => (
-              <SelectItem key={value} value={value}>
-                {t(`recencyOptions.${value}`)}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
+          <Select
+            value={value.compensation}
+            onValueChange={(v) =>
+              update({ compensation: v as TaskFiltersState["compensation"] })
+            }
+          >
+            <SelectTrigger
+              aria-label={t("rewardAria")}
+              className="w-full lg:w-40"
+            >
+              <SelectValue placeholder={t("rewardPlaceholder")} />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">{t("anyReward")}</SelectItem>
+              {COMPENSATION_OPTIONS.map((value) => (
+                <SelectItem key={value} value={value}>
+                  {tCompensation(value)}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+
+          <Select
+            value={value.radius}
+            onValueChange={(v) =>
+              update({ radius: v as TaskFiltersState["radius"] })
+            }
+            disabled={!hasOrigin}
+          >
+            <SelectTrigger
+              aria-label={t("distanceAria")}
+              aria-describedby={!hasOrigin ? "radius-helper" : undefined}
+              className="w-full lg:w-40"
+            >
+              <SelectValue placeholder={t("distancePlaceholder")} />
+            </SelectTrigger>
+            <SelectContent>
+              {RADIUS_OPTIONS.map((opt) => (
+                <SelectItem key={opt.value} value={opt.value}>
+                  {opt.km == null
+                    ? t("anyDistance")
+                    : t("within", { km: opt.km })}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+
+          <Select
+            value={value.recency}
+            onValueChange={(v) =>
+              update({ recency: v as TaskFiltersState["recency"] })
+            }
+          >
+            <SelectTrigger
+              aria-label={t("recencyAria")}
+              className="w-full lg:w-40"
+            >
+              <SelectValue placeholder={t("recencyPlaceholder")} />
+            </SelectTrigger>
+            <SelectContent>
+              {RECENCY_OPTIONS.map((value) => (
+                <SelectItem key={value} value={value}>
+                  {t(`recencyOptions.${value}`)}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
       </div>
       {!hasOrigin ? (
         <p id="radius-helper" className="text-xs text-muted-foreground">

--- a/frontend/lib/auth-context.tsx
+++ b/frontend/lib/auth-context.tsx
@@ -2,6 +2,7 @@
 
 import * as React from "react"
 import type { ReactNode } from "react"
+import { useQueryClient } from "@tanstack/react-query"
 
 import type {
   AuthUser,
@@ -42,12 +43,17 @@ const MIN_REFRESH_DELAY_MS = 1_000
 export function AuthProvider({ children }: { children: ReactNode }) {
   const [user, setUser] = React.useState<AuthUser | null | undefined>(null)
   const [expiresAt, setExpiresAt] = React.useState<string | null>(null)
+  const queryClient = useQueryClient()
 
   // Single in-flight refresh promise — every caller (proactive timer, 401
   // retry, visibilitychange, login) shares the same Promise, so the backend
   // sees exactly one refresh request per logical refresh moment. This is the
   // single point that prevents the atomic-rotation race.
   const inFlightRefresh = React.useRef<Promise<boolean> | null>(null)
+
+  // Latched on logout so performRefresh stops minting tokens until the next
+  // login. Cleared again in login().
+  const loggedOutRef = React.useRef(false)
 
   // Refs so imperative handlers (visibilitychange, bridge) can read the latest
   // values without re-registering listeners on every state change.
@@ -89,6 +95,14 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
     inFlightRefresh.current = (async () => {
       try {
+        // After an explicit logout, never mint fresh tokens until the next
+        // login — a scheduled proactive refresh or an in-flight 401 retry
+        // firing post-logout would re-issue the refresh cookie, which the
+        // middleware would read as "still signed in".
+        if (loggedOutRef.current) {
+          return false
+        }
+
         const response = await fetch(AUTH_API_PATHS.refresh, {
           method: "POST",
           cache: "no-store",
@@ -109,6 +123,17 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
         const data = (await response.json()) as RefreshResponse
         setExpiresAt(data.expiresAt ?? null)
+
+        // Re-sync the user after a background rotation so server-side changes
+        // (e.g. a newly granted admin role) are reflected without a full
+        // reload. Skip if a logout raced in while we were rotating.
+        if (!loggedOutRef.current) {
+          const session = await fetchSession()
+          if (!loggedOutRef.current && session.user) {
+            setUser(session.user)
+            setExpiresAt(session.expiresAt)
+          }
+        }
         return true
       } catch {
         // Network error — same as transient: don't log out.
@@ -119,7 +144,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     })()
 
     return inFlightRefresh.current
-  }, [])
+  }, [fetchSession])
 
   // Public refreshSession: ensures we have a valid session. Tries the session
   // endpoint first; if that 401s, attempts a refresh and re-fetches.
@@ -203,6 +228,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
   const login = React.useCallback(
     async (input: LoginInput) => {
+      // Clear the logout latch so this fresh session can rotate tokens again.
+      loggedOutRef.current = false
       await authMutation(AUTH_API_PATHS.login, input)
       const nextUser = await refreshSession()
 
@@ -229,6 +256,15 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   }, [])
 
   const logout = React.useCallback(async () => {
+    // Latch the guard first so any concurrent/scheduled refresh becomes a
+    // no-op, then drain an already in-flight rotation before revoking — that
+    // way logout clears whatever cookies the rotation may have just minted.
+    loggedOutRef.current = true
+    const pending = inFlightRefresh.current
+    if (pending) {
+      await pending.catch(() => {})
+    }
+
     try {
       await fetch(AUTH_API_PATHS.logout, {
         method: "POST",
@@ -237,8 +273,11 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     } finally {
       setUser(undefined)
       setExpiresAt(null)
+      // Drop every cached query so the next account to sign in on this tab
+      // never sees the previous user's tasks, profile, or conversations.
+      queryClient.clear()
     }
-  }, [])
+  }, [queryClient])
 
   return (
     <AuthContext.Provider

--- a/frontend/messages/hu.json
+++ b/frontend/messages/hu.json
@@ -436,7 +436,7 @@
       }
     },
     "detail": {
-      "posted": "{relative} ezelőtt közzétéve",
+      "posted": "Közzétéve {relative}",
       "description": "Leírás",
       "postedBy": "Közzétette",
       "editTask": "Feladat szerkesztése",


### PR DESCRIPTION
## Summary

Closes #75. Fixes the five bugs surfaced during the polish pass and one localization defect found along the way.

- **Logout re-authentication race (PROD):** `logout()` now latches a logged-out flag and `await`s the in-flight refresh **before** revoking, so a proactive / `visibilitychange` refresh can't re-mint cookies after logout. This race barely opens on localhost (~1ms round-trip) but PROD latency widens it — which is why it reproduced in production.
- **Cross-account avatar/name bleed:** clear the React Query cache on logout so the next account doesn't inherit the previous user's cached data.
- **Apply button on own tasks:** disabled when you're the task owner (plus auth/application loading states).
- **Mobile filters:** responsive layout for the search bar + category/location/radius/sort selects, verified down to 360px wide.
- **Search debounce:** raised the feed location/filter debounce to 450ms so it no longer fires on every keystroke.
- **Localization:** fixed doubled "ezelőtt" in the Hungarian relative "posted" string (`Intl.RelativeTimeFormat` already emits "N nappal ezelőtt").

## Test plan

- [x] **Bug 1 — validate on the Vercel preview (real HTTPS + latency):** log in, then log out; confirm you stay logged out and a protected route bounces to `/login`. Repeat a few times to catch the race.
- [x] Bug 2 — filters render cleanly at 360px and 375px
- [x] Bug 4 — switch accounts (Local User → Anna K.); confirm no cached name/email/task bleed
- [x] Bug 5 — own task shows Edit/Cancel (no Apply); other's open task shows enabled Apply
- [x] Bug 3 — debounce no longer searches on every keystroke
- [x] Hungarian "Közzétéve 3 nappal ezelőtt" renders without the doubled "ezelőtt"
- [x] typecheck, lint (`--max-warnings=0`), prettier all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)