### PR TITLE
Standardize page typography on design tokens (#291)

### DIFF
--- a/frontend/app/(auth)/login/forgot/page.tsx
+++ b/frontend/app/(auth)/login/forgot/page.tsx
@@ -13,9 +13,7 @@ export default async function ForgotPasswordPage() {
   return (
     <div className="flex flex-col gap-6">
       <header className="flex flex-col gap-1">
-        <h1 className="text-2xl font-semibold tracking-tight">
-          {t("headerTitle")}
-        </h1>
+        <h1 className="font-heading text-page-title">{t("headerTitle")}</h1>
         <p className="text-sm text-muted-foreground">{t("headerSubtitle")}</p>
       </header>
       <ForgotPasswordForm />

--- a/frontend/app/(auth)/reset-password/page.tsx
+++ b/frontend/app/(auth)/reset-password/page.tsx
@@ -14,9 +14,7 @@ export default async function ResetPasswordPage() {
   return (
     <div className="flex flex-col gap-6">
       <header className="flex flex-col gap-1">
-        <h1 className="text-2xl font-semibold tracking-tight">
-          {t("headerTitle")}
-        </h1>
+        <h1 className="font-heading text-page-title">{t("headerTitle")}</h1>
         <p className="text-sm text-muted-foreground">{t("headerSubtitle")}</p>
       </header>
       <Suspense>

--- a/frontend/app/(main)/tasks/[id]/not-found.tsx
+++ b/frontend/app/(main)/tasks/[id]/not-found.tsx
@@ -9,13 +9,11 @@ export default async function TaskNotFound() {
   return (
     <main className="flex flex-1 items-center justify-center px-6 py-24">
       <div className="flex max-w-md flex-col items-center gap-4 text-center">
-        <p className="font-mono text-xs tracking-[0.25em] text-muted-foreground uppercase">
+        <p className="font-mono text-caption tracking-[0.25em] text-muted-foreground uppercase">
           404
         </p>
-        <h1 className="text-2xl font-semibold tracking-tight">
-          {t("heading")}
-        </h1>
-        <p className="text-sm text-muted-foreground">{t("body")}</p>
+        <h1 className="font-heading text-page-title">{t("heading")}</h1>
+        <p className="text-body-sm text-muted-foreground">{t("body")}</p>
         <Button asChild>
           <Link href="/tasks">{t("back")}</Link>
         </Button>

--- a/frontend/app/(main)/tasks/[id]/page.client.tsx
+++ b/frontend/app/(main)/tasks/[id]/page.client.tsx
@@ -65,7 +65,7 @@ export function TaskDetailPageClient({ id }: TaskDetailPageClientProps) {
       </div>
 
       <header className="flex flex-col gap-2">
-        <h1 className="text-2xl font-semibold tracking-tight">{task.title}</h1>
+        <h1 className="font-heading text-page-title">{task.title}</h1>
         <ul className="flex flex-wrap items-center gap-x-4 gap-y-1 text-sm text-muted-foreground">
           {task.locationText ? (
             <li className="flex items-center gap-1.5">

--- a/frontend/app/not-found.tsx
+++ b/frontend/app/not-found.tsx
@@ -16,13 +16,11 @@ export default async function NotFound() {
   return (
     <main className="flex min-h-svh items-center justify-center px-6">
       <div className="flex max-w-md flex-col items-center gap-4 text-center">
-        <p className="font-mono text-xs tracking-[0.25em] text-muted-foreground uppercase">
+        <p className="font-mono text-caption tracking-[0.25em] text-muted-foreground uppercase">
           404
         </p>
-        <h1 className="text-2xl font-semibold tracking-tight">
-          {t("heading")}
-        </h1>
-        <p className="text-sm text-muted-foreground">{t("body")}</p>
+        <h1 className="font-heading text-page-title">{t("heading")}</h1>
+        <p className="text-body-sm text-muted-foreground">{t("body")}</p>
         <Button asChild>
           <Link href="/feed">{t("backToFeed")}</Link>
         </Button>

--- a/frontend/app/terms/page.tsx
+++ b/frontend/app/terms/page.tsx
@@ -51,9 +51,7 @@ export default async function TermsPage() {
         <TermsAcceptancePanel />
       </Suspense>
 
-      <h1 className="mb-2 text-3xl font-semibold tracking-tight">
-        {t("heading")}
-      </h1>
+      <h1 className="mb-2 font-heading text-page-title">{t("heading")}</h1>
       {activeTerms && (
         <p className="mb-10 text-sm text-muted-foreground">
           {t("versionLine", {


### PR DESCRIPTION
Closes #291.

## What

Replaces ad-hoc Tailwind size classes on page-level headings with the design-token utilities defined in `globals.css`, so every page heading goes through one source of truth instead of each page picking its own `text-2xl`/`text-3xl` combo.

- Page H1s now use `font-heading text-page-title` — same convention the shared `PageHeader` component already uses.
- 404 eyebrows switch to `text-caption`; supporting body copy switches to `text-body-sm`.

## Files

- `app/(auth)/login/forgot/page.tsx` — H1
- `app/(auth)/reset-password/page.tsx` — H1
- `app/not-found.tsx` — eyebrow, H1, body
- `app/(main)/tasks/[id]/not-found.tsx` — eyebrow, H1, body
- `app/(main)/tasks/[id]/page.client.tsx` — task title H1
- `app/terms/page.tsx` — H1

## Deliberately out of scope

- **Marketing landing hero** (`app/page.tsx`): currently uses a responsive `text-4xl sm:text-5xl` scale; the fixed `text-display` token doesn't model that mobile→desktop step yet. Worth a follow-up to either extend the token or accept a single size — left for a separate PR so this one stays mechanical.
- **Admin pages** (`app/(admin)/admin/**`): that surface is still being built and the headings are placeholders.

## Verify

- `npx tsc --noEmit` — clean
- `npx eslint` on the 6 changed files — clean
- `npx prettier --check` on the 6 changed files — clean